### PR TITLE
fix: replace passlib with direct bcrypt — eliminate  log noise

### DIFF
--- a/backend/app/auth/services/sso.py
+++ b/backend/app/auth/services/sso.py
@@ -143,7 +143,7 @@ async def find_user_by_email(email: str) -> Optional[User]:
 
 async def get_or_create_sso_user(email: str, role_id: int = 2) -> User:
     """Find existing user by email or create a new SSO‑managed user."""
-    from passlib.context import CryptContext
+    import bcrypt
 
     async with AsyncSession(async_engine) as session:
         result = await session.execute(select(User).where(User.email == email))
@@ -151,10 +151,10 @@ async def get_or_create_sso_user(email: str, role_id: int = 2) -> User:
         if user:
             return user
 
-        # Create a new user with a random unusable password
-        pwd_ctx = CryptContext(schemes=["bcrypt"])
-        random_pw = secrets.token_urlsafe(64)
-        hashed = pwd_ctx.hash(random_pw)
+        # Create a new user with a random unusable password.
+        # token_urlsafe(48) → 64 chars, safely under bcrypt's 72-byte limit.
+        random_pw = secrets.token_urlsafe(48)
+        hashed = bcrypt.hashpw(random_pw.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
         username = email.split("@")[0]
         # Ensure unique username

--- a/backend/app/auth/services/totp.py
+++ b/backend/app/auth/services/totp.py
@@ -11,11 +11,11 @@ import string
 import time
 from typing import Optional
 
+import bcrypt
 import pyotp
 import qrcode
 from cryptography.fernet import Fernet
 from loguru import logger
-from passlib.context import CryptContext
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import select
@@ -53,8 +53,6 @@ except (ValueError, TypeError) as e:
     raise RuntimeError(
         f"Failed to initialise TOTP Fernet from derived JWT_SECRET key. (underlying error: {e})",
     ) from e
-
-_pwd_ctx = CryptContext(schemes=["bcrypt"])
 
 # ── Brute-force protection ───────────────────────────────────────────────────
 # Per-user: {user_id: (fail_count, first_fail_time)}
@@ -115,7 +113,8 @@ def _generate_backup_codes() -> tuple[list[str], list[dict]]:
     for _ in range(_BACKUP_CODE_COUNT):
         code = "".join(secrets.choice(alphabet) for _ in range(_BACKUP_CODE_LENGTH))
         codes.append(code)
-        hashed.append({"hash": _pwd_ctx.hash(code), "used": False})
+        hashed_code = bcrypt.hashpw(code.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        hashed.append({"hash": hashed_code, "used": False})
     return codes, hashed
 
 
@@ -124,7 +123,7 @@ def _verify_backup_code(backup_code: str, stored_codes: list[dict]) -> int:
     for i, entry in enumerate(stored_codes):
         if entry.get("used"):
             continue
-        if _pwd_ctx.verify(backup_code.upper().strip(), entry["hash"]):
+        if bcrypt.checkpw(backup_code.upper().strip().encode("utf-8"), entry["hash"].encode("utf-8")):
             return i
     return -1
 

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -2,13 +2,13 @@ import os
 from datetime import datetime
 from datetime import timedelta
 
+import bcrypt
 import jwt
 from fastapi import Depends
 from fastapi import HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from fastapi.security import SecurityScopes
 from loguru import logger
-from passlib.context import CryptContext
 
 from app.auth.services.universal import find_user
 from app.auth.services.universal import get_role
@@ -44,14 +44,13 @@ class AuthHandler:
             "customer_user": "Customer portal users",
         },
     )
-    pwd_context = CryptContext(schemes=["bcrypt"])
     secret = _load_jwt_secret()
 
