### PR TITLE
refactor: centralize env configuration and tighten TLS handling

### DIFF
--- a/backend/app/agents/services/status.py
+++ b/backend/app/agents/services/status.py
@@ -8,7 +8,7 @@ from sqlalchemy.future import select
 from app.agents.schema.agents import OutdatedVelociraptorAgentsResponse
 from app.agents.schema.agents import OutdatedWazuhAgentsResponse
 from app.connectors.velociraptor.utils.universal import UniversalService
-from app.db.db_session import session
+from app.db.db_session import get_sync_db_session
 from app.db.universal_models import Agents
 
 
@@ -23,7 +23,8 @@ def get_agent(agent_id: str) -> List[Agents]:
         AgentMetadata: The agent object if found, otherwise None.
     """
     try:
-        return session.query(Agents).filter(Agents.agent_id == agent_id).first()
+        with get_sync_db_session() as sync_session:
+            return sync_session.query(Agents).filter(Agents.agent_id == agent_id).first()
     except Exception as e:
         logger.error(f"Failed to fetch agent with agent_id {agent_id}: {e}")
         raise HTTPException(

--- a/backend/app/data_store/data_store_session.py
+++ b/backend/app/data_store/data_store_session.py
@@ -1,23 +1,20 @@
-from pathlib import Path
-
-from environs import Env
 from loguru import logger
 from miniopy_async import Minio
 
-env = Env()
-env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
-logger.info(f"Loading environment from {Path(__file__).parent.parent.parent.parent / '.env'}")
-
-
-minio_root_user = env.str("MINIO_ROOT_USER", default="admin")
-minio_root_password = env.str("MINIO_ROOT_PASSWORD", default="password")
-minio_url = env.str("MINIO_URL", default="copilot-minio")
-minio_secure = env.bool("MINIO_SECURE", default=False)
-
-logger.info(f"Minio Root User: {minio_root_user} and password: {minio_root_password}")
+from settings import MINIO_REGION
+from settings import MINIO_ROOT_PASSWORD
+from settings import MINIO_ROOT_USER
+from settings import MINIO_SECURE
+from settings import MINIO_URL
 
 
 async def create_session() -> Minio:
-    client = Minio(f"{minio_url}:9000", access_key=minio_root_user, secret_key=minio_root_password, secure=minio_secure)
+    logger.info("Initializing MinIO client via centralized settings")
+    client = Minio(
+        MINIO_URL,
+        access_key=MINIO_ROOT_USER,
+        secret_key=MINIO_ROOT_PASSWORD,
+        secure=MINIO_SECURE,
+        region=MINIO_REGION,
+    )
     return client

--- a/backend/app/db/db_session.py
+++ b/backend/app/db/db_session.py
@@ -1,53 +1,109 @@
 # ! NEW WITH MYSQL ! #
 
+import ssl
 from contextlib import asynccontextmanager
 from contextlib import contextmanager
 
-# from settings import SQLALCHEMY_DATABASE_URI
-from pathlib import Path
-
-from environs import Env
 from loguru import logger
+from sqlalchemy.engine.url import URL
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session
 from sqlmodel import create_engine
 
-env = Env()
-env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
-logger.info(f"Loading environment from {Path(__file__).parent.parent.parent.parent / '.env'}")
+from settings import DB_TLS
+from settings import DB_TLS_CA
+from settings import MAX_OVERFLOW
+from settings import POOL_RECYCLE
+from settings import POOL_SIZE
+from settings import POOL_TIMEOUT
+from settings import SQLALCHEMY_DATABASE_URI
+from settings import TLS_VERIFY
 
-db_user = env.str("MYSQL_USER", default="copilot")
-db_password = env.str("MYSQL_PASSWORD")
-db_root_password = env.str("MYSQL_ROOT_PASSWORD")
-db_url = env.str("MYSQL_URL", default="copilot-mysql")
 
-logger.info(f"DB User: {db_user} and password: {db_password}")
+# --- helper to map async → sync driver ---
+def make_sync_uri(url: URL) -> str:
+    backend = url.get_backend_name()
+    driver = url.get_driver_name()
 
-# Update the SQLALCHEMY_DATABASE_URI to a MySQL compatible one in settings.py
-# For this example, let's assume it has been updated. copilot-mysql
-SQLALCHEMY_DATABASE_URI_NO_DB = f"mysql+pymysql://root:{db_root_password}@{db_url}"
-SQLALCHEMY_DATABASE_URI = f"mysql+aiomysql://{db_user}:{db_password}@{db_url}/copilot"
+    if backend == "mysql" and driver == "aiomysql":
+        url = url.set(drivername="mysql+pymysql")
+    elif backend == "sqlite" and driver == "aiosqlite":
+        url = url.set(drivername="sqlite")
+    return str(url)
 
+
+_url: URL = make_url(SQLALCHEMY_DATABASE_URI)
+_backend = _url.get_backend_name()
+
+async_connect_args: dict = {}
+sync_connect_args: dict = {}
+
+if DB_TLS and _backend == "mysql":
+    if TLS_VERIFY:
+        # Use system store when no custom CA is provided
+        ssl_ctx = ssl.create_default_context(cafile=DB_TLS_CA or None)
+        ssl_ctx.check_hostname = True
+        logger.info("MySQL TLS enabled (verified)")
+    else:
+        ssl_ctx = ssl._create_unverified_context()
+        logger.warning("MySQL TLS enabled (UNVERIFIED) — debug only")
+
+    # Pass the same SSLContext to BOTH drivers:
+    async_connect_args["ssl"] = ssl_ctx  # aiomysql expects SSLContext
+    sync_connect_args["ssl"] = ssl_ctx  # PyMySQL accepts SSLContext, too
+else:
+    if DB_TLS and _backend != "mysql":
+        logger.info(f"DB TLS requested but backend is '{_backend}'. Ignoring TLS connect args.")
+    else:
+        logger.info("DB TLS disabled")
+
+# Async engine (aiomysql)
+async_engine_kwargs = {
+    "echo": False,
+    "connect_args": async_connect_args,
+    "pool_pre_ping": True,
+}
+
+if _backend == "mysql":
+    async_engine_kwargs.update(
+        pool_recycle=POOL_RECYCLE,
+        pool_size=POOL_SIZE,
+        max_overflow=MAX_OVERFLOW,
+        pool_timeout=POOL_TIMEOUT,
+        pool_use_lifo=True,
+    )
+
+async_engine = create_async_engine(
+    SQLALCHEMY_DATABASE_URI,
+    **async_engine_kwargs,
+)
+
+# Sync engine (pymysql/sqlite)
+sync_engine_kwargs = {
+    "echo": False,
+    "connect_args": sync_connect_args,
+    "pool_pre_ping": True,
+}
+
+if _backend == "mysql":
+    sync_engine_kwargs.update(
+        pool_recycle=POOL_RECYCLE,
+        pool_size=POOL_SIZE,
+        max_overflow=MAX_OVERFLOW,
+        pool_timeout=POOL_TIMEOUT,
+        pool_use_lifo=True,
+    )
+
+sync_engine = create_engine(
+    make_sync_uri(_url),
+    **sync_engine_kwargs,
+)
 
 session = "placeholder"
 
-# Create async engine for MySQL using aiomysql
-async_engine = create_async_engine(
-    SQLALCHEMY_DATABASE_URI,
-    echo=False,
-    # Additional MySQL-specific options can be set here if needed
-)
-# If you still need sync sessions for some operations, set it appropriately
-# This would typically require a different sync driver since SQLAlchemy doesn't use aiomysql for sync operations
-# ! THIS IS USED BY THE SCHEDULER ! #
-sync_engine = create_engine(
-    SQLALCHEMY_DATABASE_URI.replace("+aiomysql", "+pymysql"),
-    echo=False,
-    # Additional MySQL-specific options can be set here if needed
-)
 
 # Create a configured "AsyncSession" class
 AsyncSessionLocal = sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)

--- a/backend/app/schedulers/utils/universal.py
+++ b/backend/app/schedulers/utils/universal.py
@@ -1,15 +1,12 @@
-import os
-
 import requests
-from dotenv import load_dotenv
 from loguru import logger
 from sqlalchemy import select
 
 from app.auth.services.universal import get_scheduler_password
 from app.db.db_session import get_db_session
 from app.schedulers.models.scheduler import JobMetadata
-
-load_dotenv()
+from settings import SERVER_IP
+from settings import SERVER_PORT
 
 
 def scheduler_login():
@@ -25,7 +22,7 @@ def scheduler_login():
 
     # Get an auth token
     token_response = requests.post(
-        f"http://{os.getenv('SERVER_IP')}:5000/auth/token",
+        f"http://{SERVER_IP}:{SERVER_PORT}/auth/token",
         headers={
             "accept": "application/json",
             "Content-Type": "application/x-www-form-urlencoded",

--- a/backend/app/smtp/routes/reports.py
+++ b/backend/app/smtp/routes/reports.py
@@ -4,9 +4,9 @@ from loguru import logger
 
 from app.auth.models.users import SMTP
 from app.auth.models.users import SMTPInput
-from app.auth.services.universal import select_all_users
+from app.auth.services.universal import select_all_users_sync
 from app.auth.utils import AuthHandler
-from app.db.db_session import session
+from app.db.db_session import get_sync_db_session
 from app.smtp.schema.configure import SMTPResponse
 
 smtp_reports_router = APIRouter()
@@ -21,22 +21,23 @@ auth_handler = AuthHandler()
     description="Register new SMTP for user",
 )
 async def register(user_id: int, smtp: SMTPInput):
-    users = select_all_users()
-    logger.info(users)
-    if not any(x.id == user_id for x in users):
-        raise HTTPException(status_code=400, detail="User not found")
-    # Check if SMTP already exists for user
-    smtp_found = session.query(SMTP).filter(SMTP.user_id == user_id).first()
-    if smtp_found:
-        raise HTTPException(status_code=400, detail="SMTP already exists for user")
-    hashed_pwd = auth_handler.get_password_hash(smtp.smtp_password)
-    u = SMTP(
-        email=smtp.email,
-        smtp_password=hashed_pwd,
-        smtp_server=smtp.smtp_server,
-        smtp_port=smtp.smtp_port,
-        user_id=user_id,
-    )
-    session.add(u)
-    session.commit()
+    with get_sync_db_session() as sync_session:
+        users = select_all_users_sync(sync_session)
+        logger.info(users)
+        if not any(x.id == user_id for x in users):
+            raise HTTPException(status_code=400, detail="User not found")
+        # Check if SMTP already exists for user
+        smtp_found = sync_session.query(SMTP).filter(SMTP.user_id == user_id).first()
+        if smtp_found:
+            raise HTTPException(status_code=400, detail="SMTP already exists for user")
+        hashed_pwd = auth_handler.get_password_hash(smtp.smtp_password)
+        u = SMTP(
+            email=smtp.email,
+            smtp_password=hashed_pwd,
+            smtp_server=smtp.smtp_server,
+            smtp_port=smtp.smtp_port,
+            user_id=user_id,
+        )
+        sync_session.add(u)
+        sync_session.commit()
     return {"message": "SMTP created successfully", "success": True}

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,5 @@
+"""General utility helpers."""
+
+from .url import ensure_host_port
+
+__all__ = ["ensure_host_port"]

--- a/backend/app/utils/url.py
+++ b/backend/app/utils/url.py
@@ -1,0 +1,76 @@
+"""URL-related utility helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
+
+
+def _format_netloc(username: str | None, password: str | None, host: str, port: int | None) -> str:
+    if not host:
+        return ""
+    # Bracket raw IPv6 literals without brackets
+    if ":" in host and not host.startswith("[") and not host.endswith("]"):
+        host = f"[{host}]"
+
+    userinfo = ""
+    if username:
+        # Re-encode to avoid invalid characters in userinfo
+        u = quote(username, safe="")  # RFC 3986
+        if password is not None:
+            p = quote(password, safe="")
+            userinfo = f"{u}:{p}@"
+        else:
+            userinfo = f"{u}@"
+
+    return f"{userinfo}{host}" if port is None else f"{userinfo}{host}:{port}"
+
+
+def ensure_host_port(endpoint: str, port: int) -> str:
+    if not endpoint:
+        return endpoint
+    if not (1 <= port <= 65535):
+        raise ValueError("port must be in 1..65535")
+
+    # Normalize scheme handling:
+    has_scheme = "://" in endpoint
+    scheme_prefix = "" if has_scheme else "//"
+    parsed = urlparse(f"{scheme_prefix}{endpoint}")
+
+    # Already has an explicit port
+    if parsed.port is not None:
+        return endpoint
+
+    # Raw netloc as it appeared (for precise replacement)
+    raw_netloc = parsed.netloc or ""
+    # urlparse can return 'host:' when no digits after ':'
+    if raw_netloc.endswith(":") and parsed.port is None:
+        raw_netloc = raw_netloc[:-1]
+
+    # Host fallback when netloc is empty in no-scheme cases like 'host/path'
+    host = parsed.hostname or (parsed.path.split("/", 1)[0] if not parsed.netloc else "")
+
+    new_netloc = _format_netloc(parsed.username, parsed.password, host or "", port)
+    if not new_netloc:
+        return endpoint  # cannot determine host
+
+    if has_scheme:
+        # Rebuild with urlunparse to preserve path, query, fragment
+        return urlunparse(
+            (
+                parsed.scheme,
+                new_netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            ),
+        )
+
+    # No scheme: replace only the authority portion at the start
+    if parsed.netloc:
+        return endpoint.replace(parsed.netloc, new_netloc, 1)
+    # Fallback for 'host[/...]'
+    remainder = endpoint[len(host) :] if host and endpoint.startswith(host) else endpoint
+    return f"{new_netloc}{remainder}"

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -6,29 +6,75 @@ For local development, use a .env file to set
 environment variables.
 """
 from pathlib import Path
+from urllib.parse import quote_plus
 
 from environs import Env
 from loguru import logger
 
+from app.utils import ensure_host_port
+
 env = Env()
 env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
 logger.info(f"Loading environment from {Path(__file__).parent.parent / '.env'}")
-# logger.info(f"Loading environment from {Path(__file__).parent.parent.parent / 'docker-env' / '.env'}")
 
-
-basedir = Path().absolute()
-db_path = str(basedir / "data" / "copilot.db")
-
-ENV = env.str("SECRET_KEY", default="production")
-DEBUG = env.bool("FLASK_DEBUG", default=False)
+# Generic app settings
+ENVIRONMENT: str = env.str("ENVIRONMENT", default="PRODUCTION")
+SERVER_IP: str = env.str("SERVER_IP", default="localhost")
+SERVER_PORT: int = env.int("SERVER_PORT", default=5000)
 SECRET_KEY = env.str("SECRET_KEY", "not-a-secret")
-# SQLALCHEMY_DATABASE_URI = env.str("SQLALCHEMY_DATABASE_URI", f"sqlite:///{db_path}")
-SQLALCHEMY_DATABASE_URI = env.str(
-    "SQLALCHEMY_DATABASE_URI",
-    f"sqlite+aiosqlite:///{db_path}",
-)
-SQLALCHEMY_TRACK_MODIFICATIONS = env.bool(
+MANAGED_DB: bool = env.bool("MANAGED_DB", default=False)
+DEBUG: bool = env.bool("FLASK_DEBUG", default=False)
+
+# Object Storage (MinIO / S3 compatible)
+MINIO_ROOT_USER: str = env.str("MINIO_ROOT_USER", default="admin")
+MINIO_ROOT_PASSWORD: str = env.str("MINIO_ROOT_PASSWORD", default="password")
+MINIO_URL: str = env.str("MINIO_URL", default="copilot-minio")
+MINIO_PORT: int = env.int("MINIO_PORT", default=9000)
+MINIO_URL = ensure_host_port(MINIO_URL, MINIO_PORT)
+MINIO_SECURE: bool = env.bool("MINIO_SECURE", default=False)
+MINIO_REGION: str | None = env.str("MINIO_REGION", default="") or None
+
+# TLS for MySQL
+TLS_VERIFY: bool = env.bool("DB_TLS_VERIFY", default=False)
+DB_TLS: bool = env.bool("DB_TLS", default=False)
+DB_TLS_CA: str | None = env.str("DB_TLS_CA", default="") or None
+
+# DSN strings
+SQLALCHEMY_DATABASE_URI: str
+SQLALCHEMY_DATABASE_URI_NO_DB: str | None
+
+# Database config
+mysql_user = env.str("MYSQL_USER", default="")
+mysql_password = env.str("MYSQL_PASSWORD", default="")
+mysql_url = env.str("MYSQL_URL", default="")
+mysql_port = env.int("MYSQL_PORT", default=3306)
+mysql_url = ensure_host_port(mysql_url, mysql_port) if mysql_url else mysql_url
+mysql_db = env.str("MYSQL_DATABASE", default="copilot")
+mysql_root_password = env.str("MYSQL_ROOT_PASSWORD", default="")
+
+POOL_SIZE: int = env.int("DB_POOL_SIZE", 15)
+MAX_OVERFLOW: int = env.int("DB_MAX_OVERFLOW", 15)
+POOL_TIMEOUT: int = env.int("DB_POOL_TIMEOUT", 10)
+POOL_RECYCLE: int = env.int("DB_POOL_RECYCLE", 1800)
+
+if mysql_user and mysql_password and mysql_url:
+    # Build DSN directly
+    enc_user = quote_plus(mysql_user)
+    enc_pass = quote_plus(mysql_password)
+    SQLALCHEMY_DATABASE_URI = f"mysql+aiomysql://{enc_user}:{enc_pass}@{mysql_url}/{mysql_db}"
+
+    # Only used if MANAGED_DB=false (bootstrap path). Leave None if you don't have a root/admin.
+    SQLALCHEMY_DATABASE_URI_NO_DB = f"mysql+pymysql://root:{quote_plus(mysql_root_password)}@{mysql_url}" if mysql_root_password else None
+else:
+    basedir = Path().absolute()
+    db_path = str(basedir / "data" / "copilot.db")
+    SQLALCHEMY_DATABASE_URI = env.str(
+        "SQLALCHEMY_DATABASE_URI",
+        f"sqlite+aiosqlite:///{db_path}",
+    )
+    SQLALCHEMY_DATABASE_URI_NO_DB = None
+
+SQLALCHEMY_TRACK_MODIFICATIONS: bool = env.bool(
     "SQLALCHEMY_TRACK_MODIFICATIONS",
     default=False,
 )


### PR DESCRIPTION
## Summary
- move database, MinIO, and server env parsing into `backend/settings.py`, adding helpers to normalize host/port, pool settings, and TLS flags
- expose TLS-aware async/sync engines and session helpers so services, schedulers, and SMTP routes stop managing raw SQLAlchemy sessions
- update Alembic, bootstrap routines, and startup logic to reuse the centralized settings, gate bootstrap to unmanaged MySQL deployments, perform connectivity preflight, and dispose engines cleanly
