### PR TITLE
feat(event-sources): customer-portal renders configured columns (issue #833 slice 3/3)

### DIFF
--- a/customer-portal/src/components/eventSearch/List.vue
+++ b/customer-portal/src/components/eventSearch/List.vue
@@ -57,10 +57,10 @@
 </template>
 
 <script setup lang="tsx">
-import type { DataTableColumns, TagProps } from "naive-ui"
+import type { DataTableColumn, DataTableColumns, TagProps } from "naive-ui"
 import type { SearchFormLoad, SearchFormParams } from "@/components/eventSearch/SearchForm.vue"
 import type { ApiError } from "@/types/common"
-import type { EventSearchQueryParams, EventSearchResult } from "@/types/siem"
+import type { DisplayColumn, EventSearchQueryParams, EventSearchResult, EventSourceItem } from "@/types/siem"
 import { useElementSize } from "@vueuse/core"
 import { NAlert, NButton, NDataTable, NEmpty, useMessage } from "naive-ui"
 import { computed, ref, useTemplateRef } from "vue"
@@ -95,7 +95,43 @@ function selectEvent(event: EventSearchResult) {
 const { width: headerWidthRef } = useElementSize(useTemplateRef("headerRef"))
 const simpleMode = computed(() => headerWidthRef.value < 600)
 
-const columns = computed<DataTableColumns<EventSearchResult>>(() => [
+const selectedEventSource = computed<EventSourceItem | null>(() => {
+	const sourceName = searchFormParams.value?.sourceName
+	const sources = searchFormLoad.value?.eventSources
+	if (!sourceName || !sources) return null
+	return sources.find(s => s.name === sourceName) ?? null
+})
+
+/** Walk a dotted path (e.g. "agent.name") through a nested object. */
+function getNestedValue(obj: EventSearchResult, path: string): unknown {
+	return path.split(".").reduce<unknown>((acc, segment) => {
+		if (acc && typeof acc === "object") {
+			return (acc as Record<string, unknown>)[segment]
+		}
+		return undefined
+	}, obj)
+}
+
+function formatCellValue(val: unknown): string {
+	if (val === undefined || val === null || val === "") return "-"
+	if (Array.isArray(val)) return val.map(v => (v === null || v === undefined ? "" : String(v))).join(", ")
+	if (typeof val === "object") return JSON.stringify(val)
+	return String(val)
+}
+
+function buildColumnFromConfig(col: DisplayColumn): DataTableColumn<EventSearchResult> {
+	return {
+		title: col.label || col.key,
+		key: col.key,
+		width: col.width || undefined,
+		ellipsis: { tooltip: true },
+		render: row => <div>{formatCellValue(getNestedValue(row, col.key))}</div>
+	}
+}
+
+// Defaults preserved from the original hardcoded layout so behaviour is unchanged
+// for event sources that haven't been configured yet.
+const defaultColumns = computed<DataTableColumn<EventSearchResult>[]>(() => [
 	{
 		title: "Timestamp",
 		key: "Timestamp",
@@ -124,26 +160,34 @@ const columns = computed<DataTableColumns<EventSearchResult>>(() => [
 		title: "Rule",
 		key: "Rule",
 		render: row => <div>{row.rule_description || row.rule?.description || "-"}</div>
-	},
-	{
-		title: "Actions",
-		key: "actions",
-		width: 150,
-		fixed: simpleMode.value ? undefined : "right",
-		render: row => {
-			return (
-				<NButton
-					onClick={() => selectEvent(row)}
-					v-slots={{
-						icon: () => <Icon name="carbon:view" />
-					}}
-				>
-					View Details
-				</NButton>
-			)
-		}
 	}
 ])
+
+const actionsColumn = computed<DataTableColumn<EventSearchResult>>(() => ({
+	title: "Actions",
+	key: "actions",
+	width: 150,
+	fixed: simpleMode.value ? undefined : "right",
+	render: row => (
+		<NButton
+			onClick={() => selectEvent(row)}
+			v-slots={{
+				icon: () => <Icon name="carbon:view" />
+			}}
+		>
+			View Details
+		</NButton>
+	)
+}))
+
+const columns = computed<DataTableColumns<EventSearchResult>>(() => {
+	const configured = selectedEventSource.value?.displayed_columns
+	const dataColumns =
+		configured && configured.length > 0 ? configured.map(buildColumnFromConfig) : defaultColumns.value
+	// Always keep the View Details action at the right edge — it's the only way
+	// to open the event drawer from the table.
+	return [...dataColumns, actionsColumn.value]
+})
 
 function handleSearchFormSearch(params: SearchFormParams) {
 	searchFormParams.value = params

--- a/customer-portal/src/types/siem.ts
+++ b/customer-portal/src/types/siem.ts
@@ -1,3 +1,12 @@
+export interface DisplayColumn {
+	/** Field path in the event _source object (dotted, e.g. "agent.name"). */
+	key: string
+	/** Human-readable column header. */
+	label: string
+	/** Optional pixel width hint. */
+	width?: number | null
+}
+
 export interface EventSourceItem {
 	id: number
 	customer_code: string
@@ -6,6 +15,7 @@ export interface EventSourceItem {
 	event_type: string
 	time_field: string
 	enabled: boolean
+	displayed_columns?: DisplayColumn[] | null
 	created_at: string
 	updated_at: string
 }


### PR DESCRIPTION
## Summary
Final slice of [issue #833](https://github.com/socfortress/CoPilot/issues/833). Customer portal now mirrors the SOC portal's column-render path (read-only) — end customers see whatever the SOC admin configured per event source via slice 2 (#869), with a graceful fallback to the prior hardcoded 5-column layout when nothing is configured.

No config UI on the customer portal by design — SOC admins are the only ones who set columns, customers just consume them. Slice 1's `GET /siem/event_sources/{customer_code}` already returns `displayed_columns` since #868, so no API plumbing was needed.

## Changes
- **`customer-portal/src/types/siem.ts`** — new `DisplayColumn` interface; `EventSourceItem.displayed_columns` is now `DisplayColumn[] | null`.
- **`customer-portal/src/components/eventSearch/List.vue`**:
  - `selectedEventSource` resolved by looking up the picked `sourceName` in `searchFormLoad.eventSources` (no SearchForm.vue plumbing needed since that data already flows up).
  - `getNestedValue` / `formatCellValue` helpers — same dotted-path walker + array/object formatting as the SOC portal.
  - Hardcoded data columns extracted into `defaultColumns`; the **View Details** action is split out as `actionsColumn` so it always pins to the right edge regardless of which data columns precede it (Actions is customer-portal-specific — SOC portal doesn't have it).
  - The active `columns` computed picks configured layout when present, defaults otherwise, then appends the actions column.

## Test plan
- [x] `pnpm type-check` — no new errors (only pre-existing `NEllipsis` import in `alerts/List.vue`)
- [x] Source with no configured columns → table renders the original 5-column layout (Timestamp / Level / Source / Rule / Actions)
- [x] Source with SOC-configured columns → customer-portal renders those columns + Actions on the right
- [x] Configuring columns in SOC portal then reloading the customer portal → new layout takes effect

## Closes
Closes #833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)