### PR TITLE
fix: from_attributes=True on integration schemas (Pydantic 2 ORM extraction)

### DIFF
--- a/backend/app/integrations/schema.py
+++ b/backend/app/integrations/schema.py
@@ -150,11 +150,15 @@ class IntegrationAuthKeys(BaseModel):
     auth_value: str
     subscription_id: int
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class IntegrationService(BaseModel):
     auth_type: str
     service_name: str
     id: int
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class IntegrationSubscription(BaseModel):
@@ -163,6 +167,8 @@ class IntegrationSubscription(BaseModel):
     integration_service_id: int
     integration_service: IntegrationService
     integration_auth_keys: List[IntegrationAuthKeys]  # Changed from IntegrationConfig
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CustomerIntegrations(BaseModel):
@@ -185,6 +191,8 @@ class CustomerIntegrations(BaseModel):
         description="The deployment status.",
         examples=[True],
     )
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CustomerIntegrationsResponse(BaseModel):


### PR DESCRIPTION
## Summary
`GET /api/integrations/customer_integrations/{customer_code}` 500'd on response validation:

```
8 validation errors for CustomerIntegrationsResponse
available_integrations.0
  Input should be a valid dictionary or instance of CustomerIntegrations
  [type=model_type, input_value=CustomerIntegrations(...)]
```

Two distinct classes share the name `CustomerIntegrations`:
- `app/integrations/models/customer_integration_settings.py` — SQLModel table
- `app/integrations/schema.py` — Pydantic response schema

The route hands SQLAlchemy ORM rows directly to the Pydantic response (`select(CustomerIntegrations).options(joinedload(...))` → `result.scalars().unique().all()` → `CustomerIntegrationsResponse(available_integrations=...)`). Pydantic 1 extracted attributes leniently; v2 requires explicit `from_attributes=True` (the rename of v1's `orm_mode`).

Add `model_config = ConfigDict(from_attributes=True)` to the four schemas in the joinedload chain:
- `IntegrationAuthKeys`
- `IntegrationService`
- `IntegrationSubscription`
- `CustomerIntegrations`

Sibling `CustomerIntegrationsMetaSchema` already had it — that's why the meta endpoint never broke.

## Risk
- Additive change (new config; no field shape changes).
- Other consumers that already pass dicts continue to validate as before.

## Test plan
- [ ] `GET /api/integrations/customer_integrations/{customer_code}` returns 200 with the SQLAlchemy-loaded rows serialized via the Pydantic schema
- [ ] `GET /api/integrations/customer_integrations` (the no-arg variant) still works (it goes through `process_customer_integrations` which constructs Pydantic objects explicitly, but the inner `IntegrationSubscription` chain still receives ORM rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)