### PR TITLE
docs: apply SOCFortress.co theme to MkDocs Material

### DIFF
--- a/docs/stylesheets/socfortress-theme.css
+++ b/docs/stylesheets/socfortress-theme.css
@@ -1,0 +1,71 @@
+/*
+SOCFortress theme overrides for MkDocs Material.
+
+Palette extracted from https://www.socfortress.co/ (see /_nuxt/entry.*.css):
+- primary-500:   #f85d3b
+- primary-600:   #e5411d
+- primary-400:   #ff6f4f
+- accent-500:    #884fff
+- accent-600:    #7d30f7
+- background:    #0b0912
+- grey-600:      #38384b
+- overlay-light: rgba(255,255,255,0.10)
+
+Goal: keep MkDocs Material UX, but match SOCFortress brand colors + dark aesthetic.
+*/
+
+:root {
+  /* Brand colors */
+  --md-primary-fg-color: #f85d3b;
+  --md-primary-fg-color--light: #ff6f4f;
+  --md-primary-fg-color--dark: #e5411d;
+
+  --md-accent-fg-color: #884fff;
+
+  /* Links */
+  --md-typeset-a-color: #f85d3b;
+}
+
+/* Force dark aesthetic matching socfortress.co */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #0b0912;
+  --md-default-fg-color: rgba(255, 255, 255, 0.92);
+  --md-default-fg-color--light: rgba(255, 255, 255, 0.72);
+  --md-default-fg-color--lighter: rgba(255, 255, 255, 0.55);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.14);
+
+  /* Slightly brighter panels */
+  --md-code-bg-color: rgba(255, 255, 255, 0.06);
+  --md-footer-bg-color: rgba(255, 255, 255, 0.03);
+  --md-footer-bg-color--dark: rgba(255, 255, 255, 0.05);
+
+  /* Table borders */
+  --md-typeset-table-color: rgba(255, 255, 255, 0.12);
+}
+
+/* Header + tabs: glassy like the site */
+.md-header,
+.md-tabs {
+  background: rgba(11, 9, 18, 0.72);
+  backdrop-filter: blur(10px);
+}
+
+/* Sidebar: subtle separation */
+.md-sidebar__scrollwrap {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* Buttons and code-copy hover feel */
+.md-typeset .md-button--primary {
+  background-color: #f85d3b;
+  border-color: #f85d3b;
+}
+.md-typeset .md-button--primary:hover {
+  background-color: #e5411d;
+  border-color: #e5411d;
+}
+
+/* Improve readability of inline code on dark */
+[data-md-color-scheme="slate"] .md-typeset code {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,13 @@ use_directory_urls: true
 theme:
   name: material
   language: en
+  font:
+    text: IBM Plex Sans
+    code: JetBrains Mono
+  palette:
+    - scheme: slate
+      primary: custom
+      accent: custom
   features:
     - navigation.instant
     - navigation.instant.progress
@@ -41,7 +48,11 @@ markdown_extensions:
   - def_list
   - footnotes
 
+extra:
+  generator: false
+
 extra_css:
+  - stylesheets/socfortress-theme.css
   - stylesheets/extra.css
 
 nav:


### PR DESCRIPTION
Match the docs site styling to https://www.socfortress.co/ while keeping Material UX.

- Use IBM Plex Sans / JetBrains Mono
- Force dark (slate) scheme by default
- Apply SOCFortress primary/accent palette via CSS var overrides
- Add docs/stylesheets/socfortress-theme.css and include it via mkdocs.yml

Verified locally: mkdocs build --strict