### PR TITLE
Update Grafana dashboards to include date histogram bucket aggregatio…

### DIFF
--- a/backend/app/connectors/grafana/dashboards/Bitdefender/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Bitdefender/summary.json
@@ -357,7 +357,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"
@@ -2187,7 +2187,7 @@
 			"pluginVersion": "9.2.1",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/CarbonBlack/summary.json
+++ b/backend/app/connectors/grafana/dashboards/CarbonBlack/summary.json
@@ -1694,7 +1694,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Cato/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Cato/summary.json
@@ -2073,7 +2073,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Crowdstrike/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Crowdstrike/summary.json
@@ -1171,7 +1171,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"
@@ -2185,7 +2185,7 @@
 					"targets": [
 						{
 							"alias": "",
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"
@@ -3169,7 +3169,7 @@
 					"targets": [
 						{
 							"alias": "",
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Darktrace/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Darktrace/summary.json
@@ -1526,7 +1526,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/DefenderForEndpoint/summary.json
+++ b/backend/app/connectors/grafana/dashboards/DefenderForEndpoint/summary.json
@@ -836,7 +836,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Duo/duo_auth.json
+++ b/backend/app/connectors/grafana/dashboards/Duo/duo_auth.json
@@ -1940,7 +1940,7 @@
 			"pluginVersion": "10.2.3",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_system_logs.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_system_logs.json
@@ -1547,7 +1547,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_anomalies.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_anomalies.json
@@ -1676,7 +1676,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_app_control.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_app_control.json
@@ -1668,7 +1668,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_dlp.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_dlp.json
@@ -1679,7 +1679,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_dns.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_dns.json
@@ -1864,7 +1864,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_ips.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_ips.json
@@ -1679,7 +1679,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_ssl.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_ssl.json
@@ -1661,7 +1661,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_virus.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_virus.json
@@ -1649,7 +1649,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_webfilter.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_utm_webfilter.json
@@ -1862,7 +1862,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_vpn.json
+++ b/backend/app/connectors/grafana/dashboards/Fortinet/fortinet_vpn.json
@@ -2050,7 +2050,7 @@
 					"targets": [
 						{
 							"alias": "",
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"
@@ -3603,7 +3603,7 @@
 					"targets": [
 						{
 							"alias": "",
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Huntress/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Huntress/summary.json
@@ -1111,7 +1111,7 @@
 			"targets": [
 				{
 					"alias": "",
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Mimecast/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Mimecast/summary.json
@@ -1490,7 +1490,7 @@
 					"pluginVersion": "10.2.3",
 					"targets": [
 						{
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"
@@ -2831,7 +2831,7 @@
 					"pluginVersion": "10.2.3",
 					"targets": [
 						{
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"
@@ -4178,7 +4178,7 @@
 					"pluginVersion": "10.2.3",
 					"targets": [
 						{
-							"bucketAggs": [],
+							"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 							"datasource": {
 								"type": "grafana-opensearch-datasource",
 								"uid": "replace_datasource_uid"
@@ -5481,7 +5481,7 @@
 			"pluginVersion": "10.2.3",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/active_directory.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/active_directory.json
@@ -3733,7 +3733,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/applications.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/applications.json
@@ -1555,7 +1555,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/compliance_center.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/compliance_center.json
@@ -1173,7 +1173,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/defender_for_identity.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/defender_for_identity.json
@@ -1487,7 +1487,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/dlp.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/dlp.json
@@ -1277,7 +1277,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/endpoint.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/endpoint.json
@@ -1635,7 +1635,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/exchange.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/exchange.json
@@ -1461,7 +1461,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/forms.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/forms.json
@@ -1603,7 +1603,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/mitre.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/mitre.json
@@ -1571,7 +1571,7 @@
 			"pluginVersion": "9.0.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/onedrive.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/onedrive.json
@@ -1473,7 +1473,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/powerbi.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/powerbi.json
@@ -1605,7 +1605,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/sharepoint.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/sharepoint.json
@@ -1612,7 +1612,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/summary.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/summary.json
@@ -1771,7 +1771,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/teams.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/teams.json
@@ -1436,7 +1436,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Office365/threat_intelligence.json
+++ b/backend/app/connectors/grafana/dashboards/Office365/threat_intelligence.json
@@ -1719,7 +1719,7 @@
 			"pluginVersion": "10.4.0",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/SapSiem/users_auth.json
+++ b/backend/app/connectors/grafana/dashboards/SapSiem/users_auth.json
@@ -1416,7 +1416,7 @@
 			"pluginVersion": "10.2.3",
 			"targets": [
 				{
-					"bucketAggs": [],
+					"bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
 					"datasource": {
 						"type": "grafana-opensearch-datasource",
 						"uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_administrative.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_administrative.json
@@ -1023,7 +1023,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_malware.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_malware.json
@@ -3019,7 +3019,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_mitigation.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_mitigation.json
@@ -3019,7 +3019,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_operations.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_operations.json
@@ -1023,7 +1023,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_ranger.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_ranger.json
@@ -1023,7 +1023,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_summary.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_summary.json
@@ -3022,7 +3022,7 @@
       "pluginVersion": "10.2.0",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_whitelistblacklist.json
+++ b/backend/app/connectors/grafana/dashboards/Sentinelone/sentinelone_epp_whitelistblacklist.json
@@ -1023,7 +1023,7 @@
       "pluginVersion": "10.4.2",
       "targets": [
         {
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_app_control.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_app_control.json
@@ -2265,7 +2265,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_ips.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_ips.json
@@ -2172,7 +2172,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_sdwan.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_sdwan.json
@@ -1162,7 +1162,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_summary.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_summary.json
@@ -1460,7 +1460,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_vpn.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_vpn.json
@@ -2085,7 +2085,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"

--- a/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_web_control.json
+++ b/backend/app/connectors/grafana/dashboards/Sonicwall/sonicwall_web_control.json
@@ -1898,7 +1898,7 @@
       "targets": [
         {
           "alias": "",
-          "bucketAggs": [],
+          "bucketAggs": [{"type": "date_histogram", "id": "1", "settings": {"interval": "auto"}}],
           "datasource": {
             "type": "grafana-opensearch-datasource",
             "uid": "replace_datasource_uid"


### PR DESCRIPTION
…n for latest grafana version

- Added date histogram bucket aggregation with auto interval to multiple Grafana dashboard JSON files for improved time series data visualization.
- Updated the following dashboards: Bitdefender, CarbonBlack, Cato, Crowdstrike, Darktrace, DefenderForEndpoint, Duo, Fortinet (various), Huntress, Mimecast, Office365 (various), SapSiem, Sentinelone, and Sonicwall.