### PR TITLE
feat: add shared healthcheck filter state with default 1 day timeframe

### DIFF
--- a/frontend/src/components/customers/CustomerItem.vue
+++ b/frontend/src/components/customers/CustomerItem.vue
@@ -201,7 +201,11 @@
 					<n-tab-pane name="Healthcheck Wazuh" tab="Healthcheck Wazuh" display-directive="show:lazy">
 						<n-scrollbar style="max-height: 470px" trigger="none">
 							<div class="p-6 pt-2">
-								<CustomerHealthcheckList source="wazuh" :customer-code="customer.customer_code" />
+								<CustomerHealthcheckList
+								source="wazuh"
+								:customer-code="customer.customer_code"
+								v-model:filters="healthcheckFilters"
+							/>
 							</div>
 						</n-scrollbar>
 					</n-tab-pane>
@@ -215,6 +219,7 @@
 								<CustomerHealthcheckList
 									source="velociraptor"
 									:customer-code="customer.customer_code"
+									v-model:filters="healthcheckFilters"
 								/>
 							</div>
 						</n-scrollbar>
@@ -249,6 +254,7 @@ import Api from "@/api"
 import Badge from "@/components/common/Badge.vue"
 import CardEntity from "@/components/common/cards/CardEntity.vue"
 import Icon from "@/components/common/Icon.vue"
+import { useCustomerHealthcheckFilters } from "@/composables/useCustomerHealthcheckFilters"
 import { hashMD5 } from "@/utils"
 
 const props = defineProps<{
@@ -290,6 +296,7 @@ const message = useMessage()
 const customerInfo = ref<Customer | null>(null)
 const customerMeta = ref<CustomerMeta | null>(null)
 const customerPortainerStackId = ref<number | null>(null)
+const { healthcheckFilters } = useCustomerHealthcheckFilters()
 
 const loading = computed(() => loadingFull.value || loadingDelete.value)
 const fallbackAvatar = computed(() => {

--- a/frontend/src/components/customers/healthcheck/CustomerHealthcheckList.vue
+++ b/frontend/src/components/customers/healthcheck/CustomerHealthcheckList.vue
@@ -3,13 +3,13 @@
 		<div>
 			<n-input-group>
 				<n-select
-					v-model:value="filters.unit"
+					v-model:value="filterUnit"
 					:options="unitOptions"
 					placeholder="Time unit"
 					clearable
 					class="w-28!"
 				/>
-				<n-input-number v-model:value="filters.time" :min="1" clearable placeholder="Time" class="w-32!" />
+				<n-input-number v-model:value="filterTime" :min="1" clearable placeholder="Time" class="w-32!" />
 			</n-input-group>
 		</div>
 	</div>
@@ -58,15 +58,22 @@ import type { CustomerAgentHealth, CustomerHealthcheckSource } from "@/types/cus
 import { watchDebounced } from "@vueuse/core"
 import _get from "lodash/get"
 import { NEmpty, NInputGroup, NInputNumber, NSelect, NSpin, useMessage } from "naive-ui"
-import { onBeforeMount, ref, watch } from "vue"
+import { computed, onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
 import CustomerHealthcheckItem from "./CustomerHealthcheckItem.vue"
 
-const { source, customerCode } = defineProps<{
+const props = defineProps<{
 	source: CustomerHealthcheckSource
 	customerCode: string
+	filters: Partial<{ time: number; unit: "minutes" | "hours" | "days" }>
 }>()
+
+const emit = defineEmits<{
+	(e: "update:filters", value: Partial<{ time: number; unit: "minutes" | "hours" | "days" }>): void
+}>()
+
+const { source, customerCode } = props
 
 const CheckIcon = "carbon:checkmark-outline"
 const AlertIcon = "mdi:alert-outline"
@@ -82,7 +89,20 @@ const unitOptions = [
 	{ label: "Days", value: "days" }
 ]
 
-const filters = ref<Partial<{ time: number; unit: "minutes" | "hours" | "days" }>>({})
+const filters = computed({
+	get: () => props.filters,
+	set: (value) => emit("update:filters", value)
+})
+
+const filterTime = computed({
+	get: () => props.filters.time,
+	set: (value) => emit("update:filters", { ...props.filters, time: value })
+})
+
+const filterUnit = computed({
+	get: () => props.filters.unit,
+	set: (value) => emit("update:filters", { ...props.filters, unit: value })
+})
 
 function getList() {
 	loading.value = true

--- a/frontend/src/composables/useCustomerHealthcheckFilters.ts
+++ b/frontend/src/composables/useCustomerHealthcheckFilters.ts
@@ -1,0 +1,12 @@
+import { ref } from "vue"
+
+const healthcheckFilters = ref<Partial<{ time: number; unit: "minutes" | "hours" | "days" }>>({
+	time: 1,
+	unit: "days"
+})
+
+export function useCustomerHealthcheckFilters() {
+	return {
+		healthcheckFilters
+	}
+}


### PR DESCRIPTION
Implemented a composable to synchronize healthcheck time filters across Wazuh and Velociraptor tabs, ensuring filter selections persist when switching between tabs. Set sensible default of 1 day.

Fixes #649 