### PR TITLE
fix: agent delete proceeds even when upstream services error

### DIFF
--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -1277,12 +1277,30 @@ async def delete_agent(
     if not agent:
         raise HTTPException(status_code=404, detail=f"Agent with agent_id {agent_id} not found or access denied")
 
-    await delete_agent_wazuh(agent_id)
-    client_id = await fetch_velociraptor_id(db=session, agent_id=agent_id)
-    logger.info(f"Client ID: {client_id}")
-    if client_id != "Unknown":
-        await delete_agent_velociraptor(client_id)
+    upstream_errors: list[str] = []
+
+    try:
+        await delete_agent_wazuh(agent_id)
+    except Exception as e:
+        logger.error(f"Wazuh delete failed for agent {agent_id}: {e}")
+        upstream_errors.append(f"Wazuh: {e}")
+
+    try:
+        client_id = await fetch_velociraptor_id(db=session, agent_id=agent_id)
+        logger.info(f"Client ID: {client_id}")
+        if client_id != "Unknown":
+            await delete_agent_velociraptor(client_id)
+    except Exception as e:
+        logger.error(f"Velociraptor delete failed for agent {agent_id}: {e}")
+        upstream_errors.append(f"Velociraptor: {e}")
+
     await delete_agent_from_database(db=session, agent_id=agent_id)
+
+    if upstream_errors:
+        return AgentModifyResponse(
+            success=True,
+            message=f"Agent {agent_id} deleted from CoPilot; upstream services reported: {'; '.join(upstream_errors)}",
+        )
     return AgentModifyResponse(
         success=True,
         message=f"Agent {agent_id} deleted successfully",

--- a/backend/app/agents/velociraptor/services/agents.py
+++ b/backend/app/agents/velociraptor/services/agents.py
@@ -214,33 +214,6 @@ def check_flow_success(flow: dict, client_id: str) -> dict:
         )
 
 
-def check_client_in_results(results: dict, client_id: str) -> dict:
-    """
-    Checks if a client is present in the results dictionary.
-
-    Args:
-        results (dict): The dictionary containing the results.
-        client_id (str): The ID of the client to check.
-
-    Returns:
-        dict: A dictionary with a success message if the client is found, otherwise an error message.
-    """
-    if results["results"] == []:
-        logger.info(f"Successfully deleted velociraptor client {client_id}")
-        return {
-            "message": f"Successfully deleted velociraptor client {client_id}",
-            "success": True,
-        }
-
-    for result in results["results"]:
-        if result["client_id"] == client_id:
-            logger.error(f"Failed to delete velociraptor client {client_id}")
-            return handle_exception(
-                e="Failed to delete velociraptor client",
-                client_id=client_id,
-            )
-
-
 def handle_exception(e: Exception, client_id: str) -> dict:
     """
     Handles exceptions that occur during the deletion of a Velociraptor client.
@@ -274,7 +247,6 @@ async def delete_agent_velociraptor(client_id: str) -> AgentModifyResponse:
     """
     try:
         await delete_client(client_id=client_id)
-        await ensure_client_deleted(client_id=client_id)
         return AgentModifyResponse(success=True, message="Agent deleted successfully")
     except Exception as e:
         return handle_exception(e, client_id)
@@ -301,35 +273,3 @@ async def delete_client(client_id: str) -> dict:
         return handle_exception(e, client_id)
 
 
-async def ensure_client_deleted(client_id: str) -> dict:
-    """
-    Ensures that a client is deleted from the server.
-
-    Args:
-        client_id (str): The ID of the client to be deleted.
-
-    Returns:
-        dict: The result of the deletion operation.
-    """
-    universal_service = await UniversalService.create("Velociraptor")
-    try:
-        query = create_query(
-            "SELECT collect_client(client_id='server', artifacts=['Server.Information.Clients'], env=dict()) FROM scope()",
-        )
-        flow = execute_query(universal_service, query)
-        flow_id = (
-            flow.get("results")[0]
-            .get(
-                "collect_client(client_id='server', artifacts=['Server.Information.Clients'], env=dict())",
-            )
-            .get("flow_id")
-        )
-
-        results = universal_service.read_collection_results(
-            client_id=client_id,
-            flow_id=flow_id,
-            artifact="Server.Information.Clients",
-        )
-        return check_client_in_results(results, client_id)
-    except Exception as e:
-        return handle_exception(e, client_id)

--- a/backend/app/agents/velociraptor/services/agents.py
+++ b/backend/app/agents/velociraptor/services/agents.py
@@ -271,5 +271,3 @@ async def delete_client(client_id: str) -> dict:
         return check_flow_success(flow, client_id)
     except Exception as e:
         return handle_exception(e, client_id)
-
-


### PR DESCRIPTION
## Summary
`DELETE /api/agents/{id}/delete` was 500'ing and leaving agents stuck in CoPilot's database. Two stacked issues:

### 1. Broken Velociraptor verification step
After the actual delete (`Server.Utils.DeleteClient` artifact) succeeded, `ensure_client_deleted` re-queried Velociraptor via the artifact `Server.Information.Clients` to confirm. That artifact doesn't exist on Velociraptor 0.75.6 — the server logs `Parameter refers to an unknown artifact` — so the query returns `None`, and `.get("flow_id")` on `None` crashes:

```
2026-05-09 16:40:20.611 | ERROR | ... handle_exception: Failed to delete client C.67fac759c7c223ad: 'NoneType' object has no attribute 'get'
INFO: 172.18.0.3:46272 - "DELETE /api/agents/569/delete HTTP/1.1" 500 Internal Server Error
```

The verification was redundant — `delete_client` already raises on a failed delete, and Velociraptor's eventual consistency made the poll flaky regardless. Dropped `ensure_client_deleted` and the now-unused `check_client_in_results`.

### 2. Brittle delete route
Wazuh → Velociraptor → CoPilot DB ran sequentially with no error isolation. Any upstream failure (Velociraptor unknown-artifact crash, network blip, client already gone, etc.) blocked the CoPilot bookkeeping delete and left stale rows. Wrapped Wazuh and Velociraptor in `try`/`except`, log + collect into `upstream_errors`, and always proceed to the DB delete. Success responses surface upstream issues in the message but don't fail the request.

## Risk
- Net –42 lines.
- The verification step removal is safe: `delete_client` raises on failure independently, and there's no callsite that depended on `ensure_client_deleted`'s polling behavior.
- The route hardening makes a previously-blocking error non-blocking. Bookkeeping consistency improves at the cost of allowing CoPilot's view to diverge from Wazuh/Velociraptor when those services are unhealthy — that's the intended trade-off (the user reported the prior behavior as a bug).

## Test plan
- [x] Local backend rebuilt + recreated against Velociraptor 0.75.6
- [x] `Application startup complete` — boots clean
- [x] `DELETE /api/agents/{id}/delete` for an agent that triggers the unknown-artifact crash → returns 200, agent gone from CoPilot DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)