### PR TITLE
docs: fix Mintlify homepage hero video autoplay/sizing

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,12 +26,27 @@ CoPilot is a **single pane of glass** for operating an open‑source SOC/SIEM st
 
   </div>
 
-  <Frame>
-    <video autoplay loop muted playsInline style={{width: '100%', borderRadius: 16}}>
+  <div
+    style={{
+      width: '100%',
+      borderRadius: 16,
+      overflow: 'hidden',
+      border: '1px solid rgba(255,255,255,0.08)',
+      background: 'rgba(255,255,255,0.02)',
+    }}
+  >
+    <video
+      autoPlay
+      loop
+      muted
+      playsInline
+      preload="auto"
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
       <source src="/assets/hero/copilot-hub.webm" type="video/webm" />
       <source src="/assets/hero/copilot-hub.mp4" type="video/mp4" />
     </video>
-  </Frame>
+  </div>
 </Columns>
 
 ## Popular tasks


### PR DESCRIPTION
Fixes the Mintlify homepage hero video so it reliably autoplay-loads and fills the right column.

- Uses React/MDX-correct autoPlay prop (instead of autoplay)
- Removes Frame wrapper and applies a full-width container with border + rounded corners
- Adds preload=auto and display:block to avoid odd sizing/centering