### PR TITLE
refactor: Update connector ID check for YAML file uploads

### DIFF
--- a/backend/app/connectors/routes.py
+++ b/backend/app/connectors/routes.py
@@ -213,10 +213,10 @@ async def upload_yaml_file(
     Raises:
         HTTPException: An exception with a 400 status code is raised if the file format is incorrect or connector ID is not 6.
     """
-    if connector_id != 6:
+    if connector_id not in [5, 6]:
         raise HTTPException(
             status_code=400,
-            detail="Only the Velociraptor connector is allowed for YAML file uploads.",
+            detail="Only the Velociraptor or another specific connector is allowed for YAML file uploads.",
         )
     if not file.filename.endswith(".yaml"):
         raise HTTPException(status_code=400, detail="Only .yaml files are allowed.")


### PR DESCRIPTION
The code changes in this commit modify the `upload_yaml_file` function in the `routes.py` file. The connector ID check for YAML file uploads has been updated to allow for multiple connector IDs. Previously, only connector ID 6 was allowed, but now connector IDs 5 and 6 are allowed. Additionally, the error detail message has been updated to reflect this change.