### PR TITLE
fix: tolerate Velociraptor 0.75.6 orgs() shape + ArtifactsResponse.success bool

### DIFF
--- a/backend/app/agents/velociraptor/schema/agents.py
+++ b/backend/app/agents/velociraptor/schema/agents.py
@@ -56,55 +56,12 @@ class VelociraptorClients(BaseModel):
     clients: List[VelociraptorClient]
 
 
-class Version(BaseModel):
-    name: str
-    version: str
-    commit: str
-    build_time: str
-    ci_build_url: str
-    compiler: str
-
-
-class Installer(BaseModel):
-    service_name: str
-    install_path: str
-    service_description: Optional[str] = None
-
-
-class LocalBuffer(BaseModel):
-    memory_size: int
-    disk_size: int
-    filename_linux: str
-    filename_windows: str
-    filename_darwin: str
-
-
-class ClientConfig(BaseModel):
-    server_urls: List[str]
-    ca_certificate: str
-    nonce: str
-    writeback_darwin: str
-    writeback_linux: str
-    writeback_windows: str
-    tempdir_windows: str
-    max_poll: int
-    nanny_max_connection_delay: int
-    windows_installer: Installer
-    darwin_installer: Installer
-    version: Version
-    use_self_signed_ssl: bool
-    pinned_server_name: str
-    max_upload_size: int
-    local_buffer: LocalBuffer
-
-
 class Organization(BaseModel):
     Name: str
     OrgId: str
-    # Pydantic 2 silently drops leading-underscore field annotations as
-    # PrivateAttr; alias the JSON key so it's actually parsed.
-    client_config: ClientConfig = Field(alias="_client_config")
-    model_config = ConfigDict(populate_by_name=True)
+    # _client_config is intentionally not parsed: Velociraptor 0.75.6 changed
+    # SELECT * FROM orgs() to return it as a YAML string instead of a structured
+    # object, and nothing in CoPilot reads it. Pydantic 2 ignores the unknown key.
 
 
 class VelociraptorOrganizations(BaseModel):

--- a/backend/app/connectors/velociraptor/schema/artifacts.py
+++ b/backend/app/connectors/velociraptor/schema/artifacts.py
@@ -36,7 +36,7 @@ class ArtifactsResponse(BaseModel):
     message: str = Field(...)
     # make artifacts optional
     artifacts: Optional[List[Artifacts]] = None
-    success: str = Field(...)
+    success: bool = Field(...)
 
 
 class ArtifactParametersResponse(BaseModel):


### PR DESCRIPTION
## Summary
Two Pydantic 2 strictness regressions in Velociraptor schemas, both surfaced by the local backend rebuild against the live Velociraptor 0.75.6 server:

### 1. `_client_config` shape change (orgs() sync)
- Velociraptor **0.75.6** (Dec 2025) changed `SELECT * FROM orgs()` to return `_client_config` as a YAML *string* instead of a structured dict, breaking agent sync with: `Input should be a valid dictionary or instance of ClientConfig`.
- The structured `ClientConfig` / `Version` / `Installer` / `LocalBuffer` schema chain was already dead weight — nothing in CoPilot reads `Organization.client_config` or any sub-field (verified by grep across the whole backend). Dropped them.
- Pydantic 2's default `extra='ignore'` now silently drops the unknown `_client_config` key, so any future shape change to that field is also tolerated.

### 2. `ArtifactsResponse.success` typed `str` but every caller passes `bool`
- `GET /api/artifacts` 500'd with `Input should be a valid string [type=string_type, input_value=True, input_type=bool]`.
- Pydantic 1 silently coerced `True`→`"True"`; Pydantic 2 rejects.
- Every callsite (services + routes) passes a literal `True/False` or `results["success"]` (also bool). Sibling `ArtifactParametersResponse.success` was already typed `bool`.
- Fix: change the field type to `bool`.

## Risk
- `pyvelociraptor` / gRPC transport unaffected — both fixes are parse/serialization only.
- Other agent/client schemas (`VelociraptorAgent`, `VelociraptorClient`, `VelociraptorClients`) untouched.
- No external import of the dropped types (`ClientConfig`, `Version`, `Installer`, `LocalBuffer`) anywhere in the repo.
- `success` JSON-serializes to `true`/`false` instead of `"True"`/`"False"` — frontend grep shows no consumer string-comparing it.

## Test plan
- [x] Local backend image rebuilt + recreated against Velociraptor 0.75.6
- [x] `Application startup complete` — boots clean
- [ ] Re-run agent sync — orgs fetch without 500
- [ ] `GET /api/artifacts` returns 200 with `success: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)