-    def get_password_hash(self, password):
-        return self.pwd_context.hash(password)
+    def get_password_hash(self, password: str) -> str:
+        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
-    def verify_password(self, plain_password, hashed_password):
-        return self.pwd_context.verify(plain_password, hashed_password)
+    def verify_password(self, plain_password: str, hashed_password: str) -> bool:
+        return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
 
     # ! TODO: HAVE LOGIC TO HANDLE PASSWORD RESET VIA A TOKEN BUT NOT IMPLEMENTED YET ! #
     def generate_reset_token(

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -5,7 +5,7 @@ aiosqlite
 alembic
 apscheduler
 asyncgelf
-bcrypt<5  # passlib 1.7.4 (last released 2020) is incompatible with bcrypt 5+; remove this cap when passlib gets replaced
+bcrypt<5  # bcrypt 5 errors (instead of silently truncating) on passwords >72 bytes; lift after enforcing length limit at the model layer
 cortex4py
 cryptography
 docxtpl
@@ -21,8 +21,6 @@ Jinja2
 loguru
 miniopy-async
 packaging
-passlib
-passlib[bcrypt]
 pdfkit
 Pillow  # transitive runtime dep of qrcode for 2FA QR generation (qrcode.make() uses qrcode.image.pil)
 playwright

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -132,7 +132,6 @@ oauthlib==3.3.1
 oci==2.168.1
 oss2==2.19.1
 packaging==26.2
-passlib[bcrypt]==1.7.4
 pdfkit==1.0.0
 pillow==12.2.0
 playwright==1.59.0


### PR DESCRIPTION
## Why

After #851 (`bcrypt<5` hotfix), every login still prints this on every login:

```
(trapped) error reading bcrypt version
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/passlib/handlers/bcrypt.py", line 620
    version = _bcrypt.__about__.__version__
AttributeError: module 'bcrypt' has no attribute '__about__'
```

`passlib 1.7.4` (last release **August 2020**) doesn't know about `bcrypt 4.1+` — it tries to read the `__about__.__version__` attribute that bcrypt removed in 4.1. The exception is *trapped* inside passlib's version-detection path so auth still works, but the traceback prints to stdout every single login.

The warning is cosmetic. The real cost is keeping an **unmaintained** dependency in the auth path.

## Fix

Drop passlib entirely; use bcrypt directly in the 4 places that needed it:

| File | Was | Now |
|---|---|---|
| `app/auth/utils.py` | `pwd_context = CryptContext(schemes=["bcrypt"])` + `pwd_context.hash` / `.verify` | `bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")` / `bcrypt.checkpw(...)` |
| `app/auth/services/totp.py` | `_pwd_ctx = CryptContext(...)` for backup-code hashing | direct `bcrypt.hashpw` / `bcrypt.checkpw` |
| `app/auth/services/sso.py` | local `CryptContext` for SSO random-password generation | direct `bcrypt.hashpw`. Also reduced `token_urlsafe(64)` → `token_urlsafe(48)` so the random pw stays explicitly under bcrypt's 72-byte limit instead of relying on silent truncation. |
| `requirements.in` | `passlib`, `passlib[bcrypt]` | _removed_ |

## Hash-format compatibility — IMPORTANT

passlib's bcrypt scheme writes the **same** `$2b$NN$...` envelope that raw bcrypt produces. I verified this in the test container:

```
sample hash: $2b$12$h/KvWaf/yOmyUOcGaTeI8.J...
format: $2b$ (= bcrypt rev2, same envelope passlib uses)
✅ hash round-trip OK
```

**Existing passwords + backup codes in production DBs will continue to verify** — no data migration needed.

## Verified locally

- ✅ Backend boots clean
- ✅ Login as admin → HTTP 200, valid bearer token
- ✅ **Zero `(trapped)` warnings** in logs (down from ≥1 per login)
- ✅ **Zero `passlib` references** anywhere in logs
- ✅ 2FA setup → 200 with 8 backup codes (the new direct-bcrypt path generates correctly-formatted hashes)
- ✅ Hash round-trip: `$2b$NN$...` produced by `bcrypt.hashpw` verifies identically to passlib's

## Follow-up (out of scope)

With passlib gone, the `bcrypt<5` cap in `requirements.in` exists only because bcrypt 5 raises on >72-byte passwords instead of silently truncating. A future small PR can lift that cap after enforcing a 72-byte limit (or pre-hashing with SHA-256) at the model layer — `PasswordReset.new_password` currently allows `max_length=256` which exceeds bcrypt's input limit.

## Test plan

- [ ] Deploy this image, log in as existing user (one whose password was set under passlib) — should succeed without re-enrolment
- [ ] Verify a backup code from a previously-enrolled 2FA user — should still validate
- [ ] Verify `(trapped)` warning is gone from `copilot-backend` logs

## Related PRs

- #851 hotfix: pinned `bcrypt<5` after #848 broke login (passlib + bcrypt 5 incompat)
- #852 fix: Pillow regression + Fernet error message (independent of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)