### PR TITLE
fix: sort agents list by agent_id in frontend

### DIFF
--- a/frontend/src/views/agents/Agents.vue
+++ b/frontend/src/views/agents/Agents.vue
@@ -86,12 +86,14 @@ watch(textFilter, val => {
 })
 
 const agentsFiltered = computed(() => {
-	return agents.value.filter(({ hostname, ip_address, agent_id, label }) =>
-		(hostname + ip_address + agent_id + label)
-			.toString()
-			.toLowerCase()
-			.includes(textFilterDebounced.value.toString().toLowerCase())
-	)
+	return agents.value
+		.filter(({ hostname, ip_address, agent_id, label }) =>
+			(hostname + ip_address + agent_id + label)
+				.toString()
+				.toLowerCase()
+				.includes(textFilterDebounced.value.toString().toLowerCase())
+		)
+		.sort((a, b) => a.agent_id.localeCompare(b.agent_id))
 })
 
 const itemsPaginated = computed(() => {


### PR DESCRIPTION
Users expect agents ordered by agent_id rather than database id.  Frontend now sorts filtered agents accordingly.

Fixes #665 