### PR TITLE
fix: rename FastAPI Query regex= → pattern= for 0.116+ compat

### DIFF
--- a/backend/app/connectors/wazuh_manager/routes/groups.py
+++ b/backend/app/connectors/wazuh_manager/routes/groups.py
@@ -42,7 +42,7 @@ async def list_wazuh_groups(
     hash: Optional[str] = Query(
         None,
         description="Select algorithm to generate the returned checksums",
-        regex="^(md5|sha1|sha224|sha256|sha384|sha512|blake2b|blake2s|sha3_224|sha3_256|sha3_384|sha3_512)$",
+        pattern="^(md5|sha1|sha224|sha256|sha384|sha512|blake2b|blake2s|sha3_224|sha3_256|sha3_384|sha3_512)$",
     ),
     q: Optional[str] = Query(None, description="Query to filter results by"),
     select: Optional[List[str]] = Query(None, description="Select which fields to return"),
@@ -92,7 +92,7 @@ async def get_wazuh_group_files_endpoint(
     hash: Optional[str] = Query(
         None,
         description="Select algorithm to generate the returned checksums",
-        regex="^(md5|sha1|sha224|sha256|sha384|sha512|blake2b|blake2s|sha3_224|sha3_256|sha3_384|sha3_512)$",
+        pattern="^(md5|sha1|sha224|sha256|sha384|sha512|blake2b|blake2s|sha3_224|sha3_256|sha3_384|sha3_512)$",
     ),
     q: Optional[str] = Query(None, description="Query to filter results by"),
     select: Optional[List[str]] = Query(None, description="Select which fields to return"),
@@ -140,7 +140,7 @@ async def get_wazuh_group_file_endpoint(
     filename: str = Path(..., description="Filename (e.g., agent.conf)"),
     pretty: Optional[bool] = Query(False, description="Show results in human-readable format"),
     wait_for_complete: Optional[bool] = Query(False, description="Disable timeout response"),
-    type: Optional[List[str]] = Query(None, description="Type of file", regex="^(conf|rootkit_files|rootkit_trojans|rcl)$"),
+    type: Optional[List[str]] = Query(None, description="Type of file", pattern="^(conf|rootkit_files|rootkit_trojans|rcl)$"),
     raw: Optional[bool] = Query(True, description="Format response in plain text"),
 ) -> WazuhGroupFileResponse:
     """

--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -1192,7 +1192,7 @@ async def get_case_filter_options_endpoint(
 async def list_alerts_endpoint(
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1388,7 +1388,7 @@ async def list_alerts_by_status_endpoint(
     status: AlertStatus,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1445,7 +1445,7 @@ async def list_alerts_by_assigned_to_endpoint(
     assigned_to: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1497,7 +1497,7 @@ async def list_alerts_by_asset_name_endpoint(
     asset_name: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1549,7 +1549,7 @@ async def list_alerts_by_title_endpoint(
     title: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1601,7 +1601,7 @@ async def list_alerts_by_customer_code_endpoint(
     customer_code: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(customer_access_handler.require_customer_access()),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1630,7 +1630,7 @@ async def list_alerts_by_source_endpoint(
     source: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1689,7 +1689,7 @@ async def list_alerts_multiple_filters_endpoint(
     ioc_value: Optional[str] = Query(None),
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1767,7 +1767,7 @@ async def list_alerts_multiple_filters_endpoint(
 async def list_cases_endpoint(
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -2118,7 +2118,7 @@ async def list_cases_by_status_endpoint(
     status: AlertStatus,
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
-    order: str = Query("desc", regex="^(asc|desc)$"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/integrations/microsoft_patch_tuesday/routes/microsoft_patch_tuesday.py
+++ b/backend/app/integrations/microsoft_patch_tuesday/routes/microsoft_patch_tuesday.py
@@ -45,7 +45,7 @@ async def get_patch_tuesday_data(
     cycle: Optional[str] = Query(
         None,
         description="Cycle in YYYY-Mmm format (e.g., 2026-Jan). Defaults to current month.",
-        regex=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
+        pattern=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
     ),
     include_epss: bool = Query(True, description="Include EPSS scores in the response"),
     include_kev: bool = Query(True, description="Include CISA KEV data in the response"),
@@ -87,7 +87,7 @@ async def get_patch_tuesday_summary_endpoint(
     cycle: Optional[str] = Query(
         None,
         description="Cycle in YYYY-Mmm format (e.g., 2026-Jan). Defaults to current month.",
-        regex=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
+        pattern=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
     ),
     include_epss: bool = Query(True, description="Include EPSS scores in the response"),
     include_kev: bool = Query(True, description="Include CISA KEV data in the response"),
@@ -138,7 +138,7 @@ async def search_cves(
     cycle: Optional[str] = Query(
         None,
         description="Cycle in YYYY-Mmm format to limit search to. Defaults to current month.",
-        regex=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
+        pattern=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
     ),
 ) -> PatchTuesdayResponse:
     """
@@ -162,7 +162,7 @@ async def get_by_priority(
     cycle: Optional[str] = Query(
         None,
         description="Cycle in YYYY-Mmm format. Defaults to current month.",
-        regex=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
+        pattern=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
     ),
     include_epss: bool = Query(True, description="Include EPSS scores"),
     include_kev: bool = Query(True, description="Include CISA KEV data"),
@@ -245,7 +245,7 @@ async def get_kev_items(
     cycle: Optional[str] = Query(
         None,
         description="Cycle in YYYY-Mmm format. Defaults to current month.",
-        regex=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
+        pattern=r"^\d{4}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$",
     ),
 ) -> PatchTuesdayResponse:
     """


### PR DESCRIPTION
## Summary
- FastAPI 0.116 deprecates `regex=` on `Query/Path/Header/Body` in favor of `pattern=`. Every request hitting one of these routes was logging `FastAPIDeprecationWarning: 'regex' has been deprecated, please use 'pattern' instead`.
- Mechanical rename across the 18 affected `fastapi.Query(...)` callsites:
  - `backend/app/incidents/routes/db_operations.py` — 10 sort-order params
  - `backend/app/integrations/microsoft_patch_tuesday/routes/microsoft_patch_tuesday.py` — 5 `cycle` (YYYY-Mmm) params
  - `backend/app/connectors/wazuh_manager/routes/groups.py` — 3 hash-algo / file-type params
- Pydantic `Field(regex=...)` calls in `app/auth/models/users.py` are intentionally left alone — those use `sqlmodel.Field`, whose signature doesn't accept `pattern=` (boot fails with `TypeError`), and they weren't the source of the FastAPI warning. Separate concern if/when sqlmodel adds `pattern` support.

## Test plan
- [x] `python -m py_compile` on all 3 files — clean
- [x] Local backend image rebuild + `docker compose up -d --force-recreate copilot-backend`
- [x] `Application startup complete` — boots clean
- [x] `docker compose logs copilot-backend | grep -iE "FastAPIDeprecationWarning|'regex' has been deprecated"` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)