### PR TITLE
docs: add UI Guide section mirroring the CoPilot menu

### DIFF
--- a/docs/user/ui/README.md
+++ b/docs/user/ui/README.md
@@ -1,0 +1,12 @@
+# UI Guide (mirrors the CoPilot menu)
+
+This section is organized to match the left navigation in CoPilot.
+
+Use it when you know **where you are in the UI** and want to understand:
+- what the page is for
+- who it’s for (Operator vs Admin/Engineer)
+- common workflows and gotchas
+
+If you’re brand new, start with:
+- [Quickstart (Operators)](../operators-quickstart.md)
+- [Quickstart (Admins/Engineers)](../admins-quickstart.md)

--- a/docs/user/ui/agents-copilot-actions.md
+++ b/docs/user/ui/agents-copilot-actions.md
@@ -1,0 +1,9 @@
+# CoPilot Actions
+
+**Menu:** Agents → CoPilot Actions
+
+**Best for:** Admin/Engineer + Response engineering
+
+Configure or manage endpoint actions / response capabilities.
+
+![CoPilot Actions](../../assets/ui/agents-copilot-actions.png)

--- a/docs/user/ui/agents-detection-rules.md
+++ b/docs/user/ui/agents-detection-rules.md
@@ -1,0 +1,9 @@
+# Detection Rules
+
+**Menu:** Agents → Detection Rules
+
+**Best for:** Detection engineering
+
+Edit and manage detection rules (Wazuh) through CoPilot.
+
+![Detection Rules](../../assets/ui/agents-detection-rules.png)

--- a/docs/user/ui/agents-groups.md
+++ b/docs/user/ui/agents-groups.md
@@ -1,0 +1,9 @@
+# Agent Groups
+
+**Menu:** Agents → Groups
+
+**Best for:** Admin/Engineer
+
+Use groups to segment endpoints and attach customer labels used for routing.
+
+![Groups](../../assets/ui/agents-groups.png)

--- a/docs/user/ui/agents-patch-tuesday.md
+++ b/docs/user/ui/agents-patch-tuesday.md
@@ -1,0 +1,9 @@
+# Patch Tuesday
+
+**Menu:** Agents → Patch Tuesday
+
+**Best for:** Ops + reporting
+
+Patch-focused reporting/overview.
+
+![Patch Tuesday](../../assets/ui/patch-tuesday.png)

--- a/docs/user/ui/agents-sca-overview.md
+++ b/docs/user/ui/agents-sca-overview.md
@@ -1,0 +1,9 @@
+# SCA Overview
+
+**Menu:** Agents → SCA Overview
+
+**Best for:** Ops + reporting
+
+Security Configuration Assessment overview.
+
+![SCA Overview](../../assets/ui/agents-sca-overview.png)

--- a/docs/user/ui/agents-sysmon-config.md
+++ b/docs/user/ui/agents-sysmon-config.md
@@ -1,0 +1,9 @@
+# Sysmon Config
+
+**Menu:** Agents → Sysmon Config
+
+**Best for:** Admin/Engineer
+
+Manage Sysmon configuration in a repeatable way.
+
+![Sysmon Config](../../assets/ui/agents-sysmon-config.png)

--- a/docs/user/ui/agents-vulnerability-overview.md
+++ b/docs/user/ui/agents-vulnerability-overview.md
@@ -1,0 +1,9 @@
+# Vulnerability Overview
+
+**Menu:** Agents → Vulnerability Overview
+
+**Best for:** Both (Ops + reporting)
+
+High-level view of vulnerabilities (often backed by Wazuh vulnerability detection data).
+
+![Vulnerability Overview](../../assets/ui/agents-vulnerability-overview.png)

--- a/docs/user/ui/agents.md
+++ b/docs/user/ui/agents.md
@@ -1,0 +1,9 @@
+# Agents
+
+**Menu:** Agents
+
+**Best for:** Admin/Engineer + Detection engineering
+
+Agent-related pages cover endpoint group configuration, Sysmon config, detection rules, and security posture views.
+
+![Agents](../../assets/ui/agents.png)

--- a/docs/user/ui/alerts-atomic-red-team.md
+++ b/docs/user/ui/alerts-atomic-red-team.md
@@ -1,0 +1,9 @@
+# Atomic Red Team
+
+**Menu:** Alerts → Atomic Red Team
+
+**Best for:** Detection engineering / validation
+
+Use Atomic Red Team workflows to test detections and confirm alert routing.
+
+![Atomic Red Team](../../assets/ui/alerts-atomic-red-team.png)

