### PR TITLE
Puts backend behind vite proxy (#131)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 backend/data/copilot.db
 backend/copilot.db
+node_modules

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -56,7 +56,7 @@ WORKDIR /opt/copilot
 RUN npm install
 
 # Expose ports
-EXPOSE 5000 5173
+EXPOSE 5173
 
 # Run your application
 #CMD ["sh", "-c", "cd backend && python copilot.py & cd /opt/copilot && npm run dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,5 +42,4 @@ services:
             GRAFANA_PASSWORD: ${GRAFANA_PASSWORD}
             WAZUH_WORKER_PROVISIONING_URL: ${WAZUH_WORKER_PROVISIONING_URL}
         ports:
-            - "5000:5000"
             - "5173:5173"

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -6,7 +6,7 @@ import axios, { type AxiosRequestHeaders } from "axios"
 const BASE_URL = import.meta.env.VITE_API_URL
 
 const HttpClient = axios.create({
-	baseURL: BASE_URL
+	baseURL: `${BASE_URL}/api`
 })
 
 let __TOKEN_REFRESHING = false

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,5 +41,15 @@ export default defineConfig({
 	},
 	optimizeDeps: {
 		include: ["fast-deep-equal"]
-	}
+	},
+	server: {
+		proxy: {
+			"/api": {
+				target: "http://localhost:5000",
+				changeOrigin: true,
+				secure: false,
+				rewrite: (path) => path.replace(/^\/api/, '')
+			},
+		},
+	},
 })


### PR DESCRIPTION
Hi,

In lou of seperating into two services or adding a proper web server frontend - this is a quick fix using the existing vite server to proxy calls to the backend

The allows the app to be deployed behind one port and fixes cors outside of localhost. You won't need to use "host" mode on docker compose and you can just map a port but I didn't want to move too fast.

If you want me to squash these up or remove the edit to dockerignore let me know. Also if you want me to tackle building JS and putting he frontend/backend behind nginx or caddy in a dockerfile (and slim it up) - I'd be up for that
