### PR TITLE
Shuffle API Verification

### DIFF
--- a/backend/app/models/connectors.py
+++ b/backend/app/models/connectors.py
@@ -242,7 +242,7 @@ class ShuffleConnector(Connector):
                 "Authorization": f"Bearer {self.attributes['connector_api_key']}",
             }
             shuffle_apps = requests.get(
-                f"{self.attributes['connector_url']}/api/v1/apps",
+                f"{self.attributes['connector_url']}/api/v1/apps/authentication",
                 headers=headers,
                 verify=False,
             )


### PR DESCRIPTION
modified to speed up shuffle verification...when attempting to load all apps, it was taking a long time to return a success due to how much data shuffle returns when returning all apps