### PR TITLE
fix: retry dashboard terms agg with .keyword on text-field errors

### DIFF
--- a/backend/app/siem/services/dashboards.py
+++ b/backend/app/siem/services/dashboards.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from elasticsearch7.exceptions import RequestError
 from fastapi import HTTPException
 from loguru import logger
 from sqlalchemy import select
@@ -146,6 +147,28 @@ async def disable_dashboard(
 # ── Panel data (execute queries for dashboard rendering) ─────────
 
 
+def _is_text_field_agg_error(exc: RequestError) -> bool:
+    """True iff the Elasticsearch error is the one raised when a terms agg
+    targets a `text`-typed field (which lacks per-document field data by
+    default). The error string is stable across ES 7.x and is the cue we
+    use to retry the agg against `<field>.keyword`.
+
+    Sample message body (in `exc.info`):
+        "Text fields are not optimised for operations that require
+         per-document field data like aggregations and sorting..."
+
+    Note: `str(exc)` for elasticsearch7 RequestError only includes the
+    error code ("search_phase_execution_exception"), NOT the message —
+    the human-readable text lives on `exc.info`. We match against both
+    so the type code and the specific cause both have to line up.
+    """
+    info = getattr(exc, "info", "") or ""
+    return (
+        getattr(exc, "error", "") == "search_phase_execution_exception"
+        and "Text fields are not optimised" in str(info)
+    )
+
+
 def _compute_histogram_interval(timerange: str) -> str:
     """Pick a reasonable date_histogram interval for the given timerange."""
     mapping = {
@@ -258,15 +281,34 @@ async def get_panel_data(
                     if not field:
                         results[pid] = PanelResult(type=ptype, error="No field specified for aggregation")
                         continue
-                    body["aggs"] = {
-                        "top_values": {
-                            "terms": {
-                                "field": field,
-                                "size": size,
+
+                    def _build_terms_agg(agg_field: str) -> dict:
+                        return {
+                            "top_values": {
+                                "terms": {"field": agg_field, "size": size},
                             },
-                        },
-                    }
-                    resp = await es_client.search(index=event_source.index_pattern, body=body)
+                        }
+
+                    body["aggs"] = _build_terms_agg(field)
+                    try:
+                        resp = await es_client.search(index=event_source.index_pattern, body=body)
+                    except RequestError as exc:
+                        # Elasticsearch refuses terms aggs on `text` fields by default.
+                        # If the index maps `field` as text, retry with the conventional
+                        # `field.keyword` subfield. Cheap one-shot fallback that handles
+                        # the common case where customer index templates differ.
+                        if (
+                            _is_text_field_agg_error(exc)
+                            and not field.endswith(".keyword")
+                        ):
+                            logger.info(
+                                f"Panel {pid}: '{field}' is text-typed in {event_source.index_pattern}; "
+                                f"retrying with '{field}.keyword'",
+                            )
+                            body["aggs"] = _build_terms_agg(f"{field}.keyword")
+                            resp = await es_client.search(index=event_source.index_pattern, body=body)
+                        else:
+                            raise
                     buckets = resp["aggregations"]["top_values"]["buckets"]
                     labels = [str(b["key"]) for b in buckets]
                     data = [b["doc_count"] for b in buckets]

--- a/backend/app/siem/services/dashboards.py
+++ b/backend/app/siem/services/dashboards.py
@@ -163,10 +163,7 @@ def _is_text_field_agg_error(exc: RequestError) -> bool:
     so the type code and the specific cause both have to line up.
     """
     info = getattr(exc, "info", "") or ""
-    return (
-        getattr(exc, "error", "") == "search_phase_execution_exception"
-        and "Text fields are not optimised" in str(info)
-    )
+    return getattr(exc, "error", "") == "search_phase_execution_exception" and "Text fields are not optimised" in str(info)
 
 
 def _compute_histogram_interval(timerange: str) -> str:
@@ -297,10 +294,7 @@ async def get_panel_data(
                         # If the index maps `field` as text, retry with the conventional
                         # `field.keyword` subfield. Cheap one-shot fallback that handles
                         # the common case where customer index templates differ.
-                        if (
-                            _is_text_field_agg_error(exc)
-                            and not field.endswith(".keyword")
-                        ):
+                        if _is_text_field_agg_error(exc) and not field.endswith(".keyword"):
                             logger.info(
                                 f"Panel {pid}: '{field}' is text-typed in {event_source.index_pattern}; "
                                 f"retrying with '{field}.keyword'",


### PR DESCRIPTION
## Why

Dashboard panels of type `pie` / `bar_h` build an Elasticsearch terms aggregation on the field declared in the panel template:

```python
"terms": {"field": field, "size": size}
```

ES refuses terms aggs on `text`-typed fields — they lack per-document field data by default. Customer indices that haven't had the proper Wazuh index template applied (or were created with a Graylog index set whose custom field mappings don't include `.keyword` subfields) fail with:

```
RequestError(400, 'search_phase_execution_exception',
  'Text fields are not optimised for operations that require per-document
  field data like aggregations and sorting... Please use a keyword field
  instead.')
```

Other indices in the same deployment can have proper keyword mappings and work fine, which is what makes this surprising — a dashboard breaks for one Wazuh index but not another. The data-side fix (re-apply the Wazuh template / fix Graylog index-set custom mappings) is the long-term answer; this PR is the **defensive code-side fallback** so dashboards stay usable while customers are sorting their index mappings out.

## Fix

In `app/siem/services/dashboards.py:get_panel_data`, the `pie` / `bar_h` branch now retries with `field + ".keyword"` when the original aggregation hits the specific text-field error. Cheap one-shot fallback, no second retry. If the `.keyword` attempt also fails, the original error propagates to the existing per-panel error handler so the panel renders its error card without taking down the rest of the dashboard.

```python
body["aggs"] = _build_terms_agg(field)
try:
    resp = await es_client.search(...)
except RequestError as exc:
    if _is_text_field_agg_error(exc) and not field.endswith(".keyword"):
        logger.info(f"Panel {pid}: '{field}' is text-typed; retrying with '{field}.keyword'")
        body["aggs"] = _build_terms_agg(f"{field}.keyword")
        resp = await es_client.search(...)
    else:
        raise
```

The retry guard skips fields that are already `.keyword`-suffixed (avoids infinite loops if both forms fail).

## The non-obvious bit

`str(exc)` on `elasticsearch7.exceptions.RequestError` only includes the error code (`search_phase_execution_exception`), NOT the message body. The human-readable cause lives on `exc.info`. The helper checks both:

```python
def _is_text_field_agg_error(exc: RequestError) -> bool:
    info = getattr(exc, "info", "") or ""
    return (
        getattr(exc, "error", "") == "search_phase_execution_exception"
        and "Text fields are not optimised" in str(info)
    )
```

Matching on both means we don't false-trigger on other `search_phase_execution_exception`s like `index_not_found_exception` shard failures.

## Verified

Three constructed `RequestError` cases run in the rebuilt container:

| Case | Expected match | Actual |
|---|---|---|
| Real text-field agg error | True | ✅ True |
| Unrelated 400 (parsing_exception) | False | ✅ False |
| `search_phase_execution_exception` for a different reason (index missing, shard failure) | False | ✅ False |

Backend builds, boots clean, all routers import.

## Test plan

- [ ] On the deployment that's currently logging the error: deploy this image, refresh the failing dashboard panel
- [ ] Look for the `Panel <id>: '<field>' is text-typed in <index>; retrying with '<field>.keyword'` INFO line — confirms the retry path fired
- [ ] Confirm the panel now renders data instead of the error card
- [ ] Other dashboards that already worked should continue to work unchanged (no .keyword retry triggers because their first attempt succeeds)

## Out of scope

- Fixing the underlying index mapping (data-side work — re-apply Wazuh template / fix Graylog index-set custom field mappings). This PR is the safety net for when that hasn't happened yet.
- Updating the panel JSON templates to use `.keyword` directly. Doing that would break for indices where the field IS keyword-mapped at the top level (no subfield), so the runtime fallback is more portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)