### PR TITLE
docs: prettier site nav + pretty URLs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,45 @@
 # SOCFortress CoPilot Documentation
 
-This site contains two documentation tracks:
+CoPilot is a **single pane of glass** for operating an open‑source SOC/SIEM stack (Wazuh, Graylog, Velociraptor, Grafana, etc.).
 
-- **User Guide**: How to use CoPilot day-to-day (SOC operators) and how to configure sources/integrations (admins/engineers).
-- **Developer / AI Agent Docs**: Architecture, data flows, schema, and extension playbooks for making safe changes.
+This documentation is organized into two tracks:
 
-## Start here
+- **User Guide** (operators + admins/engineers)
+- **Developer / AI Agent Docs** (architecture + safe change playbooks)
 
-- If you are an **operator/analyst**: start with **User Guide → Quickstart (Operators)**.
-- If you are an **admin/engineer**: start with **User Guide → Quickstart (Admins/Engineers)**.
-- If you are making changes to the codebase: start with **Developer / AI Agent Docs → Start Here**.
+---
+
+## Start here (pick your path)
+
+=== "SOC operator / analyst"
+
+    You spend most of your time in **Incident Management** (alerts → cases → investigations).
+
+    - [Quickstart (Operators)](user/operators-quickstart.md)
+    - [User Guide Overview](user/overview.md)
+    - [Videos (Playlist)](user/videos.md)
+
+=== "Admin / engineer"
+
+    You configure **connectors, sources, and integrations** so alerts flow into CoPilot.
+
+    - [Quickstart (Admins/Engineers)](user/admins-quickstart.md)
+    - [Features by Area](user/features.md)
+    - [Videos (Playlist)](user/videos.md)
+
+=== "Developer / AI Agent"
+
+    You are making changes to the codebase, adding connectors, or debugging flows.
+
+    - [Start Here](developer/start-here.md)
+    - [Architecture](architecture/ARCHITECTURE.md)
+    - [Data Flows](architecture/DATA_FLOWS.md)
+    - [Database Schema](architecture/DATABASE_SCHEMA.md)
+
+---
+
+## How to use this site
+
+- Use the **left sidebar** (hamburger menu on mobile) to navigate.
+- Use **Search** (top bar) to jump straight to a topic.
+- Every page is stored in‑repo under `docs/` so it can be updated via PRs.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,22 @@
+/* Small tweaks to make the landing page + nav feel less cramped */
+
+/* Slightly wider content for guide-style docs */
+.md-content__inner {
+  max-width: 900px;
+}
+
+/* Make inline code a touch more readable */
+.md-typeset code {
+  font-size: 0.9em;
+}
+
+/* Reduce spacing between list items slightly */
+.md-typeset ul li,
+.md-typeset ol li {
+  margin-bottom: 0.15rem;
+}
+
+/* Nicer horizontal rule */
+.md-typeset hr {
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,27 +1,48 @@
 site_name: SOCFortress CoPilot Docs
 site_description: User guide and developer/AI-agent documentation for SOCFortress CoPilot
+site_url: https://socfortress.github.io/CoPilot/
 repo_url: https://github.com/socfortress/CoPilot
 edit_uri: edit/main/
 
+# Use pretty URLs (/user/overview/) instead of .html pages.
+use_directory_urls: true
+
 theme:
   name: material
+  language: en
   features:
     - navigation.instant
+    - navigation.instant.progress
     - navigation.sections
     - navigation.expand
     - navigation.tracking
+    - navigation.path
     - navigation.top
+    - navigation.indexes
+    - toc.follow
     - content.code.copy
     - search.suggest
     - search.highlight
 
+plugins:
+  - search
+
 markdown_extensions:
   - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
   - toc:
       permalink: true
   - tables
   - def_list
   - footnotes
+
+extra_css:
+  - stylesheets/extra.css
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Improve docs site UX and make navigation clearer.

Changes:
- Enable pretty URLs (directory-style) so /user/overview/ works
- Set site_url for correct asset/link resolution on GitHub Pages project site
- Enable MkDocs Material plugins/features (search, better nav + TOC)
- Improve landing page clarity with role-based tabs and direct links
- Add small CSS tweaks for readability

Verified locally: mkdocs build --strict