### PR TITLE
docs: embed UI screenshots throughout the User Guide

### DIFF
--- a/docs/user/admins-quickstart.md
+++ b/docs/user/admins-quickstart.md
@@ -1,5 +1,7 @@
 # Quickstart (Admins / Engineers)
 
+![Connectors](../assets/ui/connectors.png)
+
 ## Where you spend most of your time
 
 - **Connectors**: configure connectivity to the toolchain (Wazuh, Graylog, Grafana, Velociraptor, etc.).
@@ -9,16 +11,28 @@
 ## Core workflows
 
 ### 1) Configure connectors
+
+![Connectors](../assets/ui/connectors.png)
+
 - Add URLs / credentials
 - Verify connectivity
 
 ### 2) Validate SIEM data availability
+
+![Indices → Index Management](../assets/ui/indices-management.png)
+
 - Confirm Wazuh Indexer is reachable
 - Confirm Graylog alerts are being written (often `gl-events*`)
 
 ### 3) Provision customer resources (if applicable)
+
+![Customers](../assets/ui/customers.png)
+
 - Use customer provisioning flows for Grafana/Graylog/Wazuh/Portainer where supported
 
 ### 4) Operationalize automation
+
+![Scheduler](../assets/ui/scheduler.png)
+
 - Enable scheduled collectors
 - Confirm job metadata updates and error handling

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -3,6 +3,9 @@
 This page is intended to make “hidden” features discoverable.
 
 ## Incident Management (operators)
+
+![Incident Alerts](../assets/ui/incident-alerts.png)
+
 - Alerts: triage, tagging, assignment, escalation
 - Cases: create, link alerts, close lifecycle
 - Comments: alert comments and case comments
@@ -14,14 +17,23 @@ This page is intended to make “hidden” features discoverable.
 - Graylog alerting events (commonly `gl-events*`)
 
 ## Integrations / Connectors (engineers)
+
+![Connectors](../assets/ui/connectors.png)
+
 - Connectors: configure and verify tool connectivity
 - Network connectors: customer-scoped connector configs/keys
 - Integration settings: customer integration configuration
 
 ## Reporting
+
+![Report Creation](../assets/ui/report-general.png)
+
 - Grafana reporting and PDF generation
 - Case report templates
 
 ## Automation
+
+![Scheduler](../assets/ui/scheduler.png)
+
 - Scheduler jobs (collectors, sync, alert creation)
 - Active response (where enabled)

--- a/docs/user/navigation.md
+++ b/docs/user/navigation.md
@@ -39,6 +39,30 @@ This page explains what each left‑hand navigation item in CoPilot does and how
 
 ## Left navigation map (what each item does)
 
+Below are screenshots of the main areas (from a lab environment) to help you quickly recognize where you are in the UI.
+
+- Overview: 
+
+  ![Overview](../assets/ui/overview.png)
+
+- Incident Management → Alerts:
+
+  ![Incident Alerts](../assets/ui/incident-alerts.png)
+
+- Connectors:
+
+  ![Connectors](../assets/ui/connectors.png)
+
+- Indices → Index Management:
+
+  ![Indices](../assets/ui/indices-management.png)
+
+- Graylog → Management:
+
+  ![Graylog Management](../assets/ui/graylog-management.png)
+
+---
+
 ### Overview
 
 - **Overview** → `/overview`

--- a/docs/user/operators-quickstart.md
+++ b/docs/user/operators-quickstart.md
@@ -1,5 +1,7 @@
 # Quickstart (SOC Operators)
 
+![Incident Management → Alerts](../assets/ui/incident-alerts.png)
+
 ## Where you spend most of your time
 
 - **Incident Management → Alerts**: triage, investigate, and decide next actions.
@@ -14,10 +16,16 @@
 - Add comments and assign if needed
 
 ### 2) Create and link a case
+
+![Incident Management → Cases](../assets/ui/incident-cases.png)
+
 - Create a case from the alert when it needs tracking
 - Link related alerts to the same case
 
 ### 3) Attach evidence (artifacts)
+
+![Artifacts](../assets/ui/artifacts.png)
+
 - Upload case artifacts (files, exports)
 - Use report templates when generating customer-ready PDFs
 

--- a/docs/user/overview.md
+++ b/docs/user/overview.md
@@ -2,6 +2,8 @@
 
 CoPilot is a “single pane of glass” for operating an open-source SOC/SIEM stack.
 
+![CoPilot Overview dashboard](../assets/ui/overview.png)
+
 ## Two primary user roles
 
 ### SOC operator / analyst


### PR DESCRIPTION
Sprinkle the Playwright-captured UI screenshots throughout the most relevant User Guide pages.

Adds screenshots to:
- docs/user/overview.md
- docs/user/operators-quickstart.md
- docs/user/admins-quickstart.md
- docs/user/navigation.md
- docs/user/features.md

Verified: mkdocs build --strict