### PR TITLE
fix: use numeric sort for agent IDs to handle 4+ digit IDs

### DIFF
--- a/frontend/src/views/agents/Agents.vue
+++ b/frontend/src/views/agents/Agents.vue
@@ -93,7 +93,7 @@ const agentsFiltered = computed(() => {
 				.toLowerCase()
 				.includes(textFilterDebounced.value.toString().toLowerCase())
 		)
-		.sort((a, b) => a.agent_id.localeCompare(b.agent_id))
+		.sort((a, b) => parseInt(a.agent_id) - parseInt(b.agent_id))
 })
 
 const itemsPaginated = computed(() => {


### PR DESCRIPTION
Agent IDs from Wazuh are zero-padded strings (001, 002, etc.). When IDs reach 1000+, string comparison breaks (1000 sorts before 101).
Changed from localeCompare() to parseInt() to sort numerically regardless of string length.

Fixes #673 