### PR TITLE
chore: lift bcrypt<5 cap, enforce 72-byte password limit at API layer

### DIFF
--- a/backend/app/auth/models/users.py
+++ b/backend/app/auth/models/users.py
@@ -83,11 +83,14 @@ class RoleEnum(int, Enum):
 
 class UserInput(SQLModel):
     username: str
+    # bcrypt's input is capped at 72 bytes; longer passwords would either be silently
+    # truncated (bcrypt 4 behaviour) or rejected with ValueError (bcrypt 5+). We enforce
+    # the limit here so users get a clean 422 ValidationError instead.
     password: str = Field(
-        max_length=256,
+        max_length=72,
         min_length=8,
         regex="^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#]).{8,}$",
-        description="Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character",
+        description="Password must be 8-72 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character",
     )
     email: EmailStr
     role_id: RoleEnum = Field(
@@ -110,11 +113,12 @@ class UserLogin(SQLModel):
 
 
 class Password(BaseModel):
+    # Capped at 72 — bcrypt's input limit. The generated chars are ASCII so 72 chars = 72 bytes.
     length: int = Field(
         default=12,
         ge=8,
-        le=128,
-        description="The length of the password",
+        le=72,
+        description="The length of the password (max 72 — bcrypt input limit)",
     )
     hashed: str  # Holds the hashed password
     plain: str  # Holds the plain password
@@ -122,14 +126,14 @@ class Password(BaseModel):
     @field_validator("length")
     @classmethod
     def validate_length(cls, value):
-        if value < 8 or value > 128:
-            raise ValueError("Password length must be between 8 and 128 characters.")
+        if value < 8 or value > 72:
+            raise ValueError("Password length must be between 8 and 72 characters.")
         return value
 
     @classmethod
     def generate(cls, length: int = 12) -> "Password":
-        if length < 8:  # Ensure the password is a reasonable length
-            raise ValueError("Password length should be at least 8 characters.")
+        if length < 8 or length > 72:
+            raise ValueError("Password length should be between 8 and 72 characters.")
 
         # Define the characters that can be used in the password
         lowercase = string.ascii_lowercase
@@ -180,8 +184,8 @@ class PasswordResetToken(BaseModel):
     @field_validator("new_password")
     @classmethod
     def validate_password(cls, password):
-        if len(password) < 8 or len(password) > 256:
-            raise ValueError("Password length must be between 8 and 256 characters.")
+        if len(password) < 8 or len(password) > 72:
+            raise ValueError("Password length must be between 8 and 72 characters (bcrypt input limit).")
         if not re.search(r"[a-z]", password):
             raise ValueError("Password must contain at least one lowercase letter.")
         if not re.search(r"[A-Z]", password):
@@ -195,9 +199,10 @@ class PasswordResetToken(BaseModel):
 
 class PasswordReset(BaseModel):
     username: str
+    # 8-72 chars — bcrypt's 72-byte input limit (matches UserInput).
     new_password: str = Field(
-        max_length=256,
+        max_length=72,
         min_length=8,
         regex="^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$",
-        description="Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character",
+        description="Password must be 8-72 characters long and contain at least one uppercase letter, one lowercase letter, one number, and one special character",
     )

--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -46,11 +46,19 @@ class AuthHandler:
     )
     secret = _load_jwt_secret()
 
+    @staticmethod
+    def _to_bcrypt_bytes(password: str) -> bytes:
+        # bcrypt 5 raises ValueError on >72 bytes; bcrypt 4 silently truncated.
+        # We slice by bytes (not chars) for backwards compat with hashes created
+        # under bcrypt 4's silent truncation, while protecting against bcrypt 5
+        # raising for any path that bypasses the schema-layer length validation.
+        return password.encode("utf-8")[:72]
+
     def get_password_hash(self, password: str) -> str:
-        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+        return bcrypt.hashpw(self._to_bcrypt_bytes(password), bcrypt.gensalt()).decode("utf-8")
 
     def verify_password(self, plain_password: str, hashed_password: str) -> bool:
-        return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
+        return bcrypt.checkpw(self._to_bcrypt_bytes(plain_password), hashed_password.encode("utf-8"))
 
     # ! TODO: HAVE LOGIC TO HANDLE PASSWORD RESET VIA A TOKEN BUT NOT IMPLEMENTED YET ! #
     def generate_reset_token(

--- a/backend/app/middleware/exception_handlers.py
+++ b/backend/app/middleware/exception_handlers.py
@@ -69,7 +69,14 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
     for error in errors:
         field = error["loc"][-1]
-        error_type = ErrorType(error["type"])
+        try:
+            error_type = ErrorType(error["type"])
+        except ValueError:
+            # Pydantic 2 emits codes the v1-era ErrorType enum doesn't list
+            # (string_too_long, string_pattern_mismatch, etc.) — fall back to
+            # GENERAL so unknown codes still produce a 422 with a sensible
+            # message instead of crashing the handler.
+            error_type = ErrorType.GENERAL
         details.append(ValidationErrorItem(field=field, error_type=error_type))
 
     main_message = details[0].message if details else "Validation Error"

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -47,6 +47,8 @@ from app.integrations.alert_creation_settings.models.alert_creation_settings imp
 
 ################## ! 422 VALIDATION ERROR TYPES FOR PYDANTIC VALUE ERROR RESPONSE ! ##################
 class ErrorType(str, Enum):
+    # Legacy pydantic 1 codes — kept so any consumer reading these by string
+    # value continues to work. Pydantic 2 uses the *_V2 codes below.
     PASSWORD_REGEX = "value_error.str.regex"
     TIME_RANGE = "value_error.time_range"
     JSON_INVALID = "json_invalid"
@@ -64,7 +66,19 @@ class ErrorType(str, Enum):
     MISSING = "value_error.missing"
     GENERAL = "value_error"
     INVALID_ENUM = "type_error.enum"
-    # Add other types as needed
+    # Pydantic 2 codes (renamed in #849). Add more here as users surface them.
+    STRING_TOO_SHORT = "string_too_short"
+    STRING_TOO_LONG = "string_too_long"
+    STRING_PATTERN_MISMATCH = "string_pattern_mismatch"
+    INT_PARSING = "int_parsing"
+    GREATER_THAN = "greater_than"
+    GREATER_THAN_EQUAL = "greater_than_equal"
+    LESS_THAN = "less_than"
+    LESS_THAN_EQUAL = "less_than_equal"
+    DATETIME_PARSING = "datetime_parsing"
+    DATE_PARSING = "date_parsing"
+    ENUM = "enum"
+    MISSING_V2 = "missing"
 
 
 class ValidationErrorItem(BaseModel):
@@ -93,6 +107,19 @@ class ValidationErrorItem(BaseModel):
             ErrorType.MISSING: "Missing data for required field.",
             ErrorType.GENERAL: "Invalid value.",
             ErrorType.INVALID_ENUM: "Value is not a valid enumeration member.",
+            # Pydantic 2 codes — same human messages as their v1 equivalents.
+            ErrorType.STRING_TOO_SHORT: "Value is shorter than minimum length.",
+            ErrorType.STRING_TOO_LONG: "Value is longer than maximum length.",
+            ErrorType.STRING_PATTERN_MISMATCH: "Value does not match the required pattern.",
+            ErrorType.INT_PARSING: "Input is not a valid integer.",
+            ErrorType.GREATER_THAN: "Value is too small.",
+            ErrorType.GREATER_THAN_EQUAL: "Value is too small.",
+            ErrorType.LESS_THAN: "Value is too large.",
+            ErrorType.LESS_THAN_EQUAL: "Value is too large.",
+            ErrorType.DATETIME_PARSING: "Invalid datetime format.",
+            ErrorType.DATE_PARSING: "Invalid date format.",
+            ErrorType.ENUM: "Value is not a valid enumeration member.",
+            ErrorType.MISSING_V2: "Missing data for required field.",
         }
         if self.error_type in error_messages:
             self.message = error_messages[self.error_type]

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -5,7 +5,7 @@ aiosqlite
 alembic
 apscheduler
 asyncgelf
-bcrypt<5  # bcrypt 5 errors (instead of silently truncating) on passwords >72 bytes; lift after enforcing length limit at the model layer
+bcrypt
 cortex4py
 cryptography
 docxtpl

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,7 +43,7 @@ azure-mgmt-sql==1.0.0
 azure-mgmt-storage==17.0.0
 azure-mgmt-web==1.0.0
 backports-tarfile==1.2.0
-bcrypt==4.3.0
+bcrypt==5.0.0
 boto3==1.43.6
 botocore==1.43.6
 cachetools==4.2.4


### PR DESCRIPTION
## Summary

Final cleanup of the auth-deps modernization sequence (#842 → #853). Lifts the `bcrypt<5` cap that #851/#853 left in place. **Resolves to bcrypt 5.0.0.**

The cap existed because bcrypt 5 raises `ValueError` on >72-byte passwords, while bcrypt 4 silently truncated. To lift it safely we need three coordinated changes — otherwise a user with a long password would hit a bcrypt-level 500 instead of a clean rejection.

## What changed

### 1. Schema-layer enforcement — fail at the right place

| File | Field | Was | Now |
|---|---|---|---|
| `app/auth/models/users.py` | `UserInput.password` | `max_length=256` | `max_length=72` |
| `app/auth/models/users.py` | `PasswordReset.new_password` | `max_length=256` | `max_length=72` |
| `app/auth/models/users.py` | `PasswordResetToken.validate_password` | `len > 256` check | `len > 72` check |
| `app/auth/models/users.py` | `Password.length` | `le=128` | `le=72` |
| `app/auth/models/users.py` | `Password.generate` | `length<8` reject | `length<8 or >72` reject |

Long passwords now produce a clean **422 ValidationError** at request parse time instead of crashing in bcrypt with an opaque 500.

### 2. Defensive truncation in AuthHandler — backwards compat with existing hashes

```python
@staticmethod
def _to_bcrypt_bytes(password: str) -> bytes:
    return password.encode("utf-8")[:72]

def get_password_hash(self, password: str) -> str:
    return bcrypt.hashpw(self._to_bcrypt_bytes(password), bcrypt.gensalt()).decode("utf-8")

def verify_password(self, plain_password: str, hashed_password: str) -> bool:
    return bcrypt.checkpw(self._to_bcrypt_bytes(plain_password), hashed_password.encode("utf-8"))
```

Why: existing user passwords whose original plaintext was >72 bytes were silently truncated when first hashed under bcrypt 4. The new code reproduces that truncation on verify, so the same hash matches. Also prevents bcrypt 5 from raising in any code path that bypasses schema validation (internal callers, future code, Unicode edge cases where character count <72 but UTF-8 byte count >72).

### 3. Pre-existing bug surfaced by the test scenario, fixed here

`validation_exception_handler` (`app/middleware/exception_handlers.py:72`) did `ErrorType(error["type"])`, raising `ValueError` for any pydantic 2 error code the legacy `ErrorType` enum didn't list. This had been broken since #849 (the pydantic 1→2 migration) — pydantic 2 renamed the codes (`value_error.any_str.max_length` → `string_too_long`, etc.) but the v1-era enum was never updated. No test path was hitting long-string validation, so it stayed latent. With the new 72-byte cap, that path fires.

- Handler: `try / except ValueError → ErrorType.GENERAL`. Unknown codes now produce a 422 with a sane message instead of a 400 + `"X is not a valid ErrorType"`.
- `ErrorType` enum: added v2 codes for the concepts we actually emit messages for: `string_too_short`, `string_too_long`, `string_pattern_mismatch`, `int_parsing`, `greater_than{,_equal}`, `less_than{,_equal}`, `datetime_parsing`, `date_parsing`, `enum`, `missing`.

### 4. `requirements.in`

```diff
-bcrypt<5  # bcrypt 5 errors (instead of silently truncating) on passwords >72 bytes; lift after enforcing length limit at the model layer
+bcrypt
```

`pip-compile` resolves to **bcrypt 5.0.0**.

## Verified locally

- ✅ `bcrypt 5.0.0` installed in the rebuilt image
- ✅ Admin login: **HTTP 200**, bearer token issued
- ✅ Registering a **104-char password**: HTTP 422 with structured response

  ```json
  {
    "message": "Value is longer than maximum length.",
    "details": [{
      "field": "password",
      "error_type": "string_too_long",
      "message": "Value is longer than maximum length."
    }]
  }
  ```

- ✅ Registering a normal 10-char valid password: HTTP 201
- ✅ 2FA setup: HTTP 200 with QR data URI + 8 backup codes
- ✅ Existing-hash verification: admin password generated + hashed under bcrypt 5 verifies correctly via login (token issued)

## Roadmap state

With this PR the auth-deps modernization sequence is fully done. The `auth/` stack now has:

- **No unmaintained deps** (passlib gone in #853)
- **No log-noise warnings** (`(trapped) error reading bcrypt version` gone)
- **Clear errors for malformed env vars** (`TOTP_ENCRYPTION_KEY` in #852)
- **Schema-level rejection of overlong passwords** (this PR)
- **bcrypt 5** with proper 72-byte handling (this PR)
- **Pydantic 2 error codes** properly mapped in the validation handler (this PR)

| PR | Status |
|---|---|
| #842 unused python deps dropped | ✅ |
| #843 reconcile requirements.in | ✅ |
| #844 tier 1 safe drop-ins | ✅ |
| #845 grpcio bump | ✅ |
| #848 tier 2 medium-risk majors | ✅ |
| #849 pydantic 2 + sqlmodel + SQLAlchemy 2 | ✅ |
| #850 pydantic 2 / SA2 deprecation cleanup | ✅ |
| #851 bcrypt<5 hotfix | ✅ |
| #852 Pillow regression + Fernet error (#838) | ✅ |
| #853 replace passlib with direct bcrypt | ✅ |
| **this PR** lift bcrypt<5 cap | ⏳ |

## Test plan

- [ ] Deploy this image, log in as existing user — should succeed (their password was hashed under earlier bcrypt 4/5 with same truncation behaviour)
- [ ] Try setting a >72-char password via the registration UI — should see a 422 ValidationError, not a 500
- [ ] Verify 2FA enrolment flow still works
- [ ] Spot-check `copilot-backend` logs for any new bcrypt warnings — there should be none

🤖 Generated with [Claude Code](https://claude.com/claude-code)