### PR TITLE
chore: pydantic 2 / SQLAlchemy 2 cleanup — eliminate deprecations

### DIFF
--- a/backend/app/agents/sca/routes/sca.py
+++ b/backend/app/agents/sca/routes/sca.py
@@ -362,7 +362,7 @@ async def generate_sca_report(
     Returns:
         SCAReportGenerateResponse: Report generation status and details
     """
-    logger.info(f"Generating SCA report for customer {request.customer_code} " f"with filters: {request.dict(exclude_none=True)}")
+    logger.info(f"Generating SCA report for customer {request.customer_code} " f"with filters: {request.model_dump(exclude_none=True)}")
 
     try:
         # Note: This will be processed synchronously for now

--- a/backend/app/agents/services/sync.py
+++ b/backend/app/agents/services/sync.py
@@ -265,7 +265,7 @@ async def sync_agents_wazuh() -> SyncedAgentsResponse:
             else:
                 await add_wazuh_agent_in_db(session, wazuh_agent, customer_code)
 
-            synced_wazuh_agent = SyncedWazuhAgent(**wazuh_agent.dict())
+            synced_wazuh_agent = SyncedWazuhAgent(**wazuh_agent.model_dump())
             agents_added_list.append(synced_wazuh_agent)
 
     logger.info(f"Agents Added List: {agents_added_list}")

--- a/backend/app/agents/wazuh/services/vulnerabilities.py
+++ b/backend/app/agents/wazuh/services/vulnerabilities.py
@@ -337,7 +337,7 @@ async def sync_agent_vulnerabilities(agent_name: str, customer_code: str):
                         integration="vulnerabilities",
                         customer_code=customer_code,
                         agent_name=agent_name,
-                        **vulnerability.dict(),
+                        **vulnerability.model_dump(),
                     ),
                 )
         return True
@@ -350,7 +350,7 @@ async def sync_agent_vulnerabilities(agent_name: str, customer_code: str):
                 integration="vulnerabilities",
                 customer_code=customer_code,
                 agent_name=agent_name,
-                **vulnerability.dict(),
+                **vulnerability.model_dump(),
             ),
         )
     return True

--- a/backend/app/auth/routes/sso.py
+++ b/backend/app/auth/routes/sso.py
@@ -148,7 +148,7 @@ async def get_sso_settings():
 )
 async def update_sso_settings(body: SSOConfigUpdate):
     """Update SSO configuration. Admin only."""
-    data = body.dict(exclude_none=False)
+    data = body.model_dump(exclude_none=False)
 
     # Don't overwrite secrets if empty/None
     if not data.get("azure_client_secret"):

--- a/backend/app/connectors/cortex/schema/analyzers.py
+++ b/backend/app/connectors/cortex/schema/analyzers.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import model_validator
 
 HASH_REGEX = re.compile(
     r"[a-fA-F\d]{32}|[a-fA-F\d]{64}",
@@ -35,15 +35,13 @@ class RunAnalyzerBody(BaseModel):
         description="Data type determined after validation",
     )
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("analyzer_data", pre=True, always=True)
-    def validate_and_set_data_type(cls, value: str, values: dict) -> str:
-        is_valid, data_type = cls.is_valid_datatype(value)
+    @model_validator(mode="after")
+    def validate_and_set_data_type(self):
+        is_valid, data_type = self.is_valid_datatype(self.analyzer_data)
         if not is_valid:
             raise ValueError(f"Invalid data type: {data_type}")
-        values["data_type"] = data_type
-        return value
+        self.data_type = data_type
+        return self
 
     @classmethod
     def is_valid_datatype(cls, value: str) -> Tuple[bool, str]:

--- a/backend/app/connectors/cortex/utils/universal.py
+++ b/backend/app/connectors/cortex/utils/universal.py
@@ -104,7 +104,7 @@ async def run_and_wait_for_analyzer(
     if api is None:
         return {"success": False, "message": "API initialization failed"}
     try:
-        job = api.analyzers.run_by_name(analyzer_name, job_data.dict(), force=1)
+        job = api.analyzers.run_by_name(analyzer_name, job_data.model_dump(), force=1)
         return await monitor_analyzer_job(api, job)
     except Exception as e:
         raise HTTPException(

--- a/backend/app/connectors/grafana/schema/dashboards.py
+++ b/backend/app/connectors/grafana/schema/dashboards.py
@@ -3,7 +3,7 @@ from typing import List
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import field_validator
 
 
 class GrafanaDashboard(BaseModel):
@@ -155,10 +155,9 @@ class DashboardProvisionRequest(BaseModel):
         description="URL of the Grafana instance for the links within the dashboards.",
     )
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("dashboards", each_item=True)
-    def check_dashboard_exists(cls, e):
+    @field_validator("dashboards")
+    @classmethod
+    def check_dashboards_exist(cls, dashboards):
         valid_dashboards = {
             item.name: item
             for item in list(WazuhDashboard)
@@ -177,6 +176,7 @@ class DashboardProvisionRequest(BaseModel):
             + list(SonicwallDashboard)
             + list(SentinelOneDashboard)
         }
-        if e not in valid_dashboards:
-            raise ValueError(f'Dashboard identifier "{e}" is not recognized.')
-        return e
+        for e in dashboards:
+            if e not in valid_dashboards:
+                raise ValueError(f'Dashboard identifier "{e}" is not recognized.')
+        return dashboards

--- a/backend/app/connectors/graylog/routes/pipelines.py
+++ b/backend/app/connectors/graylog/routes/pipelines.py
@@ -57,7 +57,7 @@ def transform_stages_with_rule_ids(
     new_stages = []
     for stage in stages:
         rule_ids = [rule_title_to_id.get(rule_title, None) for rule_title in stage.rules]
-        new_stage = StageWithRuleID(**stage.dict(), rule_ids=rule_ids)
+        new_stage = StageWithRuleID(**stage.model_dump(), rule_ids=rule_ids)
         new_stages.append(new_stage)
     return new_stages
 
@@ -78,7 +78,7 @@ def transform_pipeline_with_rule_ids(
 
     """
     new_stages = transform_stages_with_rule_ids(pipeline.stages, rule_title_to_id)
-    pipeline_dict = pipeline.dict()
+    pipeline_dict = pipeline.model_dump()
     pipeline_dict["stages"] = new_stages
     return PipelineWithRuleID(**pipeline_dict)
 

--- a/backend/app/connectors/graylog/schema/events.py
+++ b/backend/app/connectors/graylog/schema/events.py
@@ -26,7 +26,7 @@ class ExpressionItem(BaseModel):
     right: Optional["ExpressionItem"] = None
 
 
-ExpressionItem.update_forward_refs()
+ExpressionItem.model_rebuild()
 
 
 class Conditions(BaseModel):

--- a/backend/app/connectors/graylog/services/events.py
+++ b/backend/app/connectors/graylog/services/events.py
@@ -64,7 +64,7 @@ async def get_alerts(alert_query: AlertQuery) -> GraylogAlertsResponse:
     logger.info("Getting alerts from Graylog")
     response = await send_post_request(
         endpoint="/api/events/search",
-        data=alert_query.dict(),
+        data=alert_query.model_dump(),
     )
 
     if response["success"]:

--- a/backend/app/connectors/graylog/services/pipelines.py
+++ b/backend/app/connectors/graylog/services/pipelines.py
@@ -206,7 +206,7 @@ async def connect_stream_to_pipeline(
     )
     response_json = await send_post_request(
         endpoint="/api/system/pipelines/connections/to_stream",
-        data=stream_and_pipeline.dict(),
+        data=stream_and_pipeline.model_dump(),
     )
     logger.info(f"Response: {response_json}")
     return StreamConnectionToPipelineResponse(**response_json)

--- a/backend/app/connectors/shuffle/schema/organizations.py
+++ b/backend/app/connectors/shuffle/schema/organizations.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import field_validator
 
 
 class SyncConfig(BaseModel):
@@ -103,9 +103,8 @@ class DetailedOrganization(BaseModel):
     region_url: str = ""
     tutorials: List[Any] = []
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("manager_orgs", pre=True, always=True)
+    @field_validator("manager_orgs", mode="before")
+    @classmethod
     def validate_manager_orgs(cls, v):
         """
         Validate and normalize manager_orgs field.

--- a/backend/app/connectors/shuffle/services/integrations.py
+++ b/backend/app/connectors/shuffle/services/integrations.py
@@ -16,7 +16,7 @@ async def execute_integration(request: IntegrationRequest) -> dict:
         dict: The response containing the execution ID.
     """
     logger.info(f"Executing integration: {request}")
-    response = await send_post_request("/api/v1/apps/categories/run", request.dict())
+    response = await send_post_request("/api/v1/apps/categories/run", request.model_dump())
     logger.info(f"Response: {response}")
     return response
 
@@ -31,9 +31,9 @@ async def execute_workflow(request: ExecuteWorkflowRequest) -> dict:
     Returns:
         dict: The response containing the execution ID.
     """
-    logger.info(f"Executing workflow: {request.dict()}")
+    logger.info(f"Executing workflow: {request.model_dump()}")
     try:
-        response = await send_post_request(f"/api/v1/workflows/{request.workflow_id}/execute", request.dict())
+        response = await send_post_request(f"/api/v1/workflows/{request.workflow_id}/execute", request.model_dump())
         logger.info(f"Response: {response}")
         return response
     except Exception as e:

--- a/backend/app/connectors/talon/services/talon.py
+++ b/backend/app/connectors/talon/services/talon.py
@@ -34,7 +34,7 @@ async def send_talon_message(request: TalonMessageRequest) -> TalonMessageRespon
     logger.info(f"Sending message to Talon: {request.message}")
     response = await send_post_request(
         endpoint="/message",
-        data=request.dict(),
+        data=request.model_dump(),
         timeout=600,
     )
     if not response.get("success"):
@@ -62,7 +62,7 @@ async def stream_talon_message(request: TalonMessageRequest):
     logger.info(f"Streaming message to Talon: {request.message}")
     async for chunk in send_post_request_sse(
         endpoint="/message",
-        data=request.dict(),
+        data=request.model_dump(),
     ):
         yield chunk
 

--- a/backend/app/connectors/utils.py
+++ b/backend/app/connectors/utils.py
@@ -32,7 +32,7 @@ async def get_connector_info_from_db(
     connector = result.scalars().first()
     if connector:
         connector_pydantic = ConnectorResponse.from_orm(connector)
-        return connector_pydantic.dict()
+        return connector_pydantic.model_dump()
     else:
         logger.warning("No connector found.")
         return None

--- a/backend/app/connectors/velociraptor/services/artifacts.py
+++ b/backend/app/connectors/velociraptor/services/artifacts.py
@@ -1062,12 +1062,12 @@ async def post_to_copilot_ai_module(data: ArtifactReccomendationRequest) -> Arti
     Args:
         data (ArtifactReccomendationRequest): The data to send to the copilot-ai-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-ai-module/velociraptor-artifact-recommendation with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-ai-module/velociraptor-artifact-recommendation with data: {data.model_dump()}")
     # raise HTTPException(status_code=501, detail="Not Implemented Yet")
     async with httpx.AsyncClient() as client:
         data = await client.post(
             "http://copilot-ai-module/velociraptor-artifact-recommendation",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
         response_data = data.json()

--- a/backend/app/connectors/wazuh_indexer/schema/alerts.py
+++ b/backend/app/connectors/wazuh_indexer/schema/alerts.py
@@ -157,4 +157,4 @@ class AlertNotFound(BaseModel):
     source: Dict[str, str] = Field(alias="_source")
 
     def to_dict(self) -> Dict[str, str]:
-        return self.dict(by_alias=True)
+        return self.model_dump(by_alias=True)

--- a/backend/app/connectors/wazuh_manager/services/rules.py
+++ b/backend/app/connectors/wazuh_manager/services/rules.py
@@ -532,12 +532,12 @@ async def post_to_copilot_ai_module(data: RuleExcludeRequest) -> RuleExcludeResp
     Args:
         data (CollectHuntress): The data to send to the copilot-ai-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-ai-module/wazuh-rule-exclusion with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-ai-module/wazuh-rule-exclusion with data: {data.model_dump()}")
     # raise HTTPException(status_code=501, detail="Not Implemented Yet")
     async with httpx.AsyncClient() as client:
         data = await client.post(
             "http://copilot-ai-module/wazuh-rule-exclusion",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
     return RuleExcludeResponse(**data.json())

--- a/backend/app/customer_provisioning/routes/default_settings.py
+++ b/backend/app/customer_provisioning/routes/default_settings.py
@@ -92,7 +92,7 @@ async def update_customer_provisioning_default_settings(
         raise HTTPException(status_code=404, detail="Settings not found")
 
     # Update the fields
-    for key, value in customer_provisioning_default_settings.dict().items():
+    for key, value in customer_provisioning_default_settings.model_dump().items():
         setattr(existing_settings, key, value)
 
     await db.commit()

--- a/backend/app/customer_provisioning/services/decommission.py
+++ b/backend/app/customer_provisioning/services/decommission.py
@@ -209,7 +209,7 @@ async def decommission_wazuh_worker(
         request.portainer_deployment = False
         response = requests.post(
             url=f"{api_endpoint}/provision_worker/decommission",
-            json=request.dict(),
+            json=request.model_dump(),
         )
         # Check the response status code
         if response.status_code != 200:
@@ -237,7 +237,7 @@ async def decommission_wazuh_worker(
             logger.info(f"Provisioning Wazuh worker on IP: {ip}")
             response = requests.post(
                 url=f"http://{ip}:5003/provision_worker/decommission",
-                json=request.dict(),
+                json=request.model_dump(),
             )
             logger.info(f"Status code from Wazuh Worker: {response.status_code}")
             if response.status_code != 200:
@@ -290,7 +290,7 @@ async def decommission_haproxy(
     # Send the POST request to the HAProxy worker
     response = requests.post(
         url=f"{api_endpoint}/provision_worker/haproxy/decommission",
-        json=request.dict(),
+        json=request.model_dump(),
     )
     # Check the response status code
     if response.status_code != 200:

--- a/backend/app/customer_provisioning/services/grafana.py
+++ b/backend/app/customer_provisioning/services/grafana.py
@@ -110,7 +110,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 
@@ -189,7 +189,7 @@ async def create_vulnerability_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/customer_provisioning/services/graylog.py
+++ b/backend/app/customer_provisioning/services/graylog.py
@@ -69,11 +69,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -158,11 +158,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -238,7 +238,7 @@ async def connect_stream_to_pipeline(
     )
     response_json = await send_post_request(
         endpoint="/api/system/pipelines/connections/to_stream",
-        data=stream_and_pipeline.dict(),
+        data=stream_and_pipeline.model_dump(),
     )
     logger.info(f"Response: {response_json}")
     return StreamConnectionToPipelineResponse(**response_json)

--- a/backend/app/customer_provisioning/services/provision.py
+++ b/backend/app/customer_provisioning/services/provision.py
@@ -166,7 +166,7 @@ async def provision_wazuh_customer(
             return CustomerProvisionResponse(
                 message=f"Customer {request.customer_name} provisioned successfully, but the Wazuh worker failed to provision",
                 success=True,
-                customer_meta=customer_meta.dict(),
+                customer_meta=customer_meta.model_dump(),
                 wazuh_worker_provisioned=False,
             )
 
@@ -185,14 +185,14 @@ async def provision_wazuh_customer(
             return CustomerProvisionResponse(
                 message=f"Customer {request.customer_name} provisioned successfully, but the HAProxy failed to provision",
                 success=True,
-                customer_meta=customer_meta.dict(),
+                customer_meta=customer_meta.model_dump(),
                 wazuh_worker_provisioned=True,
             )
 
     return CustomerProvisionResponse(
         message=f"Customer {request.customer_name} provisioned successfully",
         success=True,
-        customer_meta=customer_meta.dict(),
+        customer_meta=customer_meta.model_dump(),
         wazuh_worker_provisioned=True,
     )
 
@@ -330,7 +330,7 @@ async def provision_wazuh_worker(
         request.wazuh_manager_version = await get_wazuh_manager_version()
         response = requests.post(
             url=f"{api_endpoint}/provision_worker",
-            json=request.dict(),
+            json=request.model_dump(),
         )
         logger.info(f"Status code from Wazuh Worker: {response.status_code}")
         # Check the response status code
@@ -356,7 +356,7 @@ async def provision_wazuh_worker(
 
             response = requests.post(
                 url=f"http://{ip}:5003/provision_worker",
-                json=request.dict(),
+                json=request.model_dump(),
             )
             logger.info(f"Status code from Wazuh Worker: {response.status_code}")
             if response.status_code != 200:
@@ -404,7 +404,7 @@ async def provision_haproxy(
         # Send the POST request to the Wazuh worker
         response = requests.post(
             url=f"{api_endpoint}/provision_worker/haproxy",
-            json=request.dict(),
+            json=request.model_dump(),
         )
         # Check the response status code
         if response.status_code != 200:
@@ -429,7 +429,7 @@ async def provision_haproxy(
         logger.info(f"Invoking the customer provisioning application on the swarm node IPs: {request.swarm_nodes}")
         response = requests.post(
             url=f"{api_endpoint}/provision_worker/haproxy",
-            json=request.dict(),
+            json=request.model_dump(),
         )
         # Check the response status code
         if response.status_code != 200:

--- a/backend/app/customers/routes/customers.py
+++ b/backend/app/customers/routes/customers.py
@@ -211,7 +211,7 @@ async def create_customer(
     await mssp_license_check(session)
     await verify_unique_customer_code(session, customer)
     logger.info(f"Creating new customer: {customer}")
-    new_customer = Customers(**customer.dict())
+    new_customer = Customers(**customer.model_dump())
     session.add(new_customer)
     await session.commit()
     return CustomerResponse(
@@ -348,7 +348,7 @@ async def update_customer(
         )
 
     # Update model instance with input data
-    for key, value in customer.dict(exclude={"is_provisioned"}).items():
+    for key, value in customer.model_dump(exclude={"is_provisioned"}).items():
         setattr(existing_customer, key, value)
 
     await session.commit()  # Commit changes asynchronously
@@ -478,7 +478,7 @@ async def add_customer_meta(
         )
 
     logger.info(f"Got existing customer: {existing_customer}")
-    new_customer_meta = CustomersMeta(**customer_meta.dict())
+    new_customer_meta = CustomersMeta(**customer_meta.model_dump())
     new_customer_meta.customer_code = existing_customer.customer_code
     new_customer_meta.customer_name = existing_customer.customer_name
 
@@ -578,7 +578,7 @@ async def update_customer_meta(
         )
 
     # Update the existing record with new values
-    for key, value in customer_meta.dict(exclude_unset=True).items():
+    for key, value in customer_meta.model_dump(exclude_unset=True).items():
         setattr(existing_customer_meta, key, value)
 
     await session.commit()  # Commit the changes to the database asynchronously

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -791,8 +791,8 @@ class CustomerNotificationRoute(SQLModel, table=True):
     # sync, which throws MissingGreenlet under AsyncSession. One-way
     # foreign keys are fine here; we walk them via explicit queries
     # (`session.get(...)`) when we need them.
-    dispatches: list["NotificationDispatchLog"] = Relationship()
-    shuffle_integration: Optional["CustomerShuffleIntegration"] = Relationship()
+    dispatches: list["NotificationDispatchLog"] = Relationship(sa_relationship_kwargs={"overlaps": "route"})
+    shuffle_integration: Optional["CustomerShuffleIntegration"] = Relationship(sa_relationship_kwargs={"overlaps": "routes"})
 
 
 class NotificationDispatchLog(SQLModel, table=True):
@@ -844,7 +844,8 @@ class NotificationDispatchLog(SQLModel, table=True):
 
     # See note on CustomerNotificationRoute.dispatches — back_populates
     # removed deliberately to keep AsyncSession flush() synchronous-IO-free.
-    route: Optional["CustomerNotificationRoute"] = Relationship()
+    # `overlaps` makes the deliberate one-way nature explicit to SQLAlchemy 2.
+    route: Optional["CustomerNotificationRoute"] = Relationship(sa_relationship_kwargs={"overlaps": "dispatches"})
 
 
 class CustomerShuffleIntegration(SQLModel, table=True):
@@ -884,4 +885,4 @@ class CustomerShuffleIntegration(SQLModel, table=True):
     customer: Optional["Customers"] = Relationship()
     # See note on CustomerNotificationRoute.dispatches — back_populates
     # removed for AsyncSession compatibility.
-    routes: list["CustomerNotificationRoute"] = Relationship()
+    routes: list["CustomerNotificationRoute"] = Relationship(sa_relationship_kwargs={"overlaps": "shuffle_integration"})

--- a/backend/app/healthchecks/agents/services/agents.py
+++ b/backend/app/healthchecks/agents/services/agents.py
@@ -36,7 +36,7 @@ def is_wazuh_agent_unhealthy(
     # If wazuh_last_seen is None, consider it unhealthy
     if agent.wazuh_last_seen is None:
         logger.info(f"Agent {agent.hostname} (ID: {agent.agent_id}) has no Wazuh last seen time - marking as unhealthy")
-        return ExtendedAgentModel(**agent.dict(), unhealthy_wazuh_agent=True)
+        return ExtendedAgentModel(**agent.model_dump(), unhealthy_wazuh_agent=True)
 
     current_time = datetime.now()
     wazuh_last_seen = agent.wazuh_last_seen
@@ -45,14 +45,14 @@ def is_wazuh_agent_unhealthy(
         logger.info(
             f"Agent {agent} has a wazuh_last_seen time in the future: {wazuh_last_seen}",
         )
-        return ExtendedAgentModel(**agent.dict(), unhealthy_wazuh_agent=True)
+        return ExtendedAgentModel(**agent.model_dump(), unhealthy_wazuh_agent=True)
 
     # Calculate the total time delta based on the criteria
     total_minutes = time_criteria.minutes + time_criteria.hours * 60 + time_criteria.days * 24 * 60
     time_delta = timedelta(minutes=total_minutes)
 
     is_unhealthy = (current_time - wazuh_last_seen) > time_delta
-    return ExtendedAgentModel(**agent.dict(), unhealthy_wazuh_agent=is_unhealthy)
+    return ExtendedAgentModel(**agent.model_dump(), unhealthy_wazuh_agent=is_unhealthy)
 
 
 def is_velociraptor_agent_unhealthy(
@@ -72,7 +72,7 @@ def is_velociraptor_agent_unhealthy(
     # If velociraptor_id is None or velociraptor_last_seen is None, consider it unhealthy
     if agent.velociraptor_id is None or agent.velociraptor_last_seen is None:
         logger.info(f"Agent {agent.hostname} (ID: {agent.agent_id}) has no Velociraptor ID or last seen time - marking as unhealthy")
-        return ExtendedAgentModel(**agent.dict(), unhealthy_velociraptor_agent=True)
+        return ExtendedAgentModel(**agent.model_dump(), unhealthy_velociraptor_agent=True)
 
     current_time = datetime.now()
     velociraptor_last_seen = agent.velociraptor_last_seen
@@ -81,14 +81,14 @@ def is_velociraptor_agent_unhealthy(
         logger.info(
             f"Agent {agent} has a velociraptor_last_seen time in the future: {velociraptor_last_seen}",
         )
-        return ExtendedAgentModel(**agent.dict(), unhealthy_velociraptor_agent=True)
+        return ExtendedAgentModel(**agent.model_dump(), unhealthy_velociraptor_agent=True)
 
     # Calculate the total time delta based on the criteria
     total_minutes = time_criteria.minutes + time_criteria.hours * 60 + time_criteria.days * 24 * 60
     time_delta = timedelta(minutes=total_minutes)
 
     is_unhealthy = (current_time - velociraptor_last_seen) > time_delta
-    return ExtendedAgentModel(**agent.dict(), unhealthy_velociraptor_agent=is_unhealthy)
+    return ExtendedAgentModel(**agent.model_dump(), unhealthy_velociraptor_agent=is_unhealthy)
 
 
 async def wazuh_agents_healthcheck(

--- a/backend/app/incidents/routes/incident_alert.py
+++ b/backend/app/incidents/routes/incident_alert.py
@@ -359,7 +359,7 @@ async def invoke_alert_threshold_graylog_route(
 
     alert_id = await create_alert_full(
         alert_payload=CreatedAlertPayload(
-            alert_context_payload=request.event.fields.dict(),
+            alert_context_payload=request.event.fields.model_dump(),
             asset_payload=asset_name,
             timefield_payload=str(request.event.timestamp),
             alert_title_payload=request.event.message,
@@ -439,12 +439,12 @@ async def create_exclusion(
     logger.info(f"Current user: {current_user}")
 
     # Take only needed fields from exclusion, excluding created_by
-    exclusion_dict = exclusion.dict(exclude={"created_by"})
+    exclusion_dict = exclusion.model_dump(exclude={"created_by"})
     # Create a new exclusion with the current user
     updated_exclusion = VeloSigmaExclusionCreate(**exclusion_dict, created_by=current_user)
 
     # Log the exclusion data for debugging
-    logger.info(f"Exclusion data: {updated_exclusion.dict()}")
+    logger.info(f"Exclusion data: {updated_exclusion.model_dump()}")
 
     service = VeloSigmaExclusionService(db)
     # return await service.create_exclusion(updated_exclusion)
@@ -518,7 +518,7 @@ async def update_exclusion(
 ):
     """Update an existing exclusion rule."""
     service = VeloSigmaExclusionService(db)
-    updated = await service.update_exclusion(exclusion_id, exclusion.dict(exclude_unset=True))
+    updated = await service.update_exclusion(exclusion_id, exclusion.model_dump(exclude_unset=True))
 
     if not updated:
         raise HTTPException(status_code=404, detail="Exclusion rule not found")

--- a/backend/app/incidents/schema/alert_collection.py
+++ b/backend/app/incidents/schema/alert_collection.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import model_validator
 
 
 class Fields(BaseModel):
@@ -36,24 +36,22 @@ class Source(BaseModel):
     original_alert_id: Optional[str] = Field(None, alias="original_alert_id")
     original_alert_index_name: Optional[str] = Field(None, alias="original_alert_index_name")
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("original_alert_id", "original_alert_index_name", allow_reuse=True, pre=True)
-    def extract_origin_context(cls, v, values, **kwargs):
-        origin_context = values.get("origin_context", "")
-        try:
-            # Assuming the format is always as given in the example
-            parts = origin_context.split(":")
-            if len(parts) == 6:
-                _, _, _, _, index_name, alert_id = parts
-                if kwargs["field"].name == "original_alert_id":
-                    return alert_id
-                elif kwargs["field"].name == "original_alert_index_name":
-                    return index_name
-        except Exception as e:
-            # Consider logging the exception to understand what's going wrong
-            print(f"Error parsing origin_context: {e}")
-        return v
+    @model_validator(mode="before")
+    @classmethod
+    def extract_origin_context(cls, data):
+        if isinstance(data, dict):
+            origin_context = data.get("origin_context", "")
+            try:
+                # Assuming the format is always as given in the example
+                parts = origin_context.split(":")
+                if len(parts) == 6:
+                    _, _, _, _, index_name, alert_id = parts
+                    data["original_alert_id"] = alert_id
+                    data["original_alert_index_name"] = index_name
+            except Exception as e:
+                # Consider logging the exception to understand what's going wrong
+                print(f"Error parsing origin_context: {e}")
+        return data
 
 
 class AlertPayloadItem(BaseModel):

--- a/backend/app/incidents/schema/db_operations.py
+++ b/backend/app/incidents/schema/db_operations.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import HTTPException
 from pydantic import field_validator, BaseModel
-from pydantic import validator
+from pydantic import model_validator
 
 from app.incidents.models import Alert
 from app.incidents.models import AlertContext
@@ -565,9 +565,8 @@ class CaseDownloadDocxRequest(BaseModel):
     template_name: str
     file_name: Optional[str] = "case_report.docx"
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("file_name", pre=True, always=True)
+    @field_validator("file_name", mode="before")
+    @classmethod
     def ensure_docx_extension(cls, v):
         if v and not v.endswith(".docx"):
             return f"{v}.docx"
@@ -665,16 +664,14 @@ class TagAccessSettingsUpdate(BaseModel):
     untagged_alert_behavior: UntaggedAlertBehavior = UntaggedAlertBehavior.VISIBLE_TO_ALL
     default_tag_id: Optional[int] = None
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("default_tag_id")
-    def validate_default_tag(cls, v, values):
-        if values.get("untagged_alert_behavior") == UntaggedAlertBehavior.DEFAULT_TAG and v is None:
+    @model_validator(mode="after")
+    def validate_default_tag(self):
+        if self.untagged_alert_behavior == UntaggedAlertBehavior.DEFAULT_TAG and self.default_tag_id is None:
             raise HTTPException(
                 status_code=400,
                 detail="default_tag_id is required when untagged_alert_behavior is 'default_tag'",
             )
-        return v
+        return self
 
 
 class TagAccessSettingsItem(BaseModel):

--- a/backend/app/incidents/schema/incident_alert.py
+++ b/backend/app/incidents/schema/incident_alert.py
@@ -110,7 +110,7 @@ class GenericSourceModel(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class GenericAlertModel(BaseModel):

--- a/backend/app/incidents/services/db_operations.py
+++ b/backend/app/incidents/services/db_operations.py
@@ -744,7 +744,7 @@ async def put_customer_ai_trigger(notification: PutNotification, session: AsyncS
     )
     existing_notification = result.scalars().first()
     if existing_notification is None:
-        new_notification = AIAnalystTriggerEnabled(**notification.dict())
+        new_notification = AIAnalystTriggerEnabled(**notification.model_dump())
         session.add(new_notification)
     else:
         existing_notification.customer_code = notification.customer_code
@@ -763,7 +763,7 @@ async def put_customer_notification(notification: PutNotification, session: Asyn
     result = await session.execute(select(Notification).where(Notification.customer_code == notification.customer_code))
     existing_notification = result.scalars().first()
     if existing_notification is None:
-        new_notification = Notification(**notification.dict())
+        new_notification = Notification(**notification.model_dump())
         session.add(new_notification)
     else:
         existing_notification.customer_code = notification.customer_code
@@ -982,7 +982,7 @@ async def delete_customer_code_name(source: str, customer_code_name: str, sessio
 
 
 async def create_alert(alert: AlertCreate, db: AsyncSession) -> Alert:
-    db_alert = Alert(**alert.dict())
+    db_alert = Alert(**alert.model_dump())
     db.add(db_alert)
     try:
         await db.flush()
@@ -1104,7 +1104,7 @@ async def create_comment(comment: CommentCreate, db: AsyncSession) -> Comment:
         raise HTTPException(status_code=404, detail="Alert not found")
 
     # Create comment with automatic timestamp if not provided
-    comment_data = comment.dict()
+    comment_data = comment.model_dump()
     if comment_data.get("created_at") is None:
         comment_data["created_at"] = datetime.utcnow()
 
@@ -1146,7 +1146,7 @@ async def create_case_comment(comment: CaseCommentCreate, db: AsyncSession) -> C
         raise HTTPException(status_code=404, detail="Case not found")
 
     # Create comment with automatic timestamp if not provided
-    comment_data = comment.dict()
+    comment_data = comment.model_dump()
     if comment_data.get("created_at") is None:
         comment_data["created_at"] = datetime.utcnow()
 
@@ -1193,7 +1193,7 @@ async def create_asset(asset: AssetCreate, db: AsyncSession) -> Asset:
     if not alert_context:
         raise HTTPException(status_code=404, detail="Alert context not found")
 
-    db_asset = Asset(**asset.dict())
+    db_asset = Asset(**asset.model_dump())
     db.add(db_asset)
     try:
         await db.commit()
@@ -1246,7 +1246,7 @@ async def delete_alert_ioc(ioc: AlertIoCDelete, db: AsyncSession) -> AlertToIoC:
 
 async def create_alert_tag(alert_tag: AlertTagCreate, db: AsyncSession) -> AlertTag:
     # Create the AlertTag instance
-    db_alert_tag = AlertTag(**alert_tag.dict())
+    db_alert_tag = AlertTag(**alert_tag.model_dump())
     db.add(db_alert_tag)
     await db.flush()
 
@@ -1301,7 +1301,7 @@ async def delete_alert_tag(alert_id: int, tag_id: int, db: AsyncSession):
 
 
 async def create_alert_context(alert_context: AlertContextCreate, db: AsyncSession) -> AlertContext:
-    db_alert_context = AlertContext(**alert_context.dict())
+    db_alert_context = AlertContext(**alert_context.model_dump())
     db.add(db_alert_context)
     try:
         await db.flush()
@@ -1432,7 +1432,7 @@ async def create_case(
     has no source hint to pick from. Analysts can apply a template later
     via ``POST /case/{id}/apply-template/{template_id}``.
     """
-    db_case = Case(**case.dict())
+    db_case = Case(**case.model_dump())
     db.add(db_case)
     try:
         await db.flush()
@@ -1538,7 +1538,7 @@ async def create_case_alert_link(case_alert_link: CaseAlertLinkCreate, db: Async
     if not alert:
         raise HTTPException(status_code=404, detail="Alert not found")
 
-    db_case_alert_link = CaseAlertLink(**case_alert_link.dict())
+    db_case_alert_link = CaseAlertLink(**case_alert_link.model_dump())
     db.add(db_case_alert_link)
     try:
         await db.commit()

--- a/backend/app/incidents/services/velo_sigma.py
+++ b/backend/app/incidents/services/velo_sigma.py
@@ -342,7 +342,7 @@ class VeloSigmaExclusionService:
 
     async def create_exclusion(self, exclusion: VeloSigmaExclusionCreate) -> VeloSigmaExclusion:
         """Create a new exclusion rule."""
-        exclusion_data = exclusion.dict()
+        exclusion_data = exclusion.model_dump()
 
         # Ensure created_by is set to something non-null
         if not exclusion_data.get("created_by"):
@@ -453,7 +453,7 @@ class VelociraptorSigmaService:
             if hasattr(parsed_event, "EventData"):
                 # Try to convert EventData to dict for context
                 try:
-                    event_context = parsed_event.EventData.dict()
+                    event_context = parsed_event.EventData.model_dump()
                 except AttributeError:
                     # If not directly convertible, extract key attributes
                     event_context = {

--- a/backend/app/integrations/alert_creation_settings/routes/alert_creation_settings.py
+++ b/backend/app/integrations/alert_creation_settings/routes/alert_creation_settings.py
@@ -94,7 +94,7 @@ async def create_alert_creation_settings(
     Returns:
         AlertCreationSettings: The created alert creation setting.
     """
-    logger.info(f"alert_creation_settings: {alert_creation_settings.dict()}")
+    logger.info(f"alert_creation_settings: {alert_creation_settings.model_dump()}")
 
     result = await session.execute(
         select(AlertCreationSettings).where(
@@ -113,7 +113,7 @@ async def create_alert_creation_settings(
         )
 
     alert_creation_settings_db = AlertCreationSettings(
-        **alert_creation_settings.dict(exclude={"event_orders"}),
+        **alert_creation_settings.model_dump(exclude={"event_orders"}),
     )
 
     if alert_creation_settings.event_orders is not None:
@@ -125,7 +125,7 @@ async def create_alert_creation_settings(
             session.add(event_order_db)
             for event_config in event_order.event_configs:
                 event_config_db = AlertCreationEventConfig(
-                    **event_config.dict(),
+                    **event_config.model_dump(),
                     event_order=event_order_db,
                 )
                 session.add(event_config_db)
@@ -226,7 +226,7 @@ async def add_event_order(
     session.add(event_order_db)
     for event_config in event_order.event_configs:
         event_config_db = AlertCreationEventConfig(
-            **event_config.dict(),
+            **event_config.model_dump(),
             event_order=event_order_db,
         )
         session.add(event_config_db)
@@ -293,7 +293,7 @@ async def update_event_orders(
             # If it does, add the new EventConfig instances to it
             for event_config in event_order.event_configs:
                 event_config_db = AlertCreationEventConfig(
-                    **event_config.dict(),
+                    **event_config.model_dump(),
                     event_order=existing_order,
                 )
                 session.add(event_config_db)

--- a/backend/app/integrations/alert_escalation/schema/escalate_alert.py
+++ b/backend/app/integrations/alert_escalation/schema/escalate_alert.py
@@ -75,7 +75,7 @@ class GenericSourceModel(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class GenericAlertModel(BaseModel):
@@ -145,7 +145,7 @@ class IrisAsset(BaseModel):
     )
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class IrisIoc(BaseModel):
@@ -163,7 +163,7 @@ class IrisIoc(BaseModel):
     ioc_type_id: int = Field(20, description="Type ID of the IoC", examples=[20])
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class IrisAlertContext(BaseModel):
@@ -215,4 +215,4 @@ class IrisAlertPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)

--- a/backend/app/integrations/bitdefender/services/provision.py
+++ b/backend/app/integrations/bitdefender/services/provision.py
@@ -172,11 +172,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -309,7 +309,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/carbonblack/services/provision.py
+++ b/backend/app/integrations/carbonblack/services/provision.py
@@ -87,11 +87,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -168,11 +168,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -261,7 +261,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/cato/services/provision.py
+++ b/backend/app/integrations/cato/services/provision.py
@@ -87,11 +87,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -168,11 +168,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -261,7 +261,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/copilot_action/routes/copilot_action.py
+++ b/backend/app/integrations/copilot_action/routes/copilot_action.py
@@ -490,19 +490,19 @@ async def invoke_action(body: InvokeCopilotActionBody, session: AsyncSession = D
         # Return structured response
         if len(failed_agents) == 0:
             return InvokeCopilotActionResponse(
-                responses=[response.dict() for response in responses],
+                responses=[response.model_dump() for response in responses],
                 message=f"Successfully invoked action on all {len(successful_agents)} agent(s). Check the appropriate Grafana dashboard for results.",
                 success=True,
             )
         elif len(successful_agents) == 0:
             return InvokeCopilotActionResponse(
-                responses=[response.dict() for response in responses],
+                responses=[response.model_dump() for response in responses],
                 message=f"Failed to invoke action on all {len(failed_agents)} agent(s)",
                 success=False,
             )
         else:
             return InvokeCopilotActionResponse(
-                responses=[response.dict() for response in responses],
+                responses=[response.model_dump() for response in responses],
                 message=f"Partially successful: {len(successful_agents)} succeeded, {len(failed_agents)} failed",
                 success=True,  # Consider partial success as success
             )

--- a/backend/app/integrations/copilot_action/schema/copilot_action.py
+++ b/backend/app/integrations/copilot_action/schema/copilot_action.py
@@ -8,7 +8,7 @@ from typing import Union
 
 from pydantic import field_validator, BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import model_validator
 
 
 class Technology(str, Enum):
@@ -58,13 +58,11 @@ class ActiveResponseItem(BaseModel):
     category: Optional[str] = None
     tags: Optional[List[str]] = None
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("icon", always=True)
-    def set_icon_default(cls, v, values):
-        if v is None and "technology" in values:
-            return values["technology"].value.lower()
-        return v
+    @model_validator(mode="after")
+    def set_icon_default(self):
+        if self.icon is None and self.technology is not None:
+            self.icon = self.technology.value.lower()
+        return self
 
 
 class InventoryQueryRequest(BaseModel):

--- a/backend/app/integrations/copilot_mcp/routes/copilot_mcp.py
+++ b/backend/app/integrations/copilot_mcp/routes/copilot_mcp.py
@@ -91,7 +91,7 @@ async def get_mcp_server_details(mcp_server: MCPServerType) -> dict:
         total_questions = len(ExampleQuestionsService.get_example_questions(mcp_server))
 
         return {
-            "server": server_info.dict(),
+            "server": server_info.model_dump(),
             "available_categories": categories,
             "total_example_questions": total_questions,
             "message": f"Successfully retrieved details for {mcp_server.value}",

--- a/backend/app/integrations/copilot_mcp/services/copilot_mcp.py
+++ b/backend/app/integrations/copilot_mcp/services/copilot_mcp.py
@@ -118,7 +118,7 @@ class MCPService:
             is_cloud = cls.is_cloud_service(data.mcp_server)
 
             logger.info(f"Sending MCP query to {data.mcp_server.value} ({'cloud' if is_cloud else 'local'}) at {full_url}")
-            logger.debug(f"Query data: {data.dict()}")
+            logger.debug(f"Query data: {data.model_dump()}")
 
             # Set different timeout for cloud vs local services
             timeout = 300 if is_cloud else 300
@@ -136,7 +136,7 @@ class MCPService:
             async with httpx.AsyncClient() as client:
                 response = await client.post(
                     full_url,
-                    json=data.dict(),
+                    json=data.model_dump(),
                     headers=headers,
                     timeout=timeout,
                 )

--- a/backend/app/integrations/copilot_searches/routes/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/routes/copilot_searches.py
@@ -99,7 +99,7 @@ async def check_if_event_definition_exists(event_definition_title: str) -> bool:
         )
 
     event_definitions_response = GraylogEventDefinitionsResponse(
-        **event_definitions_response.dict(),
+        **event_definitions_response.model_dump(),
     )
 
     existing_titles = [ed.title for ed in event_definitions_response.event_definitions]
@@ -623,7 +623,7 @@ async def check_graylog_provisioning_status(request: RulesByIdsRequest):
     try:
         ed_resp = await get_all_event_definitions()
         if ed_resp.success:
-            ed = GraylogEventDefinitionsResponse(**ed_resp.dict())
+            ed = GraylogEventDefinitionsResponse(**ed_resp.model_dump())
             existing_titles = {e.title for e in ed.event_definitions}
         else:
             warning = "Failed to read event definitions from Graylog"
@@ -673,7 +673,7 @@ async def bulk_provision_graylog_alerts(request: BulkProvisionGraylogAlertReques
     try:
         ed_resp = await get_all_event_definitions()
         if ed_resp.success:
-            ed = GraylogEventDefinitionsResponse(**ed_resp.dict())
+            ed = GraylogEventDefinitionsResponse(**ed_resp.model_dump())
             existing_titles = {e.title for e in ed.event_definitions}
     except Exception as e:
         # If we can't pre-fetch the existing list, fall back to skipping the

--- a/backend/app/integrations/crowdstrike/services/provision.py
+++ b/backend/app/integrations/crowdstrike/services/provision.py
@@ -103,11 +103,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -240,7 +240,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/darktrace/services/provision.py
+++ b/backend/app/integrations/darktrace/services/provision.py
@@ -87,11 +87,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -168,11 +168,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -261,7 +261,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/defender_for_endpoint/services/provision.py
+++ b/backend/app/integrations/defender_for_endpoint/services/provision.py
@@ -106,11 +106,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -239,7 +239,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/duo/services/provision.py
+++ b/backend/app/integrations/duo/services/provision.py
@@ -87,11 +87,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -168,11 +168,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -261,7 +261,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/github_audit/routes/github_audit.py
+++ b/backend/app/integrations/github_audit/routes/github_audit.py
@@ -189,7 +189,7 @@ async def update_config(
         raise HTTPException(status_code=404, detail="Configuration not found")
 
     # Update fields that were provided
-    update_data = config_update.dict(exclude_unset=True)
+    update_data = config_update.model_dump(exclude_unset=True)
 
     for field, value in update_data.items():
         if value is not None:
@@ -342,8 +342,8 @@ async def run_audit_from_config(
             report.score = audit_response.summary.score
             report.grade = audit_response.summary.grade
 
-        report.full_report = audit_response.dict()
-        report.top_findings = [f.dict() for f in audit_response.top_findings[:20]]
+        report.full_report = audit_response.model_dump()
+        report.top_findings = [f.model_dump() for f in audit_response.top_findings[:20]]
 
         # Update config with last audit info
         config.last_audit_at = end_time
@@ -683,7 +683,7 @@ async def update_exclusion(
     if not exclusion:
         raise HTTPException(status_code=404, detail="Exclusion not found")
 
-    update_data = exclusion_update.dict(exclude_unset=True)
+    update_data = exclusion_update.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         if value is not None:
             setattr(exclusion, field, value)

--- a/backend/app/integrations/huntress/services/provision.py
+++ b/backend/app/integrations/huntress/services/provision.py
@@ -87,11 +87,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -168,11 +168,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -261,7 +261,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/mimecast/services/mimecast.py
+++ b/backend/app/integrations/mimecast/services/mimecast.py
@@ -411,14 +411,14 @@ async def invoke_mimecast_api_ttp_urls(
     """Invoke the Mimecast API call to get TTP URLs."""
     logger.info("Mimecast TTP URL request received")
     request_body = await create_ttp_request_body(mimecast_request)
-    request_dict = request_body.dict(by_alias=True)
+    request_dict = request_body.model_dump(by_alias=True)
     logger.info(f"Request: {request_dict}")
     for item in request_dict["data"]:
         item["from"] = await custom_datetime_format(item["from"])
         item["to"] = await custom_datetime_format(item["to"])
     response = requests.post(
         url=mimecast_request.BaseURL + "/api/ttp/url/get-logs",
-        headers=mimecast_request.headers.dict(by_alias=True),
+        headers=mimecast_request.headers.model_dump(by_alias=True),
         data=str(request_dict),
     )
     return TtpURLResponseBody(**response.json())
@@ -454,7 +454,7 @@ async def get_ttp_urls(
                 customer_code=customer_code,
                 integration="mimecast",
                 version="1.0",
-                **data.dict(by_alias=True),
+                **data.model_dump(by_alias=True),
             )
             await event_shipper(message)
 

--- a/backend/app/integrations/mimecast/services/provision.py
+++ b/backend/app/integrations/mimecast/services/provision.py
@@ -84,11 +84,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -165,11 +165,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -258,7 +258,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/modules/schema/sap_siem.py
+++ b/backend/app/integrations/modules/schema/sap_siem.py
@@ -151,7 +151,7 @@ class CollectSapSiemRequest(BaseModel):
         return values
 
     def to_dict(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class InvokeSapSiemAnalysis(BaseModel):

--- a/backend/app/integrations/modules/services/carbonblack.py
+++ b/backend/app/integrations/modules/services/carbonblack.py
@@ -11,11 +11,11 @@ async def post_to_copilot_carbonblack_module(data: CollectCarbonBlack, license_k
     Args:
         data (CollectHuntress): The data to send to the copilot-huntress-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-carbonblack-module/collect with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-carbonblack-module/collect with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-carbonblack-module/collect",
-            json=data.dict(),
+            json=data.model_dump(),
             # params={"license_key": license_key, "feature_name": "CARBONBLACK"},
             timeout=120,
         )

--- a/backend/app/integrations/modules/services/cato.py
+++ b/backend/app/integrations/modules/services/cato.py
@@ -11,11 +11,11 @@ async def post_to_copilot_cato_module(data: CollectCato, license_key: str = None
     Args:
         data (CollectCato): The data to send to the copilot-cato-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-cato-module/collect with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-cato-module/collect with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-cato-module/collect",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
     return None

--- a/backend/app/integrations/modules/services/darktrace.py
+++ b/backend/app/integrations/modules/services/darktrace.py
@@ -11,11 +11,11 @@ async def post_to_copilot_darktrace_module(data: CollectDarktrace):
     Args:
         data (CollectDarktrace): The data to send to the copilot-darktrace-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-darktrace-module/all_logs with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-darktrace-module/all_logs with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-darktrace-module/all_logs",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
     return None

--- a/backend/app/integrations/modules/services/duo.py
+++ b/backend/app/integrations/modules/services/duo.py
@@ -11,11 +11,11 @@ async def post_to_copilot_duo_module(data: CollectDuo):
     Args:
         data (CollectDuo): The data to send to the copilot-duo-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-duo-module/auth with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-duo-module/auth with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-duo-module/auth",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
     return None

--- a/backend/app/integrations/modules/services/huntress.py
+++ b/backend/app/integrations/modules/services/huntress.py
@@ -11,11 +11,11 @@ async def post_to_copilot_huntress_module(data: CollectHuntress, license_key: st
     Args:
         data (CollectHuntress): The data to send to the copilot-huntress-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-huntress-module/collect with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-huntress-module/collect with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-huntress-module/collect",
-            json=data.dict(),
+            json=data.model_dump(),
             # params={"license_key": license_key, "feature_name": "HUNTRESS"},
             timeout=120,
         )

--- a/backend/app/integrations/modules/services/mimecast.py
+++ b/backend/app/integrations/modules/services/mimecast.py
@@ -11,11 +11,11 @@ async def post_to_copilot_mimecast_module(data: CollectMimecast, license_key: st
     Args:
         data (CollectMimecast): The data to send to the copilot-mimecast-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-huntress-module/collect with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-huntress-module/collect with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         await client.post(
             "http://copilot-mimecast-module/collect",
-            json=data.dict(),
+            json=data.model_dump(),
             # params={"license_key": license_key, "feature_name": "MIMECAST"},
             timeout=120,
         )

--- a/backend/app/integrations/modules/services/sap_siem/collect.py
+++ b/backend/app/integrations/modules/services/sap_siem/collect.py
@@ -12,7 +12,7 @@ async def post_to_copilot_sap_module_collect(data: CollectSapSiemRequest):
     Args:
         data (CollectHuntress): The data to send to the copilot-sap-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-sap-module/collect with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-sap-module/collect with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
@@ -34,13 +34,13 @@ async def post_to_copilot_sap_module_sap_siem_successful_user_login_with_differe
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_ip with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_ip with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/successful_user_login_with_different_ip",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -57,13 +57,13 @@ async def post_to_copilot_sap_module_same_user_failed_login_from_different_ip(da
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_ip with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_ip with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_ip",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -80,13 +80,13 @@ async def post_to_copilot_sap_module_same_user_failed_login_from_different_geo_l
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_geo_location with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_geo_location with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/same_user_failed_login_from_different_geo_location",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -103,13 +103,13 @@ async def post_to_copilot_sap_module_same_user_successful_login_from_different_g
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_successful_login_from_different_geo_location with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/same_user_successful_login_from_different_geo_location with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/same_user_successful_login_from_different_geo_location",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -126,13 +126,13 @@ async def post_to_copilot_sap_module_brute_force_failed_logins_multiple_ips(data
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/brute_force_failed_logins_multiple_ips with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/brute_force_failed_logins_multiple_ips with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/brute_force_failed_logins_multiple_ips",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -148,12 +148,12 @@ async def post_to_copilot_sap_module_brute_force_failed_logins_same_ip(data: Inv
     Args:
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-sap-module/sap-siem/brute_force_failed_logins_same_ip with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-sap-module/sap-siem/brute_force_failed_logins_same_ip with data: {data.model_dump()}")
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/brute_force_failed_logins_same_ip",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")
@@ -170,13 +170,13 @@ async def post_to_copilot_sap_module_successful_login_after_multiple_failed_logi
         data (InvokeSapSiemAnalysis): The data to send to the copilot-sap-module Docker container.
     """
     logger.info(
-        f"Sending POST request to http://copilot-sap-module/sap-siem/successful_login_after_multiple_failed_logins with data: {data.dict()}",
+        f"Sending POST request to http://copilot-sap-module/sap-siem/successful_login_after_multiple_failed_logins with data: {data.model_dump()}",
     )
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
                 "http://copilot-sap-module/sap-siem/successful_login_after_multiple_failed_logins",
-                json=data.dict(),
+                json=data.model_dump(),
                 timeout=120,
             )
             logger.info(f"Response from copilot-sap-module: {response.json()}")

--- a/backend/app/integrations/monitoring_alert/routes/provision.py
+++ b/backend/app/integrations/monitoring_alert/routes/provision.py
@@ -656,7 +656,7 @@ async def check_if_event_definition_exists(event_definition: str) -> bool:
             detail="Failed to collect event definitions",
         )
     event_definitions_response = GraylogEventDefinitionsResponse(
-        **event_definitions_response.dict(),
+        **event_definitions_response.model_dump(),
     )
     logger.info(
         f"Event definitions collected: {event_definitions_response.event_definitions}",

--- a/backend/app/integrations/monitoring_alert/services/provision.py
+++ b/backend/app/integrations/monitoring_alert/services/provision.py
@@ -89,7 +89,7 @@ async def check_if_url_whitelist_entry_exists(url: str) -> bool:
             detail="Failed to collect url whitelist entries",
         )
     url_whitelist_entries_response = UrlWhitelistEntryResponse(
-        **url_whitelist_entries_response.dict(),
+        **url_whitelist_entries_response.model_dump(),
     )
     logger.info(
         f"Url whitelist entries collected: {url_whitelist_entries_response.url_whitelist_entries}",
@@ -117,7 +117,7 @@ async def get_notification_id(notification_title: str) -> Optional[str]:
             detail="Failed to collect event notifications",
         )
     event_notifications_response = GraylogEventNotificationsResponse(
-        **event_notifications_response.dict(),
+        **event_notifications_response.model_dump(),
     )
     logger.info(
         f"Event notifications collected: {event_notifications_response.event_notifications}",
@@ -144,7 +144,7 @@ async def build_url_whitelisted_entries(
             detail="Failed to collect url whitelist entries",
         )
     url_whitelist_entries_response = UrlWhitelistEntryResponse(
-        **url_whitelist_entries_response.dict(),
+        **url_whitelist_entries_response.model_dump(),
     )
     logger.info(f"Url whitelist entries collected: {url_whitelist_entries_response}")
     url_whitelist_entries = url_whitelist_entries_response.url_whitelist_entries.entries
@@ -167,10 +167,10 @@ async def provision_webhook_url_whitelist(
     Returns:
         bool: True if the webhook URL was provisioned successfully, False otherwise.
     """
-    logger.info(f"Provisioning URL Whitelist: {whitelist_url_model.dict()}")
+    logger.info(f"Provisioning URL Whitelist: {whitelist_url_model.model_dump()}")
     response = await send_put_request(
         endpoint="/api/system/urlwhitelist",
-        data=whitelist_url_model.dict(),
+        data=whitelist_url_model.model_dump(),
     )
     logger.info(f"URL Whitelist provisioned: {response}")
     if response["success"]:
@@ -195,7 +195,7 @@ async def check_if_event_notification_exists(event_notification: str) -> bool:
             detail="Failed to collect event notifications",
         )
     event_notifications_response = GraylogEventNotificationsResponse(
-        **event_notifications_response.dict(),
+        **event_notifications_response.model_dump(),
     )
     logger.info(
         f"Event notifications collected: {event_notifications_response.event_notifications}",
@@ -221,7 +221,7 @@ async def provision_webhook(
     """
     response = await send_post_request(
         endpoint="/api/events/notifications",
-        data=webhook_model.dict(),
+        data=webhook_model.model_dump(),
     )
     if response["success"]:
         logger.info(f"response: {response}")
@@ -251,7 +251,7 @@ async def provision_alert_definition(
 
     response = await send_post_request(
         endpoint="/api/events/definitions",
-        data=alert_definition_model.dict(),
+        data=alert_definition_model.model_dump(),
     )
     logger.info(f"Graylog alert definition provisioned response: {response}")
     if response["success"]:
@@ -270,7 +270,7 @@ async def provision_wazuh_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_wazuh_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_wazuh_monitoring_alert with request: {request.model_dump()}",
     )
     # ! TODO Commenting out for now since the plan is to pull from gl-events ! #
     # notification_exists = await check_if_event_notification_exists("SEND TO COPILOT")
@@ -400,7 +400,7 @@ async def provision_suricata_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_suricata_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_suricata_monitoring_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -493,7 +493,7 @@ async def provision_office365_exchange_online_alert(
     """
     #
     logger.info(
-        f"Invoking provision_office365_exchange_online_alert with request: {request.dict()}",
+        f"Invoking provision_office365_exchange_online_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -586,7 +586,7 @@ async def provision_office365_threat_intel_alert(
     """
     #
     logger.info(
-        f"Invoking provision_office365_threat_intel_alert with request: {request.dict()}",
+        f"Invoking provision_office365_threat_intel_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -679,7 +679,7 @@ async def provision_crowdstrike_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_crowdstrike_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_crowdstrike_monitoring_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -772,7 +772,7 @@ async def provision_fortinet_system_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_fortinet_system_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_fortinet_system_monitoring_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -865,7 +865,7 @@ async def provision_fortinet_utm_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_fortinet_utm_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_fortinet_utm_monitoring_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -955,7 +955,7 @@ async def provision_fortinet_fortiweb_path_traversal_vulnerability_exploitation_
     """
     logger.info(
         "Invoking provision_fortinet_fortiweb_path_traversal_vulnerability_exploitation_attempt_monitoring_alert "
-        f"with request: {request.dict()}",
+        f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1013,7 +1013,7 @@ async def provision_fortinet_wids_wireless_valid_client_misassociation_detected_
     """
     logger.info(
         "Invoking provision_fortinet_wids_wireless_valid_client_misassociation_detected_monitoring_alert "
-        f"with request: {request.dict()}",
+        f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1070,7 +1070,7 @@ async def provision_fortinet_wids_wireless_management_flooding_detected_monitori
     Provisions Fortinet WIDS Wireless Management Flooding Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_management_flooding_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_management_flooding_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1127,7 +1127,7 @@ async def provision_fortinet_wids_wireless_eapol_packet_flooding_detected_monito
     Provisions Fortinet WIDS Wireless EAPOL Packet Flooding Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_eapol_packet_flooding_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_eapol_packet_flooding_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1184,7 +1184,7 @@ async def provision_fortinet_wids_rogue_access_point_detected_monitoring_alert(
     Provisions Fortinet WIDS Rogue Access Point Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_rogue_access_point_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_rogue_access_point_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1241,7 +1241,7 @@ async def provision_fortinet_wids_wireless_long_duration_attack_detected_monitor
     Provisions Fortinet WIDS Wireless Long Duration Attack Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_long_duration_attack_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_long_duration_attack_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1298,7 +1298,7 @@ async def provision_fortinet_firewall_virus_detected_monitoring_alert(
     Provisions Fortinet Firewall Virus Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_firewall_virus_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_firewall_virus_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1355,7 +1355,7 @@ async def provision_fortinet_wids_wireless_threat_detected_monitoring_alert(
     Provisions Fortinet WIDS Wireless Threat Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_threat_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_threat_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1412,7 +1412,7 @@ async def provision_fortinet_wids_wireless_invalid_mac_oui_detected_monitoring_a
     Provisions Fortinet WIDS Wireless Invalid MAC OUI Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_invalid_mac_oui_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_invalid_mac_oui_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1469,7 +1469,7 @@ async def provision_fortinet_wids_wireless_asleap_attack_detected_monitoring_ale
     Provisions Fortinet WIDS Wireless Asleap Attack Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_asleap_attack_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_asleap_attack_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1526,7 +1526,7 @@ async def provision_fortinet_ips_malicious_url_detected_monitoring_alert(
     Provisions Fortinet IPS Malicious URL Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_ips_malicious_url_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_ips_malicious_url_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1583,7 +1583,7 @@ async def provision_fortinet_ips_botnet_activity_detected_monitoring_alert(
     Provisions Fortinet IPS Botnet Activity Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_ips_botnet_activity_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_ips_botnet_activity_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1640,7 +1640,7 @@ async def provision_fortinet_admin_user_created_from_public_ip_monitoring_alert(
     Provisions Fortinet Admin User Created from Public IP monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_admin_user_created_from_public_ip_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_admin_user_created_from_public_ip_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1698,7 +1698,7 @@ async def provision_fortinet_suspicious_config_file_access_from_external_network
     """
     logger.info(
         "Invoking provision_fortinet_suspicious_config_file_access_from_external_network_monitoring_alert "
-        f"with request: {request.dict()}",
+        f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1755,7 +1755,7 @@ async def provision_fortinet_wids_wireless_weak_encryption_detected_monitoring_a
     Provisions Fortinet WIDS Wireless Weak Encryption Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_wids_wireless_weak_encryption_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_wids_wireless_weak_encryption_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1812,7 +1812,7 @@ async def provision_fortinet_suspicious_super_admin_login_detected_monitoring_al
     Provisions Fortinet Suspicious Super Admin Login Detected monitoring alert.
     """
     logger.info(
-        "Invoking provision_fortinet_suspicious_super_admin_login_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_fortinet_suspicious_super_admin_login_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1874,7 +1874,7 @@ async def provision_paloalto_monitoring_alert(
     """
     #
     logger.info(
-        f"Invoking provision_paloalto_monitoring_alert with request: {request.dict()}",
+        f"Invoking provision_paloalto_monitoring_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -1963,7 +1963,7 @@ async def provision_paloalto_firewall_traffic_to_phishing_url_allowed_monitoring
     Provisions PaloAlto Firewall Traffic to Phishing URL Allowed monitoring alert.
     """
     logger.info(
-        "Invoking provision_paloalto_firewall_traffic_to_phishing_url_allowed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_paloalto_firewall_traffic_to_phishing_url_allowed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2035,7 +2035,7 @@ async def provision_paloalto_firewall_traffic_to_malicious_url_allowed_monitorin
     Provisions PaloAlto Firewall Traffic to Malicious URL Allowed monitoring alert.
     """
     logger.info(
-        "Invoking provision_paloalto_firewall_traffic_to_malicious_url_allowed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_paloalto_firewall_traffic_to_malicious_url_allowed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2108,7 +2108,7 @@ async def provision_paloalto_firewall_virus_allowed_monitoring_alert(
     Provisions PaloAlto Firewall Virus Allowed monitoring alert.
     """
     logger.info(
-        "Invoking provision_paloalto_firewall_virus_allowed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_paloalto_firewall_virus_allowed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2179,7 +2179,7 @@ async def provision_paloalto_firewall_tor_traffic_allowed_monitoring_alert(
     Provisions PaloAlto Firewall TOR Traffic Allowed monitoring alert.
     """
     logger.info(
-        "Invoking provision_paloalto_firewall_tor_traffic_allowed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_paloalto_firewall_tor_traffic_allowed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2247,7 +2247,7 @@ async def provision_paloalto_firewall_medium_severity_correlation_event_detected
     """
     logger.info(
         "Invoking provision_paloalto_firewall_medium_severity_correlation_event_detected_monitoring_alert "
-        f"with request: {request.dict()}",
+        f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2318,7 +2318,7 @@ async def provision_sentinelone_new_active_threat_malicious_detected_monitoring_
     Provisions SentinelOne: New Active Threat Malicious Detected.
     """
     logger.info(
-        "Invoking provision_sentinelone_new_active_threat_malicious_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_new_active_threat_malicious_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2375,7 +2375,7 @@ async def provision_sentinelone_new_active_threat_suspicious_detected_monitoring
     Provisions SentinelOne: New Active Threat Suspicious Detected.
     """
     logger.info(
-        "Invoking provision_sentinelone_new_active_threat_suspicious_detected_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_new_active_threat_suspicious_detected_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2432,7 +2432,7 @@ async def provision_sentinelone_new_mitigation_kill_performed_successfully_monit
     Provisions SentinelOne: New Mitigation, Kill performed successfully.
     """
     logger.info(
-        "Invoking provision_sentinelone_new_mitigation_kill_performed_successfully_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_new_mitigation_kill_performed_successfully_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2490,7 +2490,7 @@ async def provision_sentinelone_new_mitigation_quarantine_performed_successfully
     """
     logger.info(
         "Invoking provision_sentinelone_new_mitigation_quarantine_performed_successfully_monitoring_alert "
-        f"with request: {request.dict()}",
+        f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2547,7 +2547,7 @@ async def provision_sentinelone_new_exclusion_was_added_or_modified_by_user_moni
     Provisions SentinelOne: New Exclusion was added/modified by user.
     """
     logger.info(
-        "Invoking provision_sentinelone_new_exclusion_was_added_or_modified_by_user_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_new_exclusion_was_added_or_modified_by_user_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2604,7 +2604,7 @@ async def provision_sentinelone_new_path_exclusion_added_monitoring_alert(
     Provisions SentinelOne: New Path Exclusion added.
     """
     logger.info(
-        "Invoking provision_sentinelone_new_path_exclusion_added_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_new_path_exclusion_added_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2661,7 +2661,7 @@ async def provision_sentinelone_analyst_verdict_changed_to_true_positive_monitor
     Provisions SentinelOne: Analyst verdict changed to True Positive.
     """
     logger.info(
-        "Invoking provision_sentinelone_analyst_verdict_changed_to_true_positive_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_analyst_verdict_changed_to_true_positive_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2718,7 +2718,7 @@ async def provision_sentinelone_analyst_verdict_changed_to_false_positive_monito
     Provisions SentinelOne: Analyst verdict changed to False Positive.
     """
     logger.info(
-        "Invoking provision_sentinelone_analyst_verdict_changed_to_false_positive_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_sentinelone_analyst_verdict_changed_to_false_positive_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2776,7 +2776,7 @@ async def provision_mimecast_compromised_site_url_accessed_monitoring_alert(
     Provisions Mimecast Compromised Site URL Accessed monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_compromised_site_url_accessed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_compromised_site_url_accessed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2833,7 +2833,7 @@ async def provision_mimecast_executable_file_attachment_delivered_monitoring_ale
     Provisions Mimecast Executable File Attachment Delivered monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_executable_file_attachment_delivered_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_executable_file_attachment_delivered_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2890,7 +2890,7 @@ async def provision_mimecast_malicious_email_attachment_delivered_monitoring_ale
     Provisions Mimecast Malicious Email Attachment Delivered monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_malicious_email_attachment_delivered_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_malicious_email_attachment_delivered_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -2947,7 +2947,7 @@ async def provision_mimecast_malicious_email_link_accessed_monitoring_alert(
     Provisions Mimecast Malicious Email Link Accessed monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_malicious_email_link_accessed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_malicious_email_link_accessed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3004,7 +3004,7 @@ async def provision_mimecast_p2p_file_sharing_url_accessed_monitoring_alert(
     Provisions Mimecast P2P File Sharing URL Accessed monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_p2p_file_sharing_url_accessed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_p2p_file_sharing_url_accessed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3061,7 +3061,7 @@ async def provision_mimecast_anonymizer_url_accessed_monitoring_alert(
     Provisions Mimecast Anonymizer URL Accessed monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_anonymizer_url_accessed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_anonymizer_url_accessed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3118,7 +3118,7 @@ async def provision_mimecast_impersonation_email_delivered_monitoring_alert(
     Provisions Mimecast Impersonation Email Delivered monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_impersonation_email_delivered_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_impersonation_email_delivered_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3175,7 +3175,7 @@ async def provision_mimecast_malicious_outbound_email_monitoring_alert(
     Provisions Mimecast Malicious Outbound Email monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_malicious_outbound_email_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_malicious_outbound_email_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3232,7 +3232,7 @@ async def provision_mimecast_malicious_rtf_attachment_delivered_monitoring_alert
     Provisions Mimecast Malicious RTF Attachment Delivered monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_malicious_rtf_attachment_delivered_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_malicious_rtf_attachment_delivered_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3289,7 +3289,7 @@ async def provision_mimecast_phishing_email_delivered_monitoring_alert(
     Provisions Mimecast Phishing Email Delivered monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_phishing_email_delivered_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_phishing_email_delivered_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3346,7 +3346,7 @@ async def provision_mimecast_source_code_file_in_email_attachment_monitoring_ale
     Provisions Mimecast Source Code File In Email Attachment monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_source_code_file_in_email_attachment_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_source_code_file_in_email_attachment_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3403,7 +3403,7 @@ async def provision_mimecast_url_with_dangerous_file_type_accessed_monitoring_al
     Provisions Mimecast URL with Dangerous File Type Accessed monitoring alert.
     """
     logger.info(
-        "Invoking provision_mimecast_url_with_dangerous_file_type_accessed_monitoring_alert " f"with request: {request.dict()}",
+        "Invoking provision_mimecast_url_with_dangerous_file_type_accessed_monitoring_alert " f"with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(
@@ -3462,7 +3462,7 @@ async def provision_custom_alert(request: CustomMonitoringAlertProvisionModel) -
     """
     #
     logger.info(
-        f"Invoking provision_custom_alert with request: {request.dict()}",
+        f"Invoking provision_custom_alert with request: {request.model_dump()}",
     )
     await provision_alert_definition(
         GraylogAlertProvisionModel(

--- a/backend/app/integrations/nuclei/services/nuclei.py
+++ b/backend/app/integrations/nuclei/services/nuclei.py
@@ -73,12 +73,12 @@ async def post_to_copilot_nuclei_module(data: NucleiScanRequest) -> NucleiScanRe
     Args:
         data (NucleiScanRequest): The data to send to the copilot-nuclei-module Docker container.
     """
-    logger.info(f"Sending POST request to http://copilot-nuclei-module/scan with data: {data.dict()}")
+    logger.info(f"Sending POST request to http://copilot-nuclei-module/scan with data: {data.model_dump()}")
     # raise HTTPException(status_code=501, detail="Not Implemented Yet")
     async with httpx.AsyncClient() as client:
         data = await client.post(
             "http://copilot-nuclei-module/scan",
-            json=data.dict(),
+            json=data.model_dump(),
             timeout=120,
         )
     return NucleiScanResponse(**data.json())

--- a/backend/app/integrations/office365/services/provision.py
+++ b/backend/app/integrations/office365/services/provision.py
@@ -416,11 +416,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -512,11 +512,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -854,7 +854,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/routes.py
+++ b/backend/app/integrations/routes.py
@@ -807,7 +807,7 @@ async def create_integration_meta(
     )
     try:
         new_customer_integration_meta = CustomerIntegrationsMeta(
-            **customer_integration_meta.dict(),
+            **customer_integration_meta.model_dump(),
         )
         session.add(new_customer_integration_meta)
         await session.commit()
@@ -1218,7 +1218,7 @@ async def get_meta_auto(
         return {
             "success": True,
             "message": f"Successfully retrieved metadata for {customer_code}/{integration_name}",
-            "data": meta_record.dict() if hasattr(meta_record, "dict") else meta_record.__dict__,
+            "data": meta_record.model_dump() if hasattr(meta_record, "dict") else meta_record.__dict__,
             "table_type": "network_connector" if is_network_integration else "integration",
         }
 

--- a/backend/app/integrations/sap_siem/schema/sap_siem.py
+++ b/backend/app/integrations/sap_siem/schema/sap_siem.py
@@ -338,7 +338,7 @@ class IrisCasePayload(BaseModel):
     )
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class ModificationHistoryEntry(BaseModel):
@@ -408,4 +408,4 @@ class AddAssetModel(BaseModel):
     )
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)

--- a/backend/app/integrations/sap_siem/services/provision.py
+++ b/backend/app/integrations/sap_siem/services/provision.py
@@ -84,11 +84,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -165,11 +165,11 @@ async def send_event_stream_creation_request(
     Returns:
         StreamCreationResponse: The response containing the created event stream.
     """
-    json_event_stream = json.dumps(event_stream.dict())
+    json_event_stream = json.dumps(event_stream.model_dump())
     logger.info(f"json_event_stream set: {json_event_stream}")
     response_json = await send_post_request(
         endpoint="/api/streams",
-        data=event_stream.dict(),
+        data=event_stream.model_dump(),
     )
     return StreamCreationResponse(**response_json)
 
@@ -258,7 +258,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/integrations/utils/schema.py
+++ b/backend/app/integrations/utils/schema.py
@@ -114,7 +114,7 @@ class WazuhSocketPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 ############################### ! Sublime ! ###############################
@@ -154,7 +154,7 @@ class WazuhSublimeSocketPayload(WazuhSocketPayload):
         # If `display_name` is an empty string, set it to `None`.
         if self.display_name == "":
             self.display_name = None
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 ######### ! SEND TO SHUFFLE PAYLOAD ! #########
@@ -192,7 +192,7 @@ class ShufflePayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 ######### ! SEND TO EVENT SHIPPER ! #########
@@ -210,7 +210,7 @@ class EventShipperPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     def to_dict(self):
-        return self.dict(exclude_none=True)
+        return self.model_dump(exclude_none=True)
 
 
 class EventShipperPayloadResponse(BaseModel):

--- a/backend/app/middleware/exception_handlers.py
+++ b/backend/app/middleware/exception_handlers.py
@@ -82,7 +82,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
     return JSONResponse(
         status_code=422,
-        content=ValidationErrorResponse(message=main_message, details=details).dict(),
+        content=ValidationErrorResponse(message=main_message, details=details).model_dump(),
     )
 
 

--- a/backend/app/network_connectors/routes.py
+++ b/backend/app/network_connectors/routes.py
@@ -734,7 +734,7 @@ async def create_network_connector_meta(
     )
     try:
         new_customer_network_connector_meta = CustomerNetworkConnectorsMeta(
-            **customer_network_connector_meta.dict(),
+            **customer_network_connector_meta.model_dump(),
         )
         session.add(new_customer_network_connector_meta)
         await session.commit()

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 from pydantic import field_validator, ConfigDict, BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import model_validator
 
 # ---------------------------------------------------------------------------
 # Enums (input validation only — DB stores strings)
@@ -150,21 +150,14 @@ class NotificationRouteBase(BaseModel):
     def _strip_destination(cls, v: str) -> str:
         return v.strip()
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("shuffle_integration_id", always=True)
-    def _shuffle_integration_required(cls, v, values):
-        if values.get("channel") == NotificationChannel.SHUFFLE and not v:
-            raise ValueError("shuffle_integration_id is required when channel='shuffle'")
-        return v
-
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("shuffle_app_id", always=True)
-    def _shuffle_app_required(cls, v, values):
-        if values.get("channel") == NotificationChannel.SHUFFLE and not v:
-            raise ValueError("shuffle_app_id is required when channel='shuffle'")
-        return v
+    @model_validator(mode="after")
+    def _shuffle_fields_required(self):
+        if self.channel == NotificationChannel.SHUFFLE:
+            if not self.shuffle_integration_id:
+                raise ValueError("shuffle_integration_id is required when channel='shuffle'")
+            if not self.shuffle_app_id:
+                raise ValueError("shuffle_app_id is required when channel='shuffle'")
+        return self
 
 
 class NotificationRouteCreate(NotificationRouteBase):

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -158,7 +158,7 @@ async def update_route(
     # Pydantic v1 vs v2 parity — exclude_unset returns only the fields
     # the client actually sent so a PATCH that omits `enabled` doesn't
     # accidentally re-flag it.
-    data = payload.dict(exclude_unset=True)
+    data = payload.model_dump(exclude_unset=True)
 
     # If the PATCH switches the channel to Shuffle (or re-points an
     # existing Shuffle route at a different integration), the new
@@ -265,7 +265,7 @@ async def update_shuffle_integration(
     session: AsyncSession,
 ) -> CustomerShuffleIntegration:
     integration = await _ensure_integration_belongs_to_customer(integration_id, customer_code, session)
-    data = payload.dict(exclude_unset=True)
+    data = payload.model_dump(exclude_unset=True)
     for field, value in data.items():
         setattr(integration, field, value)
     integration.updated_at = datetime.utcnow()

--- a/backend/app/siem/services/event_sources.py
+++ b/backend/app/siem/services/event_sources.py
@@ -52,7 +52,7 @@ async def create_event_source(
             detail=f"Event source '{event_source_data.name}' already exists for customer {event_source_data.customer_code}",
         )
 
-    db_event_source = EventSources(**event_source_data.dict())
+    db_event_source = EventSources(**event_source_data.model_dump())
     db.add(db_event_source)
     await db.flush()
     await db.refresh(db_event_source)

--- a/backend/app/stack_provisioning/graylog/services/fortinet.py
+++ b/backend/app/stack_provisioning/graylog/services/fortinet.py
@@ -99,11 +99,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -236,7 +236,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/stack_provisioning/graylog/services/provision.py
+++ b/backend/app/stack_provisioning/graylog/services/provision.py
@@ -264,7 +264,7 @@ async def process_content_pack(content_pack, content_pack_request):
         TLS_KEY_FILE=content_pack_request.keywords.tls_key_file,
     )
     if "PROCESSING_PIPELINE" not in content_pack:
-        content_pack = replace_keywords_in_json_complex(content_pack, replace_content_pack_keywords.dict())
+        content_pack = replace_keywords_in_json_complex(content_pack, replace_content_pack_keywords.model_dump())
         content_pack = convert_port_value_to_int(content_pack)
     await insert_and_install_content_pack(content_pack)
 

--- a/backend/app/stack_provisioning/graylog/services/sentinelone.py
+++ b/backend/app/stack_provisioning/graylog/services/sentinelone.py
@@ -100,11 +100,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -235,7 +235,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/stack_provisioning/graylog/services/sonicwall.py
+++ b/backend/app/stack_provisioning/graylog/services/sonicwall.py
@@ -98,11 +98,11 @@ async def send_index_set_creation_request(
     Returns:
         GraylogIndexSetCreationResponse: The response from Graylog after creating the index set.
     """
-    json_index_set = json.dumps(index_set.dict())
+    json_index_set = json.dumps(index_set.model_dump())
     logger.info(f"json_index_set set: {json_index_set}")
     response_json = await send_post_request(
         endpoint="/api/system/indices/index_sets",
-        data=index_set.dict(),
+        data=index_set.model_dump(),
     )
     return GraylogIndexSetCreationResponse(**response_json)
 
@@ -233,7 +233,7 @@ async def create_grafana_datasource(
         readOnly=True,
     )
     results = grafana_client.datasource.create_datasource(
-        datasource=datasource_payload.dict(),
+        datasource=datasource_payload.model_dump(),
     )
     return GrafanaDataSourceCreationResponse(**results)
 

--- a/backend/app/threat_intel/routes/socfortress.py
+++ b/backend/app/threat_intel/routes/socfortress.py
@@ -454,7 +454,7 @@ async def ai_anaylze_alert_socfortress(
 
     ai_request = SocfortressAiAlertRequest(
         integration="SOCFORTRESS AI",
-        alert_payload=alert_details._source.dict(),
+        alert_payload=alert_details._source.model_dump(),
     )
 
     socfortress_lookup = await socfortress_ai_alert_lookup(
@@ -492,7 +492,7 @@ async def ai_wazuh_exclusion_rule_socfortress(
 
     ai_request = SocfortressAiAlertRequest(
         integration="SOCFORTRESS AI",
-        alert_payload=alert_details._source.dict(),
+        alert_payload=alert_details._source.model_dump(),
     )
 
     logger.info(f"Sending request: {request}")
@@ -605,7 +605,7 @@ async def ai_velociraptor_artifact_recommendation_socfortress(
 
     ai_request = VelociraptorArtifactRecommendationRequest(
         integration="SOCFORTRESS AI",
-        alert_payload=alert_payload._source.dict(),
+        alert_payload=alert_payload._source.model_dump(),
         os=os,
         artifacts=await fetch_artifacts(os),
     )

--- a/backend/app/threat_intel/schema/epss.py
+++ b/backend/app/threat_intel/schema/epss.py
@@ -31,7 +31,7 @@ class EpssApiResponse(BaseModel):
     data: List[EpssData]
 
     def to_dict(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class EpssThreatIntelResponse(BaseModel):

--- a/backend/app/threat_intel/schema/socfortress.py
+++ b/backend/app/threat_intel/schema/socfortress.py
@@ -60,7 +60,7 @@ class IoCMapping(BaseModel):
         return v
 
     def to_dict(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class IoCResponse(BaseModel):
@@ -69,7 +69,7 @@ class IoCResponse(BaseModel):
     message: Optional[str] = Field(None, description="Message about the IoC")
 
     def to_dict(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class SocfortressProcessNameAnalysisRequest(BaseModel):
@@ -217,7 +217,7 @@ class SocfortressProcessNameAnalysisResponse(BaseModel):
     data: SocfortressProcessNameAnalysisAPIResponse
 
     def to_dict(self):
-        return self.dict()
+        return self.model_dump()
 
 
 class Artifacts(BaseModel):

--- a/backend/app/threat_intel/services/socfortress.py
+++ b/backend/app/threat_intel/services/socfortress.py
@@ -303,7 +303,7 @@ async def invoke_socfortress_ai_alert_api(
     headers = {"module-version": "1.0", "x-api-key": api_key}
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(url, json=request.dict(), headers=headers)
+            response = await client.post(url, json=request.model_dump(), headers=headers)
             response.raise_for_status()  # Raise an exception for non-successful status codes
             return response.json()
     except httpx.HTTPStatusError as e:

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -17,7 +17,7 @@ from fastapi.exceptions import RequestValidationError
 from loguru import logger
 from pydantic import field_validator, BaseModel
 from pydantic import Field
-from pydantic import validator
+from pydantic import model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import joinedload
@@ -72,13 +72,8 @@ class ValidationErrorItem(BaseModel):
     error_type: ErrorType
     message: str = None  # Initialize as None
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("message", pre=True, always=True)
-    def set_message(cls, value, values):
-        error_type = values.get("error_type")
-        logger.info(error_type)
-
+    @model_validator(mode="after")
+    def set_message(self):
         error_messages = {
             ErrorType.PASSWORD_REGEX: "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one "
             "special character.",
@@ -99,8 +94,9 @@ class ValidationErrorItem(BaseModel):
             ErrorType.GENERAL: "Invalid value.",
             ErrorType.INVALID_ENUM: "Value is not a valid enumeration member.",
         }
-
-        return error_messages.get(error_type, value)
+        if self.error_type in error_messages:
+            self.message = error_messages[self.error_type]
+        return self
 
 
 class ValidationErrorResponse(BaseModel):
@@ -275,7 +271,7 @@ class Logger:
         Returns:
             None
         """
-        log_entry = LogEntry(**log_entry_model.dict())
+        log_entry = LogEntry(**log_entry_model.model_dump())
         self.session.add(log_entry)
         await self.session.commit()
 

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import asynccontextmanager
 
 import uvicorn
 from dotenv import load_dotenv
@@ -99,7 +100,41 @@ environment = os.getenv("ENVIRONMENT", "PRODUCTION")
 # ssl_keyfile = os.path.join(os.path.dirname(__file__), "../nginx/server.key")
 # ssl_certfile = os.path.join(os.path.dirname(__file__), "../nginx/server.crt")
 
-app = FastAPI(description="CoPilot API", version="0.1.0", title="CoPilot API")
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    # ── startup ──
+    logger.info("Initializing database")
+    if environment == "PRODUCTION":
+        await create_database_if_not_exists(db_url=SQLALCHEMY_DATABASE_URI_NO_DB, db_name="copilot")
+        await create_copilot_user_if_not_exists(db_url=SQLALCHEMY_DATABASE_URI_NO_DB, db_user_name="copilot")
+    apply_migrations()
+    await create_buckets()
+    await add_connectors(async_engine)
+    await delete_connectors(async_engine)
+    await create_roles(async_engine)
+    await create_available_integrations(async_engine)
+    await create_available_network_connectors(async_engine)
+    await ensure_admin_user(async_engine)
+    await ensure_scheduler_user(async_engine)
+
+    # Initialize the scheduler
+    scheduler = await init_scheduler()
+    if not scheduler.running:
+        logger.info("Scheduler is not running, starting now...")
+        scheduler.start()
+
+    yield
+
+    # ── shutdown ──
+    logger.info("Shutting down scheduler")
+    scheduler = await get_scheduler_instance()
+    if scheduler.running:
+        logger.info("Scheduler is running, shutting down now...")
+        scheduler.shutdown()
+    await ensure_scheduler_user_removed(async_engine)
+
+
+app = FastAPI(description="CoPilot API", version="0.1.0", title="CoPilot API", lifespan=lifespan)
 
 # Create an APIRouter with a prefix of `/api`
 api_router = APIRouter(prefix="/api")
@@ -187,30 +222,6 @@ api_router.include_router(talon.router)
 app.include_router(api_router)
 
 
-@app.on_event("startup")
-async def init_db():
-    logger.info("Initializing database")
-    if environment == "PRODUCTION":
-        await create_database_if_not_exists(db_url=SQLALCHEMY_DATABASE_URI_NO_DB, db_name="copilot")
-        await create_copilot_user_if_not_exists(db_url=SQLALCHEMY_DATABASE_URI_NO_DB, db_user_name="copilot")
-    apply_migrations()
-    await create_buckets()
-    await add_connectors(async_engine)
-    await delete_connectors(async_engine)
-    await create_roles(async_engine)
-    await create_available_integrations(async_engine)
-    await create_available_network_connectors(async_engine)
-    await ensure_admin_user(async_engine)
-    await ensure_scheduler_user(async_engine)
-
-    # Initialize the scheduler
-    scheduler = await init_scheduler()
-
-    if not scheduler.running:
-        logger.info("Scheduler is not running, starting now...")
-        scheduler.start()
-
-
 # Create `scoutsuite-report` directory if it doesnt exist
 if not os.path.exists("scoutsuite-report"):
     os.makedirs("scoutsuite-report")
@@ -221,18 +232,6 @@ app.mount("/scoutsuite-report", StaticFiles(directory="scoutsuite-report"), name
 @app.get("/")
 def hello():
     return {"message": "CoPilot - We Made It!"}
-
-
-@app.on_event("shutdown")
-async def shutdown_scheduler():
-    logger.info("Shutting down scheduler")
-    # Initialize the scheduler
-    scheduler = await get_scheduler_instance()
-    if scheduler.running:
-        logger.info("Scheduler is running, shutting down now...")
-        scheduler.shutdown()
-
-    await ensure_scheduler_user_removed(async_engine)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up cleanup to #849. Addresses every deprecation warning the pydantic 1 → 2 + SQLAlchemy 1.4 → 2.0 migration left behind. Pure cleanup — no behavior changes; the diff is mechanical renames + a small set of validator hand-migrations.

## What changed (81 files, +365/-386)

| Category | Sites | What |
|---|---|---|
| `.dict()` → `.model_dump()` | 261 sites in 72 files | Pydantic v2 API |
| `update_forward_refs()` → `model_rebuild()` | 1 site | Pydantic v2 API |
| Deprecated `@validator` → `@field_validator` / `@model_validator` | 10 sites (see below) | Pydantic v2 API |
| `SAWarning: relationships overlap` → explicit `overlaps="..."` | 4 relationships | SQLAlchemy 2 ORM |
| FastAPI `@app.on_event` → lifespan handler | 1 site (`copilot.py`) | FastAPI 0.100+ API |

## The 10 `@validator` migrations (the only non-mechanical part)

| File | Validator | New form | Note |
|---|---|---|---|
| `app/utils.py` | `set_message` | `@model_validator(mode='after')` | sets `self.message` from `self.error_type` |
| `app/connectors/cortex/schema/analyzers.py` | `validate_and_set_data_type` | `@model_validator(mode='after')` | sets `self.data_type` from `self.analyzer_data` |
| `app/connectors/shuffle/schema/organizations.py` | `validate_manager_orgs` | `@field_validator(... mode='before')` | normalizes None / list / scalar |
| `app/connectors/grafana/schema/dashboards.py` | `check_dashboards_exist` | `@field_validator` with explicit list iteration | replaces `each_item=True` (removed in v2) |
| `app/integrations/copilot_action/schema/copilot_action.py` | `set_icon_default` | `@model_validator(mode='after')` | sets `self.icon` from `self.technology` |
| `app/notifications/schema/notifications.py` | `_shuffle_*_required` | one combined `@model_validator(mode='after')` | merged the two `always=True` validators |
| `app/incidents/schema/db_operations.py` | `ensure_docx_extension` | `@field_validator(... mode='before')` | unchanged semantics |
| `app/incidents/schema/db_operations.py` | `validate_default_tag` | `@model_validator(mode='after')` | cross-field check |
| `app/incidents/schema/alert_collection.py` | `extract_origin_context` | `@model_validator(mode='before')` | the trickiest — the v1 form used `kwargs["field"].name` to dispatch by which field was being validated; rewritten to set both target fields (`original_alert_id`, `original_alert_index_name`) atomically from `origin_context` in one pass |

## SQLAlchemy 2 relationship `overlaps`

The dispatch service deliberately uses one-way `back_populates`-less relationships to avoid `MissingGreenlet` errors under `AsyncSession.flush()`. SA2 raised SAWarnings about the overlapping FKs; we now declare the intent explicitly:

- `CustomerNotificationRoute.dispatches` ↔ `NotificationDispatchLog.route` → both get `overlaps="route"`/`"dispatches"`
- `CustomerNotificationRoute.shuffle_integration` ↔ `CustomerShuffleIntegration.routes` → both get `overlaps="routes"`/`"shuffle_integration"`

## FastAPI lifespan migration

`@app.on_event("startup")` and `@app.on_event("shutdown")` were combined into a single `@asynccontextmanager`-decorated `lifespan(app)` async generator passed to `FastAPI(lifespan=...)`. Startup logic before `yield`, shutdown logic after. Drops 2 deprecation warnings.

Visible in logs as `__main__:lifespan:106` instead of `__main__:init_db:191`.

## Verified locally

- `docker build` succeeds
- backend boots cleanly via lifespan handler
- all ~50 routers import without `ModuleNotFoundError`
- smoke tests pass:
  - `Password.generate()` bcrypt round-trip
  - `Fernet` encrypt/decrypt round-trip
  - `@field_validator` (UserInput.role_id — codemod-migrated in #849)
  - `@model_validator` (`ExecuteWorkflowRequest`, `AWSScoutSuiteReportRequest` — hand-migrated in #849)
  - `.model_dump()` works
  - SQLAlchemy 2 `select()` works
  - SQLModel table creation works
- **no `DeprecationWarning` or `SAWarning` remain in startup logs** (only the upstream `grafana-client` SyntaxWarning at `elements/datasource.py:414` fires — unrelated, see #848)
- existing MySQL test data preserved across the rebuild

## Risk

Low — all changes are deprecation cleanup + decorator semantics. The 10 hand-migrated validators were each tested by:
- For `@field_validator` — same input/output contract as the v1 form
- For `@model_validator(mode='after')` — preserves the `if cross-field-condition then this-field-required-or-derived` semantics
- For `extract_origin_context` (the tricky one) — the dispatch on `field.name` was replaced with setting BOTH target fields from `origin_context` in one pass; same observable behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)