### PR TITLE
feat(event-sources): SOC portal column config UI + render (issue #833 slice 2/3)

### DIFF
--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -543,7 +543,16 @@ class EventSources(SQLModel, table=True):
         if hasattr(source_data, "enabled"):
             self.enabled = source_data.enabled
         if hasattr(source_data, "displayed_columns"):
-            self.displayed_columns = source_data.displayed_columns
+            # Pydantic deserializes incoming JSON into DisplayColumn instances; the JSON
+            # column needs plain dicts, otherwise SQLAlchemy's json_serializer raises
+            # "Object of type DisplayColumn is not JSON serializable" on commit.
+            cols = source_data.displayed_columns
+            if cols is None:
+                self.displayed_columns = None
+            else:
+                self.displayed_columns = [
+                    c.model_dump() if hasattr(c, "model_dump") else c for c in cols
+                ]
         self.updated_at = datetime.utcnow()
 
 

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -542,11 +542,7 @@ class EventSources(SQLModel, table=True):
         SQLAlchemy's json_serializer otherwise raises "Object of type
         DisplayColumn is not JSON serializable" on commit.
         """
-        data = (
-            source_data.model_dump(exclude_unset=True)
-            if hasattr(source_data, "model_dump")
-            else {}
-        )
+        data = source_data.model_dump(exclude_unset=True) if hasattr(source_data, "model_dump") else {}
         for field in ("name", "index_pattern", "event_type", "time_field", "enabled", "displayed_columns"):
             if field in data:
                 setattr(self, field, data[field])

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -532,27 +532,24 @@ class EventSources(SQLModel, table=True):
     customer: Optional["Customers"] = Relationship()
 
     def update_from_model(self, source_data):
-        if hasattr(source_data, "name"):
-            self.name = source_data.name
-        if hasattr(source_data, "index_pattern"):
-            self.index_pattern = source_data.index_pattern
-        if hasattr(source_data, "event_type"):
-            self.event_type = source_data.event_type
-        if hasattr(source_data, "time_field"):
-            self.time_field = source_data.time_field
-        if hasattr(source_data, "enabled"):
-            self.enabled = source_data.enabled
-        if hasattr(source_data, "displayed_columns"):
-            # Pydantic deserializes incoming JSON into DisplayColumn instances; the JSON
-            # column needs plain dicts, otherwise SQLAlchemy's json_serializer raises
-            # "Object of type DisplayColumn is not JSON serializable" on commit.
-            cols = source_data.displayed_columns
-            if cols is None:
-                self.displayed_columns = None
-            else:
-                self.displayed_columns = [
-                    c.model_dump() if hasattr(c, "model_dump") else c for c in cols
-                ]
+        """Apply only the fields the caller explicitly set on source_data.
+
+        Pydantic 2's `model_dump(exclude_unset=True)` filters to fields the
+        client actually sent, so partial updates (e.g. PUT with just
+        `displayed_columns`) don't clobber unrelated columns to NULL. The
+        same dump recursively flattens nested Pydantic models (DisplayColumn)
+        into plain dicts, which is what the JSON column requires —
+        SQLAlchemy's json_serializer otherwise raises "Object of type
+        DisplayColumn is not JSON serializable" on commit.
+        """
+        data = (
+            source_data.model_dump(exclude_unset=True)
+            if hasattr(source_data, "model_dump")
+            else {}
+        )
+        for field in ("name", "index_pattern", "event_type", "time_field", "enabled", "displayed_columns"):
+            if field in data:
+                setattr(self, field, data[field])
         self.updated_at = datetime.utcnow()
 
 

--- a/frontend/src/api/endpoints/siem.ts
+++ b/frontend/src/api/endpoints/siem.ts
@@ -6,7 +6,7 @@ import type {
 	PanelDataResponse
 } from "@/types/dashboards.d"
 import type { EventSearchResult, FieldMapping } from "@/types/events.d"
-import type { EventSource } from "@/types/eventSources.d"
+import type { DisplayColumn, EventSource } from "@/types/eventSources.d"
 import type { FlaskBaseResponse } from "@/types/flask.d"
 import { HttpClient } from "../httpClient"
 
@@ -17,6 +17,7 @@ export interface EventSourceCreatePayload {
 	event_type: string
 	time_field: string
 	enabled: boolean
+	displayed_columns?: DisplayColumn[] | null
 }
 
 export interface EventSourceUpdatePayload {
@@ -25,6 +26,7 @@ export interface EventSourceUpdatePayload {
 	event_type?: string
 	time_field?: string
 	enabled?: boolean
+	displayed_columns?: DisplayColumn[] | null
 }
 
 export default {

--- a/frontend/src/components/events/ColumnConfigModal.vue
+++ b/frontend/src/components/events/ColumnConfigModal.vue
@@ -1,0 +1,229 @@
+<template>
+	<n-modal
+		v-model:show="showModel"
+		preset="card"
+		:title="`Configure columns: ${eventSource?.name ?? ''}`"
+		style="width: 720px; max-width: 92vw"
+		:bordered="false"
+		:mask-closable="false"
+	>
+		<div class="flex flex-col gap-4">
+			<!-- Active columns -->
+			<div class="flex flex-col gap-2">
+				<div class="flex items-center justify-between">
+					<span class="text-sm font-medium">Active columns ({{ localColumns.length }})</span>
+					<span class="text-xs opacity-60">Order matches table left-to-right</span>
+				</div>
+
+				<div
+					v-if="!localColumns.length"
+					class="rounded border border-dashed p-4 text-center text-sm opacity-60"
+				>
+					No columns configured. Defaults from the table will be shown.
+				</div>
+
+				<div v-else class="flex flex-col gap-1">
+					<div
+						v-for="(col, idx) in localColumns"
+						:key="col.key"
+						class="bg-default flex items-center gap-2 rounded border px-2 py-1.5"
+					>
+						<span class="text-xs opacity-50" style="width: 24px">{{ idx + 1 }}</span>
+						<n-input
+							v-model:value="col.label"
+							size="small"
+							placeholder="Column header"
+							style="flex: 1; max-width: 200px"
+						/>
+						<span
+							class="font-mono text-xs opacity-60"
+							style="
+								flex: 1;
+								min-width: 0;
+								overflow: hidden;
+								text-overflow: ellipsis;
+								white-space: nowrap;
+							"
+						>
+							{{ col.key }}
+						</span>
+						<n-button size="tiny" :disabled="idx === 0" @click="moveColumn(idx, -1)">
+							<template #icon>
+								<Icon :name="ArrowUpIcon" :size="14" />
+							</template>
+						</n-button>
+						<n-button size="tiny" :disabled="idx === localColumns.length - 1" @click="moveColumn(idx, 1)">
+							<template #icon>
+								<Icon :name="ArrowDownIcon" :size="14" />
+							</template>
+						</n-button>
+						<n-button size="tiny" type="error" quaternary @click="removeColumn(idx)">
+							<template #icon>
+								<Icon :name="CloseIcon" :size="14" />
+							</template>
+						</n-button>
+					</div>
+				</div>
+			</div>
+
+			<!-- Add column from available fields -->
+			<div class="flex flex-col gap-2">
+				<span class="text-sm font-medium">Add a column</span>
+				<n-input v-model:value="fieldFilter" placeholder="Filter available fields..." clearable size="small">
+					<template #prefix>
+						<Icon :name="SearchIcon" :size="14" class="opacity-50" />
+					</template>
+				</n-input>
+				<div class="max-h-60 overflow-y-auto rounded border">
+					<div
+						v-for="field in filteredFields"
+						:key="field.field"
+						class="hover:bg-hover-005 flex cursor-pointer items-center justify-between gap-2 px-2 py-1.5 text-sm"
+						@click="addColumn(field.field)"
+					>
+						<span class="font-mono">{{ field.field }}</span>
+						<span class="flex items-center gap-2">
+							<span class="text-xs opacity-50">{{ field.type }}</span>
+							<n-button size="tiny" quaternary>
+								<template #icon>
+									<Icon :name="AddIcon" :size="14" />
+								</template>
+							</n-button>
+						</span>
+					</div>
+					<div v-if="!filteredFields.length" class="p-3 text-center text-sm opacity-60">
+						{{ fieldMappings.length ? "No fields match your filter." : "Loading available fields..." }}
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<template #footer>
+			<div class="flex items-center justify-between gap-2">
+				<n-button quaternary type="warning" @click="resetToDefaults">Reset to defaults</n-button>
+				<div class="flex gap-2">
+					<n-button @click="showModel = false">Cancel</n-button>
+					<n-button type="primary" :loading="saving" @click="onSave">Save</n-button>
+				</div>
+			</div>
+		</template>
+	</n-modal>
+</template>
+
+<script setup lang="ts">
+import type { FieldMapping } from "@/types/events.d"
+import type { DisplayColumn, EventSource } from "@/types/eventSources.d"
+import { NButton, NInput, NModal, useMessage } from "naive-ui"
+import { computed, ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+
+const props = defineProps<{
+	show: boolean
+	eventSource: EventSource | null
+	fieldMappings: FieldMapping[]
+}>()
+
+const emit = defineEmits<{
+	"update:show": [value: boolean]
+	saved: [columns: DisplayColumn[] | null]
+}>()
+
+const SearchIcon = "carbon:search"
+const AddIcon = "carbon:add"
+const CloseIcon = "carbon:close"
+const ArrowUpIcon = "carbon:arrow-up"
+const ArrowDownIcon = "carbon:arrow-down"
+
+const message = useMessage()
+
+const showModel = computed({
+	get: () => props.show,
+	set: v => emit("update:show", v)
+})
+
+const localColumns = ref<DisplayColumn[]>([])
+const fieldFilter = ref("")
+const saving = ref(false)
+
+// Re-seed when the modal opens or the source changes
+watch(
+	() => [props.show, props.eventSource?.id] as const,
+	([show]) => {
+		if (show && props.eventSource) {
+			localColumns.value = (props.eventSource.displayed_columns ?? []).map(c => ({
+				key: c.key,
+				label: c.label,
+				width: c.width ?? null
+			}))
+			fieldFilter.value = ""
+		}
+	},
+	{ immediate: true }
+)
+
+const usedKeys = computed(() => new Set(localColumns.value.map(c => c.key)))
+
+const filteredFields = computed(() => {
+	const q = fieldFilter.value.trim().toLowerCase()
+	const all = props.fieldMappings.filter(f => !usedKeys.value.has(f.field))
+	if (!q) return all.slice(0, 50)
+	return all.filter(f => f.field.toLowerCase().includes(q)).slice(0, 50)
+})
+
+function defaultLabelFor(fieldPath: string): string {
+	// Take the last dotted segment, replace _ with spaces, title-case
+	const tail = fieldPath.split(".").pop() ?? fieldPath
+	return tail.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function addColumn(fieldPath: string) {
+	if (usedKeys.value.has(fieldPath)) return
+	localColumns.value.push({
+		key: fieldPath,
+		label: defaultLabelFor(fieldPath),
+		width: null
+	})
+}
+
+function removeColumn(idx: number) {
+	localColumns.value.splice(idx, 1)
+}
+
+function moveColumn(idx: number, delta: number) {
+	const target = idx + delta
+	if (target < 0 || target >= localColumns.value.length) return
+	const [item] = localColumns.value.splice(idx, 1)
+	localColumns.value.splice(target, 0, item)
+}
+
+function resetToDefaults() {
+	localColumns.value = []
+}
+
+function onSave() {
+	if (!props.eventSource) return
+	saving.value = true
+
+	// Empty list means "use defaults" — send null so the backend stores NULL.
+	const payload = localColumns.value.length ? localColumns.value : null
+
+	Api.siem
+		.updateEventSource(props.eventSource.id, { displayed_columns: payload })
+		.then(res => {
+			if (res.data.success) {
+				message.success("Columns saved")
+				emit("saved", payload)
+				showModel.value = false
+			} else {
+				message.warning(res.data?.message || "Failed to save columns")
+			}
+		})
+		.catch(err => {
+			message.error(err.response?.data?.message || "Failed to save columns")
+		})
+		.finally(() => {
+			saving.value = false
+		})
+}
+</script>

--- a/frontend/src/components/events/EventSearch.vue
+++ b/frontend/src/components/events/EventSearch.vue
@@ -64,6 +64,17 @@
 						</template>
 						Search
 					</n-button>
+					<n-button
+						quaternary
+						:disabled="!selectedEventSource"
+						title="Configure which columns to display for this event source"
+						@click="showColumnConfig = true"
+					>
+						<template #icon>
+							<Icon :name="SettingsIcon" :size="16" />
+						</template>
+						Columns
+					</n-button>
 				</div>
 
 				<!-- Query Bar with Autocomplete -->
@@ -138,6 +149,14 @@
 			@filter-add="addFilterFromDetail"
 			@filter-exclude="excludeFilterFromDetail"
 		/>
+
+		<!-- Column Config Modal -->
+		<ColumnConfigModal
+			v-model:show="showColumnConfig"
+			:event-source="selectedEventSource"
+			:field-mappings
+			@saved="onColumnsSaved"
+		/>
 	</div>
 </template>
 
@@ -145,18 +164,20 @@
 import type { DataTableColumns } from "naive-ui"
 import type { Customer } from "@/types/customers.d"
 import type { EventSearchResult, FieldMapping } from "@/types/events.d"
-import type { EventSource } from "@/types/eventSources.d"
+import type { DisplayColumn, EventSource } from "@/types/eventSources.d"
 import { NAlert, NButton, NCard, NDataTable, NDatePicker, NEmpty, NInput, NSelect, NSpin, useMessage } from "naive-ui"
 import { computed, h, nextTick, onBeforeMount, ref } from "vue"
 import { useRoute } from "vue-router"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
+import ColumnConfigModal from "./ColumnConfigModal.vue"
 import EventDetailDrawer from "./EventDetailDrawer.vue"
 
 const route = useRoute()
 
 const SearchIcon = "carbon:search"
 const CodeIcon = "carbon:code"
+const SettingsIcon = "carbon:settings"
 const FIELD_TOKEN_REGEX = /(?:^|[\s(])([a-z_][\w.]*)$/i
 
 const message = useMessage()
@@ -200,6 +221,10 @@ const eventSourceOptions = computed(() =>
 
 const showNoSourcesWarning = computed(
 	() => selectedCustomerCode.value && !loadingEventSources.value && eventSourcesList.value.length === 0
+)
+
+const selectedEventSource = computed<EventSource | null>(
+	() => eventSourcesList.value.find(s => s.name === selectedSourceName.value) ?? null
 )
 
 // -- Field mappings / autocomplete --
@@ -397,67 +422,112 @@ function loadMoreEvents() {
 }
 
 // -- Table columns --
-const columns = computed<DataTableColumns<EventSearchResult>>(() => {
-	const baseColumns: DataTableColumns<EventSearchResult> = [
-		{
-			title: "Timestamp",
-			key: "timestamp",
-			width: 180,
-			sorter: (a, b) => {
-				const timeA = a.timestamp || a["@timestamp"] || ""
-				const timeB = b.timestamp || b["@timestamp"] || ""
-				return new Date(timeA).getTime() - new Date(timeB).getTime()
-			},
-			render(row) {
-				const ts = row.timestamp || row["@timestamp"]
-				if (!ts) return "-"
-				return new Date(ts).toLocaleString()
-			}
+// Default columns we fall back to when an event source has no displayed_columns
+// configured. These keep the prior behaviour for un-customised sources.
+const defaultColumns: DataTableColumns<EventSearchResult> = [
+	{
+		title: "Timestamp",
+		key: "timestamp",
+		width: 180,
+		sorter: (a, b) => {
+			const timeA = a.timestamp || a["@timestamp"] || ""
+			const timeB = b.timestamp || b["@timestamp"] || ""
+			return new Date(timeA).getTime() - new Date(timeB).getTime()
 		},
-		{
-			title: "Source",
-			key: "agent_name",
-			width: 140,
-			ellipsis: { tooltip: true },
-			render(row) {
-				return row.agent_name || row.source || "-"
-			}
-		},
-		{
-			title: "Rule",
-			key: "rule_description",
-			ellipsis: { tooltip: true },
-			render(row) {
-				return row.rule_description || row.rule_id || "-"
-			}
-		},
-		{
-			title: "Level",
-			key: "rule_level",
-			width: 80,
-			sorter: (a, b) => (Number(a.rule_level) || 0) - (Number(b.rule_level) || 0),
-			render(row) {
-				if (row.rule_level === undefined || row.rule_level === null) return "-"
-				const level = Number(row.rule_level)
-				let type: "default" | "warning" | "error" | "success" | "info" = "default"
-				if (level >= 12) type = "error"
-				else if (level >= 8) type = "warning"
-				else if (level >= 4) type = "info"
-				return h("span", { class: `level-${type}` }, String(row.rule_level))
-			}
-		},
-		{
-			title: "Summary",
-			key: "full_log",
-			ellipsis: { tooltip: true },
-			render(row) {
-				return row.full_log || row.data || row.message || "-"
-			}
+		render(row) {
+			const ts = row.timestamp || row["@timestamp"]
+			if (!ts) return "-"
+			return new Date(ts).toLocaleString()
 		}
-	]
+	},
+	{
+		title: "Source",
+		key: "agent_name",
+		width: 140,
+		ellipsis: { tooltip: true },
+		render(row) {
+			return row.agent_name || row.source || "-"
+		}
+	},
+	{
+		title: "Rule",
+		key: "rule_description",
+		ellipsis: { tooltip: true },
+		render(row) {
+			return row.rule_description || row.rule_id || "-"
+		}
+	},
+	{
+		title: "Level",
+		key: "rule_level",
+		width: 80,
+		sorter: (a, b) => (Number(a.rule_level) || 0) - (Number(b.rule_level) || 0),
+		render(row) {
+			if (row.rule_level === undefined || row.rule_level === null) return "-"
+			const level = Number(row.rule_level)
+			let type: "default" | "warning" | "error" | "success" | "info" = "default"
+			if (level >= 12) type = "error"
+			else if (level >= 8) type = "warning"
+			else if (level >= 4) type = "info"
+			return h("span", { class: `level-${type}` }, String(row.rule_level))
+		}
+	},
+	{
+		title: "Summary",
+		key: "full_log",
+		ellipsis: { tooltip: true },
+		render(row) {
+			return row.full_log || row.data || row.message || "-"
+		}
+	}
+]
 
-	return baseColumns
+/** Walk a dotted path (e.g. "agent.name") through a nested object. */
+function getNestedValue(obj: EventSearchResult, path: string): unknown {
+	return path.split(".").reduce<unknown>((acc, segment) => {
+		if (acc && typeof acc === "object") {
+			return (acc as Record<string, unknown>)[segment]
+		}
+		return undefined
+	}, obj)
+}
+
+function formatCellValue(val: unknown): string {
+	if (val === undefined || val === null || val === "") return "-"
+	if (Array.isArray(val)) return val.map(v => (v === null || v === undefined ? "" : String(v))).join(", ")
+	if (typeof val === "object") return JSON.stringify(val)
+	return String(val)
+}
+
+function buildColumnFromConfig(col: DisplayColumn): DataTableColumns<EventSearchResult>[number] {
+	return {
+		title: col.label || col.key,
+		key: col.key,
+		width: col.width || undefined,
+		ellipsis: { tooltip: true },
+		render(row: EventSearchResult) {
+			return formatCellValue(getNestedValue(row, col.key))
+		}
+	}
+}
+
+const columns = computed<DataTableColumns<EventSearchResult>>(() => {
+	const configured = selectedEventSource.value?.displayed_columns
+	if (configured && configured.length > 0) {
+		return configured.map(buildColumnFromConfig)
+	}
+	return defaultColumns
 })
+
+// -- Configure columns modal --
+const showColumnConfig = ref(false)
+
+function onColumnsSaved(saved: DisplayColumn[] | null) {
+	// Patch the local list so the table re-renders without a network round-trip.
+	if (selectedEventSource.value) {
+		selectedEventSource.value.displayed_columns = saved
+	}
+}
 
 // -- Event detail --
 const showDetailDrawer = ref(false)

--- a/frontend/src/types/eventSources.d.ts
+++ b/frontend/src/types/eventSources.d.ts
@@ -1,5 +1,14 @@
 export type EventType = "EDR" | "EPP" | "Cloud Integration" | "Network Security"
 
+export interface DisplayColumn {
+	/** Field path in the event _source object (dotted, e.g. "agent.name"). */
+	key: string
+	/** Human-readable column header. */
+	label: string
+	/** Optional pixel width hint. */
+	width?: number | null
+}
+
 export interface EventSource {
 	id: number
 	customer_code: string
@@ -8,6 +17,7 @@ export interface EventSource {
 	event_type: EventType
 	time_field: string
 	enabled: boolean
+	displayed_columns?: DisplayColumn[] | null
 	created_at: string
 	updated_at: string
 }


### PR DESCRIPTION
## Summary
Slice 2 of [issue #833](https://github.com/socfortress/CoPilot/issues/833). Builds on slice 1 (#868) which added the `displayed_columns` storage. This slice puts the configure-columns flow in front of SOC users on the Event Search view and renders the configured columns on the table. Slice 3 will mirror the render path on the customer portal.

## What's in this slice

### Frontend
- **`ColumnConfigModal.vue`** — new modal. Lets a SOC user pick fields from the source's available mappings, edit the column header label, reorder via ↑/↓ buttons, and remove. "Reset to defaults" clears the saved layout (sends `null`) so the table falls back to the hardcoded defaults. Save calls `PUT /siem/event_sources/{id}` with `{displayed_columns: [...] | null}`.
- **`EventSearch.vue`** — new "Columns" button in the filters bar (gated on a selected event source). The hardcoded `baseColumns` array is preserved as `defaultColumns` and used as the fallback. The active `columns` computed builds from `selectedEventSource.displayed_columns` when present. Cell rendering walks the dotted field path (`agent.name`, `data.win.eventdata.targetUserName`) and formats arrays/objects sensibly.
- **Types**: new `DisplayColumn` interface; `EventSource.displayed_columns` is now `DisplayColumn[] | null`.
- **API**: `EventSourceCreatePayload` and `EventSourceUpdatePayload` accept the new field.

### Backend (latent slice-1 fixes exposed by the SOC UI)
- **Partial updates now work** — `update_from_model` switched to `model_dump(exclude_unset=True)` so a PUT with only `displayed_columns` no longer clobbers the rest of the row to NULL and trips `Column 'name' cannot be null`. The Add/Edit Event Source dialog never tripped this because it always sends the full form.
- **`DisplayColumn` instances get dumped to dicts** — same `model_dump()` call recursively flattens nested Pydantic models, fixing `Object of type DisplayColumn is not JSON serializable` on the JSON column. (Earlier attempt special-cased `displayed_columns`; the broader `exclude_unset` rewrite collapses both fixes into one.)

## Test plan
- [x] `pnpm type-check` — no new errors (only pre-existing in `MatrixView.vue`)
- [x] Configure Columns button appears on the filters bar when a source is selected
- [x] Modal lists available fields, filter works, ↑/↓ reorder works, ✕ remove works
- [x] Save persists; reopening the modal shows the saved layout
- [x] Table renders the saved columns with dotted-path field resolution and array/object formatting
- [x] "Reset to defaults" clears storage; table falls back to the prior 5-column hardcoded layout
- [x] Other CRUD on event sources (Add/Edit/Delete via the management tab) still works after the `update_from_model` rewrite

## Coming next
Slice 3: customer portal mirrors the same render path (read-only — no config UI), so end customers see whatever the SOC chose for each source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)