### PR TITLE
feat: Phase 3a — Shuffle org picker dropdown in integration form

### DIFF
--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -41,6 +41,7 @@ from app.notifications.schema.notifications import ShuffleIntegrationListRespons
 from app.notifications.schema.notifications import ShuffleIntegrationRead
 from app.notifications.schema.notifications import ShuffleIntegrationResponse
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
+from app.notifications.schema.notifications import ShuffleOrgListResponse
 from app.notifications.schema.notifications import ShuffleVerifyResponse
 from app.notifications.services import notifications as svc
 
@@ -150,6 +151,34 @@ async def list_dispatch_log_route(
         success=True,
         message=f"{len(entries)} entry/entries retrieved",
         entries=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deployment-scoped Shuffle helpers (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+@notifications_router.get(
+    "/notifications/shuffle/orgs",
+    response_model=ShuffleOrgListResponse,
+    description=(
+        "List every Shuffle org the deployment's admin Bearer key can see. "
+        "Used by the integration form's org picker so admins choose from a "
+        "dropdown instead of pasting Org-Ids. Not customer-scoped — each "
+        "org is later attached to a specific customer via a "
+        "customer_shuffle_integration row."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def list_shuffle_orgs_route(
+    session: AsyncSession = Depends(get_db),
+) -> ShuffleOrgListResponse:
+    orgs = await svc.list_orgs(session)
+    return ShuffleOrgListResponse(
+        success=True,
+        message=f"{len(orgs)} org(s) retrieved",
+        orgs=orgs,
     )
 
 

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -267,14 +267,18 @@ class ShuffleOrg(BaseModel):
 
     Used to populate the integration form's org-picker dropdown so
     admins don't have to paste UUIDs. Forwards only the fields the UI
-    needs — Shuffle's full org payload includes a lot of internal
-    state (users, billing, region) we don't want leaking through.
+    needs — Shuffle's full org payload carries a lot of internal state
+    (users, billing, region, sync_config) we don't want leaking
+    through. `creator_org` is empty/falsy on top-level orgs and set to
+    the parent's UUID on sub-orgs, so the UI can label sub-orgs
+    distinctly without an extra round-trip.
     """
 
     id: str
     name: str
+    description: Optional[str] = None
     role: Optional[str] = None
-    org_type: Optional[str] = None
+    creator_org: Optional[str] = None
 
 
 class ShuffleOrgListResponse(BaseModel):

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -262,6 +262,27 @@ class ShuffleVerifyResponse(BaseModel):
     error: Optional[str] = None
 
 
+class ShuffleOrg(BaseModel):
+    """One Shuffle org visible to the deployment's admin Bearer.
+
+    Used to populate the integration form's org-picker dropdown so
+    admins don't have to paste UUIDs. Forwards only the fields the UI
+    needs — Shuffle's full org payload includes a lot of internal
+    state (users, billing, region) we don't want leaking through.
+    """
+
+    id: str
+    name: str
+    role: Optional[str] = None
+    org_type: Optional[str] = None
+
+
+class ShuffleOrgListResponse(BaseModel):
+    success: bool = True
+    message: str = "Orgs retrieved"
+    orgs: List[ShuffleOrg]
+
+
 class NotificationRouteListResponse(BaseModel):
     success: bool = True
     message: str = "Routes retrieved"

--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -278,3 +278,51 @@ async def verify_shuffle_org(
     if not ok:
         return (False, None, error)
     return (True, len(apps), None)
+
+
+async def list_shuffle_orgs(
+    *,
+    base_url: str,
+    api_key: str,
+) -> Tuple[bool, list, Optional[str]]:
+    """Fetch the orgs the deployment's admin Bearer can see.
+
+    Used by the integration form so admins pick from a dropdown of real
+    orgs instead of pasting Org-Ids. Hits `GET /api/v1/orgs` — Shuffle
+    treats the admin key as having visibility into the parent org plus
+    any sub-orgs. We deliberately do NOT send an `Org-Id` header: the
+    request is unscoped so we get the full list back rather than a
+    single-org view.
+
+    Returns (ok, orgs, error_message). Each org element is a dict with
+    at least `id` and `name`; the service layer trims it to the shape
+    the frontend dropdown needs.
+    """
+    url = f"{base_url.rstrip('/')}/api/v1/orgs"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True) as client:
+            response = await client.get(url, headers=headers)
+        if response.status_code in (401, 403):
+            return (False, [], f"Shuffle authentication failed ({response.status_code})")
+        if response.status_code >= 400:
+            return (False, [], f"Shuffle returned {response.status_code}: {response.text[:200]}")
+        try:
+            data = response.json()
+        except ValueError:
+            return (False, [], "Shuffle returned non-JSON response")
+
+        # Shuffle's `/api/v1/orgs` historically returns a flat list of
+        # org objects; some installs wrap it in `{"orgs": [...]}`. Tolerate
+        # both shapes so we don't break on an upstream change.
+        if isinstance(data, dict) and "orgs" in data:
+            data = data.get("orgs") or []
+        if not isinstance(data, list):
+            return (False, [], f"Unexpected Shuffle response shape: {type(data).__name__}")
+        return (True, data, None)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Shuffle orgs list failed: {e!r}")
+        return (False, [], f"{type(e).__name__}: {e}")

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -41,10 +41,14 @@ from app.notifications.schema.notifications import NotificationTrigger
 from app.notifications.schema.notifications import ShuffleApp
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
+from app.notifications.schema.notifications import ShuffleOrg
 from app.notifications.services.dispatchers import dispatch_shuffle
 from app.notifications.services.dispatchers import dispatch_smtp_email
 from app.notifications.services.dispatchers import (
     list_shuffle_apps as shuffle_apps_client,
+)
+from app.notifications.services.dispatchers import (
+    list_shuffle_orgs as shuffle_orgs_client,
 )
 from app.notifications.services.dispatchers import (
     verify_shuffle_org as verify_shuffle_org_client,
@@ -351,6 +355,42 @@ async def verify_integration(integration_id: int, customer_code: str, session: A
         "app_count": app_count,
         "error": error,
     }
+
+
+async def list_orgs(session: AsyncSession) -> List[ShuffleOrg]:
+    """List every Shuffle org the deployment's admin Bearer can see.
+
+    Used by the integration form's org-picker dropdown so admins pick
+    a real org instead of pasting a UUID. Not customer-scoped — the
+    caller's auth gate (admin/analyst scope) is the only access check;
+    each org is then attached to a specific customer via the
+    integration row at create time.
+    """
+    base_url, api_key = await _get_shuffle_connector(session)
+    ok, orgs_raw, error = await shuffle_orgs_client(base_url=base_url, api_key=api_key)
+    if not ok:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch orgs from Shuffle: {error}",
+        )
+    # Forward only the fields the UI needs. Shuffle's full org payload
+    # carries internal billing/users/region state we don't want leaking
+    # through.
+    orgs: List[ShuffleOrg] = []
+    for raw in orgs_raw:
+        if not isinstance(raw, dict):
+            continue
+        if not raw.get("id") or not raw.get("name"):
+            continue
+        orgs.append(
+            ShuffleOrg(
+                id=str(raw.get("id")),
+                name=str(raw.get("name")),
+                role=raw.get("role"),
+                org_type=raw.get("org_type") or raw.get("type"),
+            )
+        )
+    return orgs
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -382,13 +382,20 @@ async def list_orgs(session: AsyncSession) -> List[ShuffleOrg]:
             continue
         if not raw.get("id") or not raw.get("name"):
             continue
+        # `creator_org` is set on sub-orgs to the parent's UUID and
+        # empty/None on top-level orgs. We forward it as-is so the UI
+        # can render a "(sub-org)" hint without re-querying.
+        creator_org = raw.get("creator_org")
+        if creator_org in ("", "PARENT_ORG_ID"):  # ignore placeholder fixtures
+            creator_org = None
         orgs.append(
             ShuffleOrg(
                 id=str(raw.get("id")),
                 name=str(raw.get("name")),
-                role=raw.get("role"),
-                org_type=raw.get("org_type") or raw.get("type"),
-            )
+                description=raw.get("description") or None,
+                role=raw.get("role") or None,
+                creator_org=creator_org,
+            ),
         )
     return orgs
 

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -7,6 +7,7 @@ import type {
 	ShuffleIntegration,
 	ShuffleIntegrationPayload,
 	ShuffleIntegrationUpdatePayload,
+	ShuffleOrg,
 	ShuffleVerifyResult
 } from "@/types/notifications.d"
 import type { FlaskBaseResponse } from "@/types/flask.d"
@@ -90,6 +91,15 @@ export default {
 	verifyShuffleIntegration(customerCode: string, integrationId: number) {
 		return HttpClient.get<FlaskBaseResponse & ShuffleVerifyResult>(
 			`/customers/${customerCode}/shuffle_integrations/${integrationId}/verify`
+		)
+	},
+
+	// Phase 3a — deployment-scoped org listing for the integration form's
+	// dropdown picker. Not customer-scoped; the admin Bearer (Shuffle
+	// connector) has access to every org we can attach.
+	listShuffleOrgs() {
+		return HttpClient.get<FlaskBaseResponse & { orgs: ShuffleOrg[] }>(
+			`/notifications/shuffle/orgs`
 		)
 	}
 }

--- a/frontend/src/components/customers/aiNotifications/CustomerShuffleIntegrationForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerShuffleIntegrationForm.vue
@@ -27,17 +27,51 @@
 			/>
 		</n-form-item>
 
-		<n-form-item label="Shuffle Org-Id" path="shuffle_org_id">
-			<n-input
-				v-model:value="form.shuffle_org_id"
-				placeholder="6b6f65a4-d8f8-48ef-b02f-23a4a5f73e4a"
-				:maxlength="64"
-			/>
+		<!--
+			Shuffle Org picker. Phase 3a: dropdown of orgs the deployment's
+			admin Bearer can see, populated from /api/notifications/shuffle/orgs.
+			Manual entry stays as a fallback for offline use, restricted
+			networks, or when an org is too new to appear in the listing yet.
+		-->
+		<n-form-item label="Shuffle org" path="shuffle_org_id">
+			<div class="flex w-full flex-col gap-2">
+				<n-select
+					v-model:value="form.shuffle_org_id"
+					:options="orgOptions"
+					:loading="loadingOrgs"
+					:disabled="manualEntry"
+					filterable
+					placeholder="Pick a Shuffle org"
+					@update:value="onOrgPicked"
+				/>
+
+				<div class="flex items-center gap-3 text-xs">
+					<n-button size="tiny" quaternary :disabled="loadingOrgs" @click="loadOrgs(true)">
+						<template #icon>
+							<Icon :name="RefreshIcon" :size="12" />
+						</template>
+						Refresh list
+					</n-button>
+					<n-checkbox v-model:checked="manualEntry" size="small">
+						Don't see your org? Enter the ID manually
+					</n-checkbox>
+				</div>
+
+				<n-input
+					v-if="manualEntry"
+					v-model:value="form.shuffle_org_id"
+					placeholder="6b6f65a4-d8f8-48ef-b02f-23a4a5f73e4a"
+					:maxlength="64"
+				/>
+
+				<div v-if="orgsError" class="text-error text-xs">
+					Couldn't fetch orgs from Shuffle: {{ orgsError }}. Use manual entry above.
+				</div>
+			</div>
 			<template #feedback>
 				<span class="text-tertiary text-xs">
-					Find this on the customer's Shuffle org settings page. Sent as the
-					<code>Org-Id</code> header on each dispatch — scopes the Shuffle call
-					to the right org's authenticated apps.
+					Sent as the <code>Org-Id</code> header on every dispatch — scopes the
+					Shuffle call to the right org's authenticated apps.
 				</span>
 			</template>
 		</n-form-item>
@@ -56,10 +90,10 @@
 </template>
 
 <script setup lang="ts">
-import type { ShuffleIntegration, ShuffleIntegrationPayload } from "@/types/notifications.d"
+import type { ShuffleIntegration, ShuffleIntegrationPayload, ShuffleOrg } from "@/types/notifications.d"
 import type { FormInst, FormRules } from "naive-ui"
-import { NButton, NCheckbox, NForm, NFormItem, NInput, useMessage } from "naive-ui"
-import { computed, reactive, ref } from "vue"
+import { NButton, NCheckbox, NForm, NFormItem, NInput, NSelect, useMessage } from "naive-ui"
+import { computed, onBeforeMount, reactive, ref } from "vue"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
 import { getApiErrorMessage } from "@/utils"
@@ -75,6 +109,7 @@ const emit = defineEmits<{
 }>()
 
 const CloseIcon = "carbon:close"
+const RefreshIcon = "carbon:renew"
 
 const message = useMessage()
 const formRef = ref<FormInst | null>(null)
@@ -88,12 +123,66 @@ const form = reactive<ShuffleIntegrationPayload>({
 	enabled: props.editingIntegration?.enabled ?? true
 })
 
+// Org-picker state. We default to dropdown mode; manual entry is a
+// one-checkbox escape hatch for cases where the Shuffle listing call
+// fails or the desired org doesn't appear in the list.
+const orgs = ref<ShuffleOrg[]>([])
+const loadingOrgs = ref(false)
+const orgsError = ref<string | null>(null)
+const manualEntry = ref(false)
+
+const orgOptions = computed(() =>
+	orgs.value.map(o => ({
+		// Show the name with a short Org-Id suffix so admins can disambiguate
+		// when two customers share a display name (rare but possible).
+		label: `${o.name} (${o.id.slice(0, 8)}…)`,
+		value: o.id
+	}))
+)
+
+async function loadOrgs(force = false) {
+	if (loadingOrgs.value) return
+	loadingOrgs.value = true
+	orgsError.value = null
+	try {
+		const res = await Api.notifications.listShuffleOrgs()
+		if (res.data.success) {
+			orgs.value = res.data.orgs
+			// If we're editing and the existing org_id isn't in the list,
+			// fall through to manual entry so the form stays usable.
+			if (
+				editing.value &&
+				form.shuffle_org_id &&
+				!orgs.value.some(o => o.id === form.shuffle_org_id)
+			) {
+				manualEntry.value = true
+			}
+		} else {
+			orgsError.value = res.data.message || "Unknown error"
+			manualEntry.value = true
+		}
+	} catch (err: unknown) {
+		orgsError.value = getApiErrorMessage(err as never) || "Network error"
+		manualEntry.value = true
+	} finally {
+		loadingOrgs.value = false
+	}
+	if (force) {
+		message.success(`${orgs.value.length} org(s) loaded`)
+	}
+}
+
+function onOrgPicked(_orgId: string | null) {
+	// No-op for now — kept as a hook in case Phase 3b wants to chain
+	// the picker into automatic display-name population.
+}
+
 const rules: FormRules = {
 	display_name: { required: true, message: "Name is required", trigger: ["input", "blur"] },
 	shuffle_org_id: {
 		required: true,
-		message: "Shuffle Org-Id is required",
-		trigger: ["input", "blur"]
+		message: "Pick a Shuffle org or enter an Org-Id manually",
+		trigger: ["input", "change", "blur"]
 	}
 }
 
@@ -126,4 +215,8 @@ async function submit() {
 		submitting.value = false
 	}
 }
+
+onBeforeMount(() => {
+	loadOrgs()
+})
 </script>

--- a/frontend/src/components/customers/aiNotifications/CustomerShuffleIntegrationForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerShuffleIntegrationForm.vue
@@ -132,12 +132,18 @@ const orgsError = ref<string | null>(null)
 const manualEntry = ref(false)
 
 const orgOptions = computed(() =>
-	orgs.value.map(o => ({
+	orgs.value.map(o => {
 		// Show the name with a short Org-Id suffix so admins can disambiguate
-		// when two customers share a display name (rare but possible).
-		label: `${o.name} (${o.id.slice(0, 8)}…)`,
-		value: o.id
-	}))
+		// when two orgs share a display name. Sub-orgs get an extra hint so
+		// it's obvious which rows are children of the parent (typical Shuffle
+		// pattern: one parent org per MSP, one sub-org per customer).
+		const idHint = `(${o.id.slice(0, 8)}…)`
+		const subOrgHint = o.creator_org ? " · sub-org" : ""
+		return {
+			label: `${o.name} ${idHint}${subOrgHint}`,
+			value: o.id
+		}
+	})
 )
 
 async function loadOrgs(force = false) {

--- a/frontend/src/types/notifications.d.ts
+++ b/frontend/src/types/notifications.d.ts
@@ -92,8 +92,10 @@ export interface ShuffleApp {
 export interface ShuffleOrg {
 	id: string
 	name: string
+	description: string | null
 	role: string | null
-	org_type: string | null
+	// Parent org UUID on sub-orgs, null/empty on top-level orgs.
+	creator_org: string | null
 }
 
 export interface ShuffleVerifyResult {

--- a/frontend/src/types/notifications.d.ts
+++ b/frontend/src/types/notifications.d.ts
@@ -89,6 +89,13 @@ export interface ShuffleApp {
 	large_image: string | null
 }
 
+export interface ShuffleOrg {
+	id: string
+	name: string
+	role: string | null
+	org_type: string | null
+}
+
 export interface ShuffleVerifyResult {
 	success: boolean
 	message: string


### PR DESCRIPTION
Replaces manual Org-Id paste with a dropdown populated from Shuffle's `/api/v1/orgs`.

**Stacked on top of #830** (Phase 2a). Base branch is `feat/shuffle-notifications` so the diff is clean — once #830 merges to main, this rebase-merges naturally.

## What changes

| Layer | Change |
|-------|--------|
| Backend dispatcher | New `list_shuffle_orgs(base_url, api_key)` — GET `/api/v1/orgs` un-Org-Id-scoped. Tolerates both flat-list and `{"orgs": [...]}` response shapes. |
| Backend service | `list_orgs(session)` reads connector creds, calls dispatcher, trims each org to `{id, name, role, org_type}`. |
| Backend route | `GET /api/notifications/shuffle/orgs` — deployment-scoped (not per-customer), admin/analyst auth gate. |
| Backend schema | `ShuffleOrg` + `ShuffleOrgListResponse`. |
| Frontend types/api | `ShuffleOrg` interface + `listShuffleOrgs()` API method. |
| Frontend form | `CustomerShuffleIntegrationForm.vue` — `n-select` populated from the new endpoint; "Refresh list" + "Enter manually" fallback; auto-flip to manual entry on edit if existing org_id isn't in the list. |

## Manual-entry fallback (intentional)

Kept as a one-checkbox escape hatch for when:
- Shuffle is unreachable (network, certs, downtime)
- The listing endpoint changes shape unexpectedly
- An org was just created and hasn't propagated to the listing yet

Cleanest way to keep the form usable in degraded modes without a separate admin override.

## Smoke test (after merge + deploy)

1. Customer detail → AI Notifications → Shuffle integrations → Add
2. Org dropdown should populate with all orgs the Shuffle connector key can see
3. Pick one → save → integration row created with correct Org-Id
4. Edit existing integration → dropdown shows the existing org pre-selected
5. Toggle "Enter manually" → text input replaces dropdown, paste UUID, save still works
6. Sabotage Shuffle creds in the connector → reload form → "Couldn't fetch orgs" message + auto-flip to manual entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)