### PR TITLE
fix(agents): coerce wazuh_last_seen fallback to datetime on insert

### DIFF
--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -117,8 +117,11 @@ class Agents(SQLModel, table=True):
     @classmethod
     def create_from_model(cls, wazuh_agent, velociraptor_agent, customer_code):
         # Check if agent_last_seen is 'Unknown' and set wazuh_last_seen accordingly
-        if wazuh_agent.agent_last_seen == "Unknown":
-            wazuh_last_seen_value = "1970-01-01T00:00:00+00:00"  # default datetime value
+        if wazuh_agent.agent_last_seen in ("Unknown", "1970-01-01T00:00:00+00:00"):
+            wazuh_last_seen_value = datetime.strptime(
+                "1970-01-01T00:00:00+00:00",
+                "%Y-%m-%dT%H:%M:%S%z",
+            ).replace(tzinfo=None)
         else:
             wazuh_last_seen_value = wazuh_agent.agent_last_seen_as_datetime
 
@@ -144,8 +147,11 @@ class Agents(SQLModel, table=True):
 
     @classmethod
     def create_wazuh_agent_from_model(cls, wazuh_agent, customer_code):
-        if wazuh_agent.agent_last_seen == "Unknown":
-            wazuh_last_seen_value = "1970-01-01T00:00:00+00:00"
+        if wazuh_agent.agent_last_seen in ("Unknown", "1970-01-01T00:00:00+00:00"):
+            wazuh_last_seen_value = datetime.strptime(
+                "1970-01-01T00:00:00+00:00",
+                "%Y-%m-%dT%H:%M:%S%z",
+            ).replace(tzinfo=None)
         else:
             wazuh_last_seen_value = wazuh_agent.agent_last_seen_as_datetime
 


### PR DESCRIPTION
## Summary
- Wazuh agents in `never_connected` state report `agent_last_seen="Unknown"`. The create paths in `Agents.create_from_model` / `create_wazuh_agent_from_model` were assigning the raw string `"1970-01-01T00:00:00+00:00"` to the `wazuh_last_seen` DATETIME column, which MySQL rejects with `1292 Incorrect datetime value`.
- Mirrored the conversion the update paths already do (`strptime` → naive datetime) so INSERTs succeed for never-connected agents.

## Symptom prior to fix
```
ERROR | app.agents.services.sync:add_wazuh_agent_in_db:125 - Failed to add agent <name> to the database:
(pymysql.err.OperationalError) (1292, "Incorrect datetime value: '1970-01-01T00:00:00+00:00' for column 'wazuh_last_seen' at row 1")
```

## Test plan
- [ ] Run agent sync against a Wazuh deployment that contains at least one `never_connected` agent and confirm `add_wazuh_agent_in_db` logs success instead of the `1292` error.
- [ ] Verify the row lands in `agents` with `wazuh_last_seen = 1970-01-01 00:00:00` and `wazuh_agent_status = 'never_connected'`.
- [ ] Re-run sync to confirm the existing-row update path (already working) still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)