### PR TITLE
fix: load .env into os.environ after environs 9 → 15 bump

### DIFF
--- a/backend/app/data_store/data_store_session.py
+++ b/backend/app/data_store/data_store_session.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
+from dotenv import load_dotenv
 from environs import Env
 from loguru import logger
 from miniopy_async import Minio
 
+# Repo root is four parents up (backend/app/data_store/data_store_session.py).
+# environs >= 14 stopped mutating os.environ from read_env(); use python-dotenv
+# so os.environ.get() callsites elsewhere in the app see .env values.
+_DOTENV_PATH = Path(__file__).parent.parent.parent.parent / ".env"
+load_dotenv(_DOTENV_PATH)
 env = Env()
-env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
-logger.info(f"Loading environment from {Path(__file__).parent.parent.parent.parent / '.env'}")
+logger.info(f"Loading environment from {_DOTENV_PATH}")
 
 
 minio_root_user = env.str("MINIO_ROOT_USER", default="admin")

--- a/backend/app/db/db_session.py
+++ b/backend/app/db/db_session.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 # from settings import SQLALCHEMY_DATABASE_URI
 from pathlib import Path
 
+from dotenv import load_dotenv
 from environs import Env
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,10 +15,13 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session
 from sqlmodel import create_engine
 
+# Repo root is four parents up from this file (backend/app/db/db_session.py).
+# environs >= 14 stopped mutating os.environ from read_env(); use python-dotenv so
+# os.environ.get() callsites (e.g. _load_jwt_secret) see values from .env.
+_DOTENV_PATH = Path(__file__).parent.parent.parent.parent / ".env"
+load_dotenv(_DOTENV_PATH)
 env = Env()
-env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
-logger.info(f"Loading environment from {Path(__file__).parent.parent.parent.parent / '.env'}")
+logger.info(f"Loading environment from {_DOTENV_PATH}")
 
 db_user = env.str("MYSQL_USER", default="copilot")
 db_password = env.str("MYSQL_PASSWORD")

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -1,17 +1,26 @@
 import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 
-import uvicorn
 from dotenv import load_dotenv
-from fastapi import APIRouter
-from fastapi import FastAPI
-from fastapi import HTTPException
-from fastapi.exceptions import RequestValidationError
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from loguru import logger
 
-from app.auth.utils import AuthHandler
+# Load .env into os.environ before any `from app...` import. AuthHandler's class body
+# (app/auth/utils.py) calls _load_jwt_secret() at import time and reads JWT_SECRET
+# directly from os.environ — environs >= 14 no longer populates os.environ from
+# read_env(), so without this line the backend refuses to boot unless JWT_SECRET is
+# already exported in the shell (or uvicorn was invoked with --env-file).
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+import uvicorn  # noqa: E402
+from fastapi import APIRouter  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from fastapi.exceptions import RequestValidationError  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
+from fastapi.staticfiles import StaticFiles  # noqa: E402
+from loguru import logger  # noqa: E402
+
+from app.auth.utils import AuthHandler  # noqa: E402
 from app.data_store.data_store_setup import create_buckets
 from app.db.db_session import SQLALCHEMY_DATABASE_URI_NO_DB
 from app.db.db_session import async_engine
@@ -91,8 +100,6 @@ from app.schedulers.scheduler import init_scheduler
 
 
 auth_handler = AuthHandler()
-# Get the `SERVER_IP` from the `.env` file
-load_dotenv()
 server_ip = os.getenv("SERVER_IP", "localhost")
 environment = os.getenv("ENVIRONMENT", "PRODUCTION")
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -7,14 +7,17 @@ environment variables.
 """
 from pathlib import Path
 
+from dotenv import load_dotenv
 from environs import Env
 from loguru import logger
 
+# environs >= 14 stopped mutating os.environ from read_env() — values only land on the
+# Env instance. Use python-dotenv to populate os.environ for the many os.environ.get()
+# callsites across the app (notably _load_jwt_secret in app/auth/utils.py).
+_DOTENV_PATH = Path(__file__).parent.parent / ".env"
+load_dotenv(_DOTENV_PATH)
 env = Env()
-env.read_env(Path(__file__).parent.parent / ".env")
-# env.read_env(Path(__file__).parent.parent.parent / "docker-env" / ".env")
-logger.info(f"Loading environment from {Path(__file__).parent.parent / '.env'}")
-# logger.info(f"Loading environment from {Path(__file__).parent.parent.parent / 'docker-env' / '.env'}")
+logger.info(f"Loading environment from {_DOTENV_PATH}")
 
 
 basedir = Path().absolute()


### PR DESCRIPTION
## Summary

- **Reported by a developer:** `uvicorn copilot:app --port=5000` from `backend/` no longer boots without `--env-file ../.env`.
- **Root cause:** environs 14.0.0 changed `Env.read_env()` to populate the `Env` instance's private `_environ` dict instead of `os.environ`. PR #844 (tier-1 deps) bumped environs 9.5.0 → 15.0.1 without catching this. `env.str()` / `env.bool()` callsites kept working (they fall back to `self._environ`), but `os.environ.get("JWT_SECRET")` in `_load_jwt_secret()` — invoked at `AuthHandler` class-body import time — stopped seeing the value. PR #814's "fail fast on missing JWT_SECRET" then turned the silent miss into a hard `RuntimeError` at boot.
- **Fix:** replace the two `env.read_env(...)` calls with `python-dotenv`'s `load_dotenv(...)` (which still mutates `os.environ`), plus a defensive `load_dotenv` at the very top of `copilot.py` so the JWT-secret check is independent of the downstream import chain.
- **Bonus:** fix a latent path bug in `backend/app/db/db_session.py` and `backend/app/data_store/data_store_session.py` — `Path(__file__).parent.parent / ".env"` resolved to `backend/app/.env`, not `<repo>/.env`. environs's `recurse=True` walked up and found the real file by accident; with `load_dotenv` (no recurse) the path must be correct, so it's now four parents up.

## Test plan

- [x] Branch off `main`, apply patch, build backend image: `docker buildx build --load -t ghcr.io/socfortress/copilot-backend:latest backend/`
- [x] `docker compose up -d --force-recreate copilot-backend`
- [x] Container reaches `Application startup complete` + `Uvicorn running on 0.0.0.0:5000` (no `RuntimeError: JWT_SECRET environment variable is not set`)
- [x] `POST /api/auth/token` with bogus creds returns a real DB-backed `401 {"success":false,"message":"Incorrect username or password"}` — proves `_load_jwt_secret()` ran without raising
- [ ] Reviewer: run `uvicorn copilot:app --port=5000` from `backend/` *without* `--env-file ../.env` and confirm it boots
- [ ] Reviewer: log in through the UI and verify session works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)