### PR TITLE
fix: broad from_attributes=True on Pydantic schemas sharing a SQLModel name

### DIFF
--- a/backend/app/connectors/shuffle/schema/organizations.py
+++ b/backend/app/connectors/shuffle/schema/organizations.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
 
@@ -27,6 +28,8 @@ class SSOConfig(BaseModel):
     client_secret: str = ""
     openid_authorization: str = ""
     openid_token: str = ""
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class OrgAuth(BaseModel):

--- a/backend/app/connectors/sublime/schema/alerts.py
+++ b/backend/app/connectors/sublime/schema/alerts.py
@@ -19,6 +19,8 @@ class FlaggedRule(BaseModel):
         description="List of tags associated with the flagged rule",
     )
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class Mailbox(BaseModel):
     external_id: Optional[str] = Field(
@@ -26,6 +28,8 @@ class Mailbox(BaseModel):
         description="External identifier for the mailbox",
     )
     id: str = Field(..., description="Unique identifier for the mailbox")
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Message(BaseModel):
@@ -43,6 +47,8 @@ class TriggeredAction(BaseModel):
     id: str = Field(..., description="Unique identifier for the triggered action")
     name: str = Field(..., description="Name of the triggered action")
     type: str = Field(..., description="Type of the triggered action")
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Data(BaseModel):

--- a/backend/app/connectors/wazuh_indexer/schema/alerts.py
+++ b/backend/app/connectors/wazuh_indexer/schema/alerts.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import field_validator
 
@@ -16,6 +17,8 @@ class Alert(BaseModel):
         [],
         description="The alerts returned from the search.",
     )
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AlertsSearchBody(BaseModel):

--- a/backend/app/incidents/schema/db_operations.py
+++ b/backend/app/incidents/schema/db_operations.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import HTTPException
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import field_validator
 from pydantic import model_validator
 
@@ -513,6 +514,8 @@ class Notification(BaseModel):
     shuffle_workflow_id: str
     enabled: bool
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class NotificationResponse(BaseModel):
     notifications: Optional[List[Notification]] = []
@@ -530,6 +533,8 @@ class AITrigger(BaseModel):
     id: int
     customer_code: str
     enabled: bool
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class AITriggerResponse(BaseModel):

--- a/backend/app/network_connectors/schema.py
+++ b/backend/app/network_connectors/schema.py
@@ -143,11 +143,15 @@ class NetworkConnectorsAuthKeys(BaseModel):
     auth_value: str
     subscription_id: int
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class NetworkConnectorsService(BaseModel):
     auth_type: str
     service_name: str
     id: int
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class NetworkConnectorsSubscription(BaseModel):
@@ -156,6 +160,8 @@ class NetworkConnectorsSubscription(BaseModel):
     network_connectors_service_id: int
     network_connectors_service: NetworkConnectorsService
     network_connectors_keys: List[NetworkConnectorsAuthKeys]
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CustomerNetworkConnectors(BaseModel):
@@ -178,6 +184,8 @@ class CustomerNetworkConnectors(BaseModel):
         description="The deployment status.",
         examples=[True],
     )
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CustomerNetworkConnectorsResponse(BaseModel):


### PR DESCRIPTION
## Summary
Same Pydantic 1→2 root cause as #864: v1 extracted attributes from ORM rows leniently; v2 requires explicit `from_attributes=True` (the rename of v1's `orm_mode`). I audited every Pydantic `BaseModel` whose name collides with a `SQLModel(table=True)` and found **11 missing the config** — three endpoints were already 400'ing (network_connectors, notification, ai_trigger):

```
GET /api/network_connectors/customer_network_connectors/00001 → 400
  validation error for CustomerNetworkConnectorsResponse
  available_network_connectors.0
    Input should be a valid dictionary or instance of CustomerNetworkConnectors

GET /api/incidents/db_operations/notification/00001 → 400
  validation error for NotificationResponse
  notifications.0
    Input should be a valid dictionary or instance of Notification

GET /api/incidents/db_operations/ai_trigger/00001 → 400
  validation error for AITriggerResponse
  ai_triggers.0
    Input should be a valid dictionary or instance of AITrigger
```

## Scope
- **Confirmed-broken (6 schemas):** `CustomerNetworkConnectors`, `NetworkConnectorsSubscription`, `NetworkConnectorsService`, `NetworkConnectorsAuthKeys` in `network_connectors/schema.py`; `Notification`, `AITrigger` in `incidents/schema/db_operations.py`.
- **Defense-in-depth (5 schemas):** `FlaggedRule`, `Mailbox`, `TriggeredAction` in `sublime/schema/alerts.py`; `SSOConfig` in `shuffle/schema/organizations.py`; `Alert` in `wazuh_indexer/schema/alerts.py`. These share names with SQLModels but actually receive external-API JSON — adding the flag is harmless and prevents future regressions.

## Risk
- Pure additive ConfigDict change — no field shape changes, no breaking renames.
- Sibling schemas in these files (e.g., `CustomerIntegrationsMetaSchema`, `FlaggedRuleSchema`) already have it, so the pattern is established.
- Stacks cleanly on top of #864 (which fixes the integrations chain by the same mechanism).

## Test plan
- [x] Local backend rebuilt + recreated with this branch merged on top of #863 + #864
- [x] `Application startup complete` — boots clean
- [ ] `GET /api/network_connectors/customer_network_connectors/{customer_code}` → 200
- [ ] `GET /api/incidents/db_operations/notification/{customer_code}` → 200
- [ ] `GET /api/incidents/db_operations/ai_trigger/{customer_code}` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)