### PR TITLE
feat: display customer provisioning status in list view

### DIFF
--- a/backend/app/customers/schema/customers.py
+++ b/backend/app/customers/schema/customers.py
@@ -25,6 +25,7 @@ class CustomerRequestBody(BaseModel):
     country: Optional[str] = Field(None, description="Country")
     customer_type: Optional[str] = Field(None, description="Type of the customer")
     logo_file: Optional[str] = Field(None, description="Logo file for the customer")
+    is_provisioned: Optional[bool] = Field(None, description="Whether the customer has been provisioned")
 
     class Config:
         orm_mode = True
@@ -43,6 +44,7 @@ class CustomerRequestBody(BaseModel):
                 "country": "USA",
                 "customer_type": "Enterprise",
                 "logo_file": "logo.png",
+                "is_provisioned": True,
             },
         }
 

--- a/frontend/src/components/customers/CustomerItem.vue
+++ b/frontend/src/components/customers/CustomerItem.vue
@@ -100,6 +100,16 @@
 							{{ customerInfo?.parent_customer_code }}
 						</template>
 					</Badge>
+
+					<Badge type="splitted" :color="customer.is_provisioned ? 'success' : 'danger'" bright>
+						<template #iconLeft>
+							<Icon :name="ProvisionIcon" :size="13" />
+						</template>
+						<template #label>Status</template>
+						<template #value>
+							{{ customer.is_provisioned ? "Provisioned" : "Not Provisioned" }}
+						</template>
+					</Badge>
 				</div>
 			</template>
 
@@ -281,6 +291,7 @@ const InfoIcon = "carbon:information"
 const ArrowIcon = "carbon:arrow-left"
 const LocationIcon = "carbon:location"
 const PhoneIcon = "carbon:phone"
+const ProvisionIcon = "carbon:network-3"
 
 const showDetails = ref(false)
 const selectedTabsGroup = ref<"customer" | "agents" | "wazuh_worker">("customer")

--- a/frontend/src/types/customers.d.ts
+++ b/frontend/src/types/customers.d.ts
@@ -15,6 +15,7 @@ export interface Customer {
 	customer_type: string
 	// TODO: consider removing it (logo_file)
 	logo_file: string
+	is_provisioned?: boolean
 }
 
 export interface CustomerMeta {


### PR DESCRIPTION
Add is_provisioned field to customer API response and show color-coded status badge (green for provisioned, red for not provisioned) in the customer list.

Fixes #647 