### PR TITLE
fix: 2FA setup paths — Pillow regression + clear TOTP key error (#838)

### DIFF
--- a/backend/app/auth/services/totp.py
+++ b/backend/app/auth/services/totp.py
@@ -29,10 +29,30 @@ from app.db.db_session import async_engine
 # haven't set TOTP_ENCRYPTION_KEY continue to decrypt stored TOTP secrets.
 _totp_enc_key = os.environ.get("TOTP_ENCRYPTION_KEY")
 if _totp_enc_key:
-    _fernet_key = _totp_enc_key.encode()
+    # Trim accidental whitespace/newlines that .env editors sometimes append
+    _fernet_key = _totp_enc_key.strip().encode()
+    _fernet_key_source = "TOTP_ENCRYPTION_KEY"
 else:
     _fernet_key = base64.urlsafe_b64encode(hashlib.sha256(AuthHandler.secret.encode()).digest())
-_fernet = Fernet(_fernet_key)
+    _fernet_key_source = "JWT_SECRET (derived fallback)"
+
+try:
+    _fernet = Fernet(_fernet_key)
+except (ValueError, TypeError) as e:
+    # Surface a clear, actionable error instead of the obscure
+    # `binascii.Error: Incorrect padding` chain. See issue #838.
+    if _fernet_key_source == "TOTP_ENCRYPTION_KEY":
+        raise RuntimeError(
+            "TOTP_ENCRYPTION_KEY is malformed. Expected a 32-byte url-safe base64 key "
+            "(typically 44 characters ending with '='). Generate a valid one with:\n"
+            "  python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\"\n"
+            f"Then paste the value into your .env without surrounding quotes or trailing whitespace. "
+            f"(underlying error: {e})",
+        ) from e
+    # Fallback path failed — would be a bug, not a misconfiguration
+    raise RuntimeError(
+        f"Failed to initialise TOTP Fernet from derived JWT_SECRET key. (underlying error: {e})",
+    ) from e
 
 _pwd_ctx = CryptContext(schemes=["bcrypt"])
 

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -24,6 +24,7 @@ packaging
 passlib
 passlib[bcrypt]
 pdfkit
+Pillow  # transitive runtime dep of qrcode for 2FA QR generation (qrcode.make() uses qrcode.image.pil)
 playwright
 pydantic[email]
 PyJWT

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -134,6 +134,7 @@ oss2==2.19.1
 packaging==26.2
 passlib[bcrypt]==1.7.4
 pdfkit==1.0.0
+pillow==12.2.0
 playwright==1.59.0
 policyuniverse==1.5.1.20231109
 portalocker==2.10.1


### PR DESCRIPTION
## Two related fixes in the auth/TOTP startup stack

### 1. Pillow regression — blocks 2FA enrolment for everyone (regression from #842)

`POST /api/auth/2fa/setup` returns **500** with:

```
ModuleNotFoundError: No module named 'PIL'
  File "/opt/venv/lib/python3.11/site-packages/qrcode/image/pil.py", line 2
    from PIL import Image, ImageDraw
```

The unused-deps prune in #842 dropped Pillow because no Python file in `backend/` does `import PIL` directly. That was a **false positive** — `qrcode.make()` lazily imports `qrcode.image.pil` on first call, which depends on Pillow. Static-audit tools won't catch this kind of transitive runtime dep.

Adds Pillow to `requirements.in` with an explanatory comment so it doesn't get accidentally pruned again. pip-compile resolves to **Pillow 12.2.0**.

### 2. Clear error when `TOTP_ENCRYPTION_KEY` is malformed — closes #838

User `p4rtyR1ng`'s symptom: backend dies at startup with this opaque chain:

```
binascii.Error: Incorrect padding
The above exception was the direct cause of the following exception:
ValueError: Fernet key must be 32 url-safe base64-encoded bytes.
```

The traceback doesn't say:
- *Which* env var is the problem
- What format is expected
- How to generate a valid one

Wraps the Fernet init in `app/auth/services/totp.py:35` with `try/except (ValueError, TypeError)`. On failure, raises a clear `RuntimeError`:

```
TOTP_ENCRYPTION_KEY is malformed. Expected a 32-byte url-safe base64 key
(typically 44 characters ending with '='). Generate a valid one with:
  python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
Then paste the value into your .env without surrounding quotes or trailing whitespace.
(underlying error: Fernet key must be 32 url-safe base64-encoded bytes.)
```

Also adds defensive `.strip()` when reading `TOTP_ENCRYPTION_KEY` — accidental newlines or trailing whitespace from .env editors no longer break startup even when the rest of the value is correct.

The fallback derived-from-`JWT_SECRET` path gets its own (different, less likely-to-fire) error message — that path failing would be a bug, not a misconfiguration.

## Verified locally

- ✅ `POST /api/auth/2fa/setup` returns 200 with a valid PNG QR data URI (910 bytes), `otpauth_url`, and 8 backup codes.
- ✅ Backend with malformed `TOTP_ENCRYPTION_KEY=this-is-not-a-valid-key` surfaces the new clear error.
- ✅ Backend with `TOTP_ENCRYPTION_KEY` missing the trailing `=` padding (the likely real-world cause): same clear error.
- ✅ Backend with a valid `TOTP_ENCRYPTION_KEY`: module loads cleanly.

## Test plan

- [ ] Deploy this image, log in as admin
- [ ] In Profile / 2FA, click "Enable 2FA" — QR code should render and 8 backup codes should display
- [ ] Verify the TOTP code from the authenticator app, complete enrolment
- [ ] Optional: deliberately break `TOTP_ENCRYPTION_KEY` in `.env` (drop the trailing `=`), restart the backend container, confirm the clear `RuntimeError` message appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)