--- a/docs/user/ui/alerts-mitre.md
+++ b/docs/user/ui/alerts-mitre.md
@@ -1,0 +1,9 @@
+# MITRE ATT&CK
+
+**Menu:** Alerts → MITRE ATT&CK
+
+**Best for:** Detection engineering + reporting
+
+Use this view for ATT&CK alignment, coverage discussions, and investigation context.
+
+![MITRE](../../assets/ui/alerts-mitre.png)

--- a/docs/user/ui/alerts-siem.md
+++ b/docs/user/ui/alerts-siem.md
@@ -1,0 +1,9 @@
+# SIEM
+
+**Menu:** Alerts → SIEM
+
+**Best for:** Both
+
+Use the SIEM view to search/pivot into surrounding events. This is often where you use `index_name` + `index_id` references.
+
+![SIEM](../../assets/ui/alerts-siem.png)

--- a/docs/user/ui/alerts.md
+++ b/docs/user/ui/alerts.md
@@ -1,0 +1,15 @@
+# Alerts
+
+**Menu:** Alerts
+
+**Best for:** Admin/Engineer + Detection engineering + SOC leadership
+
+This section is oriented around SIEM views and testing/coverage (not the day-to-day triage queue).
+
+## Sub-pages
+
+- SIEM
+- MITRE ATT&CK
+- Atomic Red Team
+
+![SIEM Alerts](../../assets/ui/alerts-siem.png)

--- a/docs/user/ui/artifacts.md
+++ b/docs/user/ui/artifacts.md
@@ -1,0 +1,9 @@
+# Artifacts
+
+**Menu:** Artifacts
+
+**Best for:** SOC operators / analysts
+
+Artifacts are where you manage investigation files and evidence.
+
+![Artifacts](../../assets/ui/artifacts.png)

--- a/docs/user/ui/connectors.md
+++ b/docs/user/ui/connectors.md
@@ -1,0 +1,9 @@
+# Connectors
+
+**Menu:** Connectors
+
+**Best for:** Admin/Engineer
+
+Connectors are where you configure and verify connectivity to underlying tools.
+
+![Connectors](../../assets/ui/connectors.png)

--- a/docs/user/ui/customer-portal.md
+++ b/docs/user/ui/customer-portal.md
@@ -1,0 +1,7 @@
+# Customer Portal
+
+**Menu:** Customer Portal
+
+**Best for:** Admin/Engineer + customer-facing workflows
+
+![Customer Portal](../../assets/ui/customer-portal.png)

--- a/docs/user/ui/customers.md
+++ b/docs/user/ui/customers.md
@@ -1,0 +1,17 @@
+# Customers
+
+**Menu:** Customers
+
+**Best for:** Admin/Engineer
+
+Customers represent tenants in CoPilot.
+
+Deep link tips:
+- `/customers?code=<customer_code>`
+- `/customers?action=add-customer`
+
+![Customers](../../assets/ui/customers.png)
+
+## Related
+
+- [Customer Provisioning (Tenancy)](../customer-provisioning.md)

--- a/docs/user/ui/external-network-connectors.md
+++ b/docs/user/ui/external-network-connectors.md
@@ -1,0 +1,5 @@
+# Network Connectors
+
+**Menu:** External Services → Network Connectors
+
+![Network Connectors](../../assets/ui/external-network-connectors.png)

--- a/docs/user/ui/external-services.md
+++ b/docs/user/ui/external-services.md
@@ -1,0 +1,9 @@
+# External Services
+
+**Menu:** External Services
+
+**Best for:** Admin/Engineer
+
+External Services covers third-party integrations, network connectors, and auth helpers.
+
+![3rd Party Integrations](../../assets/ui/external-third-party-integrations.png)

--- a/docs/user/ui/external-singul-app-auth.md
+++ b/docs/user/ui/external-singul-app-auth.md
@@ -1,0 +1,5 @@
+# Singul App Auth
+
+**Menu:** External Services → Singul App Auth
+
+![Singul App Auth](../../assets/ui/external-singul-app-auth.png)

--- a/docs/user/ui/external-third-party-integrations.md
+++ b/docs/user/ui/external-third-party-integrations.md
@@ -1,0 +1,5 @@
+# 3rd Party Integrations
+
+**Menu:** External Services → 3rd Party Integrations
+
+![3rd Party Integrations](../../assets/ui/external-third-party-integrations.png)

--- a/docs/user/ui/graylog-management.md
+++ b/docs/user/ui/graylog-management.md
@@ -1,0 +1,5 @@
+# Graylog Management
+
+**Menu:** Graylog → Management
+
+![Graylog Management](../../assets/ui/graylog-management.png)

--- a/docs/user/ui/graylog-metrics.md
+++ b/docs/user/ui/graylog-metrics.md
@@ -1,0 +1,5 @@
+# Graylog Metrics
+
+**Menu:** Graylog → Metrics
+
+![Graylog Metrics](../../assets/ui/graylog-metrics.png)

--- a/docs/user/ui/graylog-pipelines.md
+++ b/docs/user/ui/graylog-pipelines.md
@@ -1,0 +1,5 @@
+# Graylog Pipelines
+
+**Menu:** Graylog → Pipelines
+
+![Graylog Pipelines](../../assets/ui/graylog-pipelines.png)

--- a/docs/user/ui/graylog.md
+++ b/docs/user/ui/graylog.md
@@ -1,0 +1,9 @@
+# Graylog
+
+**Menu:** Graylog
+
+**Best for:** Admin/Engineer
+
+Graylog pages help you manage pipelines, metrics, and management screens.
+
+![Graylog Management](../../assets/ui/graylog-management.png)

--- a/docs/user/ui/healthcheck.md
+++ b/docs/user/ui/healthcheck.md
@@ -1,0 +1,9 @@
+# Healthcheck
+
+**Menu:** Healthcheck
+
+**Best for:** Both
+
+Healthcheck provides a high-level signal of platform/stack health.
+
+![Healthcheck](../../assets/ui/healthcheck.png)

--- a/docs/user/ui/incident-alerts.md
+++ b/docs/user/ui/incident-alerts.md
@@ -1,0 +1,11 @@
+# Incident Alerts
+
+**Menu:** Incident Management → Alerts
+
+**Best for:** SOC operators / analysts
+
+This is your primary triage queue.
+
+Deep link tip: `/incident-management/alerts?alert_id=<id>`
+
+![Incident Alerts](../../assets/ui/incident-alerts.png)

--- a/docs/user/ui/incident-cases.md
+++ b/docs/user/ui/incident-cases.md
@@ -1,0 +1,11 @@
+# Incident Cases
+
+**Menu:** Incident Management → Cases
+
+**Best for:** SOC operators / analysts
+
+Cases track investigation lifecycle and allow you to link related alerts, comments, and artifacts.
+
+Deep link tip: `/incident-management/cases?case_id=<id>`
+
+![Incident Cases](../../assets/ui/incident-cases.png)

--- a/docs/user/ui/incident-management.md
+++ b/docs/user/ui/incident-management.md
@@ -1,0 +1,15 @@
+# Incident Management
+
+**Menu:** Incident Management
+
+**Best for:** SOC operators / analysts
+
+Incident Management is where analysts spend most of their time.
+
+## Sub-pages
+
+- **Sources**: define/organize alert sources
+- **Alerts**: triage queue
+- **Cases**: investigation lifecycle
+
+![Incident Alerts](../../assets/ui/incident-alerts.png)

--- a/docs/user/ui/incident-sources.md
+++ b/docs/user/ui/incident-sources.md
@@ -1,0 +1,9 @@
+# Incident Sources
+
+**Menu:** Incident Management → Sources
+
+**Best for:** Admin/Engineer (setup) + Operator (awareness)
+
+Sources define how alerts are grouped and routed into Incident Management.
+
+![Incident Sources](../../assets/ui/incident-sources.png)

--- a/docs/user/ui/indices-management.md
+++ b/docs/user/ui/indices-management.md
@@ -1,0 +1,5 @@
+# Index Management
+
+**Menu:** Indices → Index Management
+
+![Index Management](../../assets/ui/indices-management.png)

--- a/docs/user/ui/indices-snapshots.md
+++ b/docs/user/ui/indices-snapshots.md
@@ -1,0 +1,5 @@
+# Snapshot & Restore
+
+**Menu:** Indices → Snapshot & Restore
+
+![Snapshot & Restore](../../assets/ui/indices-snapshots.png)

--- a/docs/user/ui/indices.md
+++ b/docs/user/ui/indices.md
@@ -1,0 +1,9 @@
+# Indices
+
+**Menu:** Indices
+
+**Best for:** Admin/Engineer
+
+Index Management is used to understand storage/retention, snapshots, and index health.
+
+![Indices](../../assets/ui/indices-management.png)

--- a/docs/user/ui/overview.md
+++ b/docs/user/ui/overview.md
@@ -1,0 +1,17 @@
+# Overview
+
+**Menu:** Overview
+
+**Best for:** Both
+
+## What this page is
+
+The Overview dashboard is a high-level snapshot of your CoPilot environment: customers, alert/case counts, and key stack health signals.
+
+![Overview](../../assets/ui/overview.png)
+
+## Common workflows
+
+- Confirm the platform is healthy at a glance before starting triage.
+- Jump into Incident Management for alerts/cases.
+- Use health/usage widgets to spot issues (for example: storage pressure, connector errors).

--- a/docs/user/ui/report-creation.md
+++ b/docs/user/ui/report-creation.md
@@ -1,0 +1,9 @@
+# Report Creation
+
+**Menu:** Report Creation
+
+**Best for:** Admin/Engineer + SOC leadership
+
+Report Creation is where you generate PDF/report outputs (Grafana dashboards and security reporting).
+
+![Report Creation](../../assets/ui/report-general.png)

--- a/docs/user/ui/report-general.md
+++ b/docs/user/ui/report-general.md
@@ -1,0 +1,5 @@
+# General Reports
+
+**Menu:** Report Creation → General Reports
+
+![General Reports](../../assets/ui/report-general.png)

--- a/docs/user/ui/report-sca.md
+++ b/docs/user/ui/report-sca.md
@@ -1,0 +1,5 @@
+# SCA Reports
+
+**Menu:** Report Creation → SCA Reports
+
+![SCA Reports](../../assets/ui/report-sca.png)

--- a/docs/user/ui/report-vulnerability.md
+++ b/docs/user/ui/report-vulnerability.md
@@ -1,0 +1,5 @@
+# Vulnerability Reports
+
+**Menu:** Report Creation → Vulnerability Reports
+
+![Vulnerability Reports](../../assets/ui/report-vulnerability.png)

--- a/docs/user/ui/scheduler.md
+++ b/docs/user/ui/scheduler.md
@@ -1,0 +1,9 @@
+# Scheduler
+
+**Menu:** Scheduler
+
+**Best for:** Admin/Engineer
+
+Scheduler controls background jobs/collectors.
+
+![Scheduler](../../assets/ui/scheduler.png)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,53 @@ nav:
       - Customer Provisioning (Tenancy): user/customer-provisioning.md
       - Features by Area: user/features.md
       - Navigation Guide (UI): user/navigation.md
+      - UI Guide (mirrors menu):
+          - Start here: user/ui/README.md
+          - Overview: user/ui/overview.md
+          - Incident Management:
+              - Incident Management: user/ui/incident-management.md
+              - Sources: user/ui/incident-sources.md
+              - Alerts: user/ui/incident-alerts.md
+              - Cases: user/ui/incident-cases.md
+          - Alerts:
+              - Alerts: user/ui/alerts.md
+              - SIEM: user/ui/alerts-siem.md
+              - MITRE ATT&CK: user/ui/alerts-mitre.md
+              - Atomic Red Team: user/ui/alerts-atomic-red-team.md
+          - Artifacts: user/ui/artifacts.md
+          - Customers: user/ui/customers.md
+          - Agents:
+              - Agents: user/ui/agents.md
+              - Groups: user/ui/agents-groups.md
+              - Sysmon Config: user/ui/agents-sysmon-config.md
+              - Detection Rules: user/ui/agents-detection-rules.md
+              - CoPilot Actions: user/ui/agents-copilot-actions.md
+              - Vulnerability Overview: user/ui/agents-vulnerability-overview.md
+              - Patch Tuesday: user/ui/agents-patch-tuesday.md
+              - SCA Overview: user/ui/agents-sca-overview.md
+          - Report Creation:
+              - Report Creation: user/ui/report-creation.md
+              - General Reports: user/ui/report-general.md
+              - Vulnerability Reports: user/ui/report-vulnerability.md
+              - SCA Reports: user/ui/report-sca.md
+          - Healthcheck: user/ui/healthcheck.md
+          - Indices:
+              - Indices: user/ui/indices.md
+              - Index Management: user/ui/indices-management.md
+              - Snapshot & Restore: user/ui/indices-snapshots.md
+          - Graylog:
+              - Graylog: user/ui/graylog.md
+              - Management: user/ui/graylog-management.md
+              - Metrics: user/ui/graylog-metrics.md
+              - Pipelines: user/ui/graylog-pipelines.md
+          - Connectors: user/ui/connectors.md
+          - External Services:
+              - External Services: user/ui/external-services.md
+              - 3rd Party Integrations: user/ui/external-third-party-integrations.md
+              - Network Connectors: user/ui/external-network-connectors.md
+              - Singul App Auth: user/ui/external-singul-app-auth.md
+          - Scheduler: user/ui/scheduler.md
+          - Customer Portal: user/ui/customer-portal.md
       - Videos (Playlist): user/videos.md
   - Developer / AI Agent Docs:
       - Start Here: developer/start-here.md


### PR DESCRIPTION
Add a new User Guide subsection that mirrors the in-app left navigation structure (Overview, Incident Management, Alerts, Artifacts, Customers, Agents, Report Creation, Healthcheck, Indices, Graylog, Connectors, External Services, Scheduler, Customer Portal).

- Adds docs/user/ui/* pages (lightweight stubs with screenshots + basic purpose)
- Updates mkdocs.yml nav to include the new UI Guide tree

Verified: mkdocs build --strict