### PR TITLE
feat: guard scheduled jobs on connector state and add timeouts

### DIFF
--- a/backend/app/connectors/services.py
+++ b/backend/app/connectors/services.py
@@ -399,6 +399,15 @@ class ConnectorServices:
             connector_record.connector_api_key = connector.connector_api_key
             connector_record.connector_extra_data = connector.connector_extra_data
             connector_record.connector_last_updated = datetime.now()
+            connector_record.connector_configured = any(
+                [
+                    connector.connector_url,
+                    connector.connector_username,
+                    connector.connector_password,
+                    connector.connector_api_key,
+                    connector.connector_extra_data,
+                ],
+            )
 
             # Commit the changes to the database
             session.add(connector_record)

--- a/backend/app/connectors/utils.py
+++ b/backend/app/connectors/utils.py
@@ -1,5 +1,7 @@
 from typing import Any
 from typing import Dict
+from typing import Iterable
+from typing import List
 from typing import Optional
 
 from loguru import logger
@@ -58,3 +60,16 @@ async def is_connector_verified(connector_name: str, db: AsyncSession) -> bool:
     else:
         logger.warning("No connector found.")
         return False
+
+
+async def get_unverified_connectors(
+    connector_names: Iterable[str],
+    db: AsyncSession,
+) -> List[str]:
+    """Return the subset of connectors that are not verified."""
+
+    missing: List[str] = []
+    for connector_name in connector_names:
+        if not await is_connector_verified(connector_name, db):
+            missing.append(connector_name)
+    return missing

--- a/backend/app/schedulers/services/agent_sync.py
+++ b/backend/app/schedulers/services/agent_sync.py
@@ -23,7 +23,14 @@ async def agent_sync():
     """
     logger.info("Synchronizing agents via scheduler...")
     async with get_db_session() as session:
-        await sync_all_agents()
+        response = await sync_all_agents()
+
+        if not response.success:
+            logger.info(
+                "agent_sync job skipped: {message}",
+                message=response.message,
+            )
+            return
 
         stmt = select(JobMetadata).where(JobMetadata.job_id == "agent_sync")
         result = await session.execute(stmt)


### PR DESCRIPTION
## Summary
- add a connector verification helper and use it across agent sync, alert creation, and incident routes so jobs skip cleanly when prerequisites aren’t verified
- enforce connector-configured flags during db population and update connector services to derive configured state automatically
- apply consistent HTTP timeouts and short-circuit logic to Graylog and Wazuh connectors, ensuring clients are closed and errors reported clearly
- guard InfluxDB alert fetches and Elasticsearch-backed incident workflows when connectors are unverified, and surface friendly skip messages to schedulers
- partially addresses #142 – prevents UI/log errors when unused connectors are left unverified
