### PR TITLE
fix(auth): remove hardcoded JWT secret fallback (GHSA-4gxj-hw3c-3x2x)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,10 @@
 SERVER_IP=0.0.0.0
 
 # SECURITY: JWT secret for token signing.
-# ⚠️  The default value below is publicly known — change it before any deployment!
+# REQUIRED — the application will refuse to start if this is unset or set to the
+# known-compromised default disclosed in GHSA-4gxj-hw3c-3x2x.
 # Generate a unique secret with: openssl rand -base64 32
-JWT_SECRET=bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc=
+JWT_SECRET=REPLACE_ME
 
 # SECURITY: Dedicated secret for signing OAuth2 state tokens (SSO flows).
 # If not set, falls back to JWT_SECRET — set this to isolate SSO state signing.

--- a/backend/app/auth/services/totp.py
+++ b/backend/app/auth/services/totp.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
 
 from app.auth.models.totp import UserTOTP
+from app.auth.utils import AuthHandler
 from app.db.db_session import async_engine
 
 # Prefer a dedicated TOTP_ENCRYPTION_KEY (proper Fernet key, separate from JWT).
@@ -30,8 +31,7 @@ _totp_enc_key = os.environ.get("TOTP_ENCRYPTION_KEY")
 if _totp_enc_key:
     _fernet_key = _totp_enc_key.encode()
 else:
-    _raw_secret = os.environ.get("JWT_SECRET", "bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc=")
-    _fernet_key = base64.urlsafe_b64encode(hashlib.sha256(_raw_secret.encode()).digest())
+    _fernet_key = base64.urlsafe_b64encode(hashlib.sha256(AuthHandler.secret.encode()).digest())
 _fernet = Fernet(_fernet_key)
 
 _pwd_ctx = CryptContext(schemes=["bcrypt"])

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -14,6 +14,27 @@ from app.auth.services.universal import find_user
 from app.auth.services.universal import get_role
 
 
+# Known-compromised value published in prior versions of .env.example and as a
+# hardcoded fallback. Refuse to boot if it reappears, regardless of source.
+_KNOWN_COMPROMISED_JWT_SECRET = "bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc="
+
+
+def _load_jwt_secret() -> str:
+    secret = os.environ.get("JWT_SECRET")
+    if not secret:
+        raise RuntimeError(
+            "JWT_SECRET environment variable is not set. Generate a secure value "
+            "with `openssl rand -base64 32` and set it before starting the application.",
+        )
+    if secret == _KNOWN_COMPROMISED_JWT_SECRET:
+        raise RuntimeError(
+            "JWT_SECRET is set to the known-compromised default value disclosed in "
+            "GHSA-4gxj-hw3c-3x2x. Generate a new secret with `openssl rand -base64 32` "
+            "and update your environment.",
+        )
+    return secret
+
+
 class AuthHandler:
     security = OAuth2PasswordBearer(
         tokenUrl="api/auth/token",
@@ -25,7 +46,7 @@ class AuthHandler:
         },
     )
     pwd_context = CryptContext(schemes=["bcrypt"])
-    secret = os.environ.get("JWT_SECRET", "bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc=")
+    secret = _load_jwt_secret()
 
     def get_password_hash(self, password):
         return self.pwd_context.hash(password)

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -13,7 +13,6 @@ from passlib.context import CryptContext
 from app.auth.services.universal import find_user
 from app.auth.services.universal import get_role
 
-
 # Known-compromised value published in prior versions of .env.example and as a
 # hardcoded fallback. Refuse to boot if it reappears, regardless of source.
 _KNOWN_COMPROMISED_JWT_SECRET = "bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc="


### PR DESCRIPTION
## Summary
- Removes the hardcoded JWT signing secret fallback in `backend/app/auth/utils.py` and the duplicate in `backend/app/auth/services/totp.py`.
- The application now fails to boot with a clear `RuntimeError` if `JWT_SECRET` is unset or equal to the known-compromised default disclosed in [GHSA-4gxj-hw3c-3x2x](https://github.com/socfortress/CoPilot/security/advisories/GHSA-4gxj-hw3c-3x2x).
- Replaces the published secret in `.env.example` with `REPLACE_ME` and points operators at `openssl rand -base64 32`.

SSO state signing (`app/auth/services/sso.py`) already reads `AuthHandler().secret`, so it inherits the validation with no code change.

## Operator migration notes
This is a breaking change for any deployment that was implicitly relying on the hardcoded fallback. **That deployment is currently forgeable by anyone on the internet — rotation is the fix, not the regression.**

**What changes at rotation time:**

- **Passwords: safe.** Bcrypt-hashed, independent of `JWT_SECRET`. Users log in normally.
- **Active JWT sessions: invalidated.** All users re-login. Intentional — forged tokens also become invalid.
- **SSO state tokens: no impact.** 10-minute TTL, transient.
- **⚠️ TOTP (2FA): impacted if `TOTP_ENCRYPTION_KEY` is unset.** The Fernet key falls back to a value derived from `JWT_SECRET`. Rotating `JWT_SECRET` without a dedicated `TOTP_ENCRYPTION_KEY` makes enrolled TOTP secrets **undecryptable** — affected users must re-enroll 2FA.

**Recommended operator steps:**

1. If TOTP is in use and `TOTP_ENCRYPTION_KEY` has never been set, derive the current key from the old `JWT_SECRET` and pin it explicitly before rotating:
   ```bash
   python -c "import base64,hashlib; print(base64.urlsafe_b64encode(hashlib.sha256(b'<old_jwt_secret>').digest()).decode())"
   ```
   Set the output as `TOTP_ENCRYPTION_KEY` in `.env` so existing TOTP secrets remain decryptable.
2. Generate a fresh `JWT_SECRET` with `openssl rand -base64 32` and update `.env`.
3. Restart. All users re-login; TOTP enrollments survive.

If no one has enrolled 2FA yet, step 1 is unnecessary.

## Test plan
- [ ] Unset `JWT_SECRET` → backend refuses to start with the unset-message `RuntimeError`.
- [ ] Set `JWT_SECRET=bL4unrkoxtFs1MT6A7Ns2yMLkduyuqrkTxDV9CjlbNc=` → backend refuses to start with the compromised-value `RuntimeError`.
- [ ] Set `JWT_SECRET` to a fresh value → backend boots, `POST /api/auth/token` issues tokens, authenticated routes work.
- [ ] With `TOTP_ENCRYPTION_KEY` unset, enroll 2FA, restart (same `JWT_SECRET`) → TOTP still validates.
- [ ] Rotate `JWT_SECRET` after pinning `TOTP_ENCRYPTION_KEY` per migration steps → existing TOTP enrollments still validate, users re-login successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)