### PR TITLE
security: bump mysql to 8.0.46-debian (8.0.38 → latest 8.0.x patch)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     #     restart: always
 
     copilot-mysql:
-        image: mysql:8.0.38-debian
+        image: mysql:8.0.46-debian
         environment:
             MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
             MYSQL_DATABASE: copilot


### PR DESCRIPTION
## Summary

- Bumps the `copilot-mysql` service in `docker-compose.yml` from `mysql:8.0.38-debian` to `mysql:8.0.46-debian` to pull in accumulated 8.0.x patch updates since 8.0.38 (released 2024-07).
- 8.0.46 is the most recent debian-tagged release on the official `mysql` Docker image at the time of writing — same major.minor line, no schema or behavior changes.
- One-line change; the `mysql-data` named volume is reused untouched.

## Upgrade path verified locally

For existing deployments running `mysql:8.0.38-debian`:

1. `docker compose pull && docker compose up -d` recreates only the `copilot-mysql` container.
2. MySQL runs the data-dictionary upgrade itself on first boot — no manual `mysql_upgrade` step required:
   ```
   [Server] Server upgrade from '80038' to '80046' started.
   [Server] Server upgrade from '80038' to '80046' completed.
   ```
3. Total downtime in the test: ~5s end-to-end.
4. Backend container stays up; SQLAlchemy/aiomysql pool reconnects automatically. APScheduler emits a single transient `Lost connection to MySQL server during query` warning during the few seconds of MySQL downtime, then recovers on its own.

## Test plan

- [ ] On a host already running 8.0.38: `docker compose pull && docker compose up -d` and confirm `copilot-mysql` recreates without manual intervention.
- [ ] Confirm `docker exec … mysql -e "SELECT VERSION();"` returns `8.0.46`.
- [ ] Confirm `alembic_version`, `connectors`, `role`, `available_integrations`, and `user` row counts are unchanged across the upgrade.
- [ ] Confirm the backend health endpoint (`GET /`) responds 200 after MySQL is back.
- [ ] Confirm only the expected APScheduler reconnect warning appears in `copilot-backend` logs (no traceback / no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)