### PR TITLE
docs: restructure Mintlify nav (5 tabs) + role-based entrypoints

### DIFF
--- a/docs/admin/index.mdx
+++ b/docs/admin/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Admin / Platform Guide
+description: Provisioning, integrations/connectors, and platform reliability for CoPilot.
+---
+
+# Admin / Platform Guide
+
+This section is organized around **data onboarding and reliability**.
+
+## Start here
+
+- [Admin/Engineer quickstart](/user/admins-quickstart)
+- [First wins (30 minutes)](/getting-started/first-wins)
+
+## Tenancy & onboarding
+
+- [Customer provisioning](/user/customer-provisioning)
+- [Customers (UI reference)](/user/ui/customers)
+
+## Integrations & connectors
+
+- [3rd‑party integrations](/user/ui/external-third-party-integrations)
+- [Network connectors](/user/ui/external-network-connectors)
+
+## Platform health
+
+- [Indices management](/user/ui/indices-management)
+- [Graylog management](/user/ui/graylog-management)
+
+## Video walkthroughs
+
+- [Admin/Engineer track videos](/user/videos#adminengineer-track)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,15 +17,14 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "User Guide",
+        "tab": "Get Started",
         "groups": [
           {
-            "group": "Start here",
+            "group": "Welcome",
             "pages": [
               "index",
-              "user/overview",
-              "user/navigation",
-              "user/features"
+              "getting-started/roles-and-mental-model",
+              "getting-started/first-wins"
             ]
           },
           {
@@ -36,91 +35,101 @@
             ]
           },
           {
-            "group": "Provisioning",
+            "group": "Core concepts",
             "pages": [
-              "user/customer-provisioning"
+              "user/overview",
+              "user/navigation",
+              "user/features"
+            ]
+          },
+          {
+            "group": "Watch next",
+            "pages": [
+              {
+                "title": "Operator track videos",
+                "href": "/user/videos#operator-track"
+              },
+              {
+                "title": "Admin/Engineer track videos",
+                "href": "/user/videos#adminengineer-track"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Operator",
+        "groups": [
+          {
+            "group": "Start here",
+            "pages": [
+              "operator/index",
+              "user/operators-quickstart"
+            ]
+          },
+          {
+            "group": "Incident workflow",
+            "pages": [
+              "user/ui/incident-alerts",
+              "user/ui/incident-cases",
+              "user/ui/artifacts"
+            ]
+          },
+          {
+            "group": "Reference (by menu)",
+            "pages": [
+              "user/ui/incident-management",
+              "user/ui/incident-sources"
             ]
           },
           {
             "group": "Videos",
             "pages": [
+              {
+                "title": "Operator track",
+                "href": "/user/videos#operator-track"
+              },
               "user/videos"
             ]
           }
         ]
       },
       {
-        "tab": "UI Guide",
+        "tab": "Admin / Platform",
         "groups": [
           {
-            "group": "Overview",
+            "group": "Start here",
             "pages": [
-              "user/ui/overview"
+              "admin/index",
+              "user/admins-quickstart",
+              "user/customer-provisioning"
             ]
           },
           {
-            "group": "Incident Management",
+            "group": "Integrations & connectors",
             "pages": [
-              "user/ui/incident-management",
-              "user/ui/incident-alerts",
-              "user/ui/incident-cases",
-              "user/ui/incident-sources"
-            ]
-          },
-          {
-            "group": "Customers",
-            "pages": [
-              "user/ui/customers",
               "user/ui/external-third-party-integrations",
               "user/ui/external-network-connectors"
             ]
           },
           {
-            "group": "Graylog",
+            "group": "Platform (by menu)",
             "pages": [
-              "user/ui/graylog",
+              "user/ui/customers",
+              "user/ui/indices-management",
               "user/ui/graylog-management",
               "user/ui/graylog-pipelines",
               "user/ui/graylog-metrics"
             ]
           },
           {
-            "group": "Indices",
+            "group": "Videos",
             "pages": [
-              "user/ui/indices",
-              "user/ui/indices-management",
-              "user/ui/indices-snapshots"
-            ]
-          },
-          {
-            "group": "Agents",
-            "pages": [
-              "user/ui/agents",
-              "user/ui/agents-groups",
-              "user/ui/agents-vulnerability-overview",
-              "user/ui/agents-sca-overview",
-              "user/ui/agents-sysmon-config",
-              "user/ui/agents-patch-tuesday",
-              "user/ui/agents-detection-rules",
-              "user/ui/agents-copilot-actions"
-            ]
-          },
-          {
-            "group": "Reports",
-            "pages": [
-              "user/ui/report-general",
-              "user/ui/report-creation",
-              "user/ui/report-sca",
-              "user/ui/report-vulnerability"
-            ]
-          },
-          {
-            "group": "Other",
-            "pages": [
-              "user/ui/healthcheck",
-              "user/ui/scheduler",
-              "user/ui/artifacts",
-              "user/ui/customer-portal"
+              {
+                "title": "Admin/Engineer track",
+                "href": "/user/videos#adminengineer-track"
+              },
+              "user/videos"
             ]
           }
         ]
@@ -149,26 +158,38 @@
             "pages": [
               "integrations/ADDING_A_CONNECTOR"
             ]
+          },
+          {
+            "group": "Videos",
+            "pages": [
+              {
+                "title": "Browse videos",
+                "href": "/user/videos"
+              }
+            ]
           }
         ]
       },
       {
-        "tab": "GitHub",
+        "tab": "Videos",
         "groups": [
           {
-            "group": "Project",
+            "group": "Library",
+            "pages": [
+              "videos/index",
+              "user/videos"
+            ]
+          },
+          {
+            "group": "Role tracks",
             "pages": [
               {
-                "title": "CoPilot repo",
-                "href": "https://github.com/socfortress/CoPilot"
+                "title": "Operator track",
+                "href": "/user/videos#operator-track"
               },
               {
-                "title": "Releases",
-                "href": "https://github.com/socfortress/CoPilot/releases"
-              },
-              {
-                "title": "Issues",
-                "href": "https://github.com/socfortress/CoPilot/issues"
+                "title": "Admin/Engineer track",
+                "href": "/user/videos#adminengineer-track"
               }
             ]
           }

--- a/docs/getting-started/first-wins.mdx
+++ b/docs/getting-started/first-wins.mdx
@@ -1,0 +1,34 @@
+---
+title: First wins (30 minutes)
+description: Four fast milestones to prove CoPilot is working end-to-end.
+---
+
+# First wins (30 minutes)
+
+If you’re onboarding a new environment, aim for these milestones.
+
+## 1) Operator: triage an alert → open a case
+- Go to **Incident Management → Alerts**
+- Open an alert and review the context
+- Create or link a **Case**
+
+**Docs:** [Incident alerts](/user/ui/incident-alerts) · [Incident cases](/user/ui/incident-cases)
+
+**Video track:** [Operator track](/user/videos#operator-track)
+
+## 2) Admin: provision a customer
+Provision a tenant and verify it appears correctly in the Customers view.
+
+**Docs:** [Customer provisioning](/user/customer-provisioning)
+
+## 3) Admin: connect an integration / connector
+Connect at least one data source and verify it shows up in CoPilot.
+
+**Docs:**
+- [3rd‑party integrations](/user/ui/external-third-party-integrations)
+- [Network connectors](/user/ui/external-network-connectors)
+
+## 4) Validate indices and retention
+Make sure the backing indices/patterns exist and data is landing where expected.
+
+**Docs:** [Indices management](/user/ui/indices-management)

--- a/docs/getting-started/roles-and-mental-model.mdx
+++ b/docs/getting-started/roles-and-mental-model.mdx
@@ -1,0 +1,54 @@
+---
+title: Roles & mental model
+description: How to think about CoPilot as a SOC operator vs. admin/engineer vs. developer.
+---
+
+# Roles & mental model
+
+CoPilot is easiest to learn if you separate it into **two jobs**:
+
+1) **Operate incidents** (alerts → cases → evidence → response)
+2) **Make incidents possible** (connect sources/integrations so alerts flow)
+
+## SOC operator / analyst
+
+You spend most of your time in **Incident Management**.
+
+You care about:
+- Is this alert real?
+- What’s the blast radius?
+- What evidence do I need?
+- What do I do next?
+
+**Start here:**
+- [Operator quickstart](/user/operators-quickstart)
+- [Incident alerts (UI reference)](/user/ui/incident-alerts)
+- [Cases (UI reference)](/user/ui/incident-cases)
+- Videos: [Operator track](/user/videos#operator-track)
+
+## Admin / engineer
+
+You care about **data onboarding and reliability**.
+
+You care about:
+- Are sources connected and healthy?
+- Are parsing / streams / pipelines configured correctly?
+- Are indices and retention behaving?
+- Is each customer/tenant provisioned correctly?
+
+**Start here:**
+- [Admin/Engineer quickstart](/user/admins-quickstart)
+- [Customer provisioning](/user/customer-provisioning)
+- Videos: [Admin/Engineer track](/user/videos#adminengineer-track)
+
+## Developer / AI agent
+
+You are extending or modifying CoPilot.
+
+You care about:
+- Architecture + data flows
+- Schema changes (Alembic as source of truth)
+- Adding a connector safely
+
+**Start here:**
+- [Developer start here](/developer/start-here)

--- a/docs/operator/index.mdx
+++ b/docs/operator/index.mdx
@@ -1,0 +1,23 @@
+---
+title: Operator Guide
+description: Playbooks and workflows for SOC operators and analysts using CoPilot.
+---
+
+# Operator Guide
+
+This section is organized by **outcomes** (what you’re trying to do), not menu items.
+
+## Start here
+
+- [Operator quickstart](/user/operators-quickstart)
+- [First wins (30 minutes)](/getting-started/first-wins)
+
+## Daily workflow
+
+- [Triage alerts](/user/ui/incident-alerts)
+- [Work cases](/user/ui/incident-cases)
+- [Artifacts & evidence](/user/ui/artifacts)
+
+## Video walkthroughs
+
+- [Operator track videos](/user/videos#operator-track)

--- a/docs/videos/index.mdx
+++ b/docs/videos/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Videos
+description: The CoPilot YouTube playlist, summarized and organized by role.
+---
+
+# Videos
+
+Use the playlist like documentation: each video is linked and summarized into skimmable bullets.
+
+- [Open the video library](/user/videos)
+
+## Role-based tracks
+
+- [Operator track](/user/videos#operator-track)
+- [Admin/Engineer track](/user/videos#adminengineer-track)


### PR DESCRIPTION
Restructures Mintlify docs navigation to mimic docs.openclaw.ai patterns: outcome/role-first with reference second.

- Five tabs: Get Started, Operator, Admin/Platform, Developer, Videos
- Sprinkles role-specific video links inside the relevant tabs
- Adds small entrypoint pages: /operator, /admin, /videos
- Adds onboarding pages: Roles & mental model + First wins (30 minutes)

No file moves required; this is primarily a navigation + entrypoint improvement.