### PR TITLE
fix(customer-portal): white-label SOCFortress branding

### DIFF
--- a/customer-portal/src/app-layouts/common/MainFooter.vue
+++ b/customer-portal/src/app-layouts/common/MainFooter.vue
@@ -2,35 +2,23 @@
 	<footer class="footer py-4" :class="{ boxed }">
 		<div class="wrap flex items-center justify-end gap-3">
 			<div class="copy">
-				Made with
-				<Icon :size="22" class="text-primary mx-1">
-					<BrainIcon />
-				</Icon>
-				By
-				<a
-					href="https://www.socfortress.co/"
-					target="_blank"
-					alt="SOCFortress"
-					rel="noopener noreferrer"
-					class="mx-1"
-				>
-					SOCFortress
-				</a>
-				All rights Reserved © Copyright {{ year }}
+				<template v-if="portalTitle">© Copyright {{ year }} {{ portalTitle }}</template>
+				<template v-else>© Copyright {{ year }}</template>
 			</div>
 		</div>
 	</footer>
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue"
-import BrainIcon from "@/assets/icons/brain-icon.svg"
-import Icon from "@/components/common/Icon.vue"
+import { computed, ref } from "vue"
+import { usePortalSettingsStore } from "@/stores/portalSettings"
 
 const { boxed } = defineProps<{
 	boxed: boolean
 }>()
 
+const portalSettingsStore = usePortalSettingsStore()
+const portalTitle = computed(() => portalSettingsStore.portalTitle)
 const year = ref(new Date().getFullYear())
 </script>
 

--- a/customer-portal/src/app-layouts/common/Toolbar/Avatar.vue
+++ b/customer-portal/src/app-layouts/common/Toolbar/Avatar.vue
@@ -6,14 +6,13 @@
 
 <script lang="ts" setup>
 import { NAvatar, NDropdown } from "naive-ui"
-import { h, ref } from "vue"
+import { ref } from "vue"
 import { useRouter } from "vue-router"
 import { useAuthStore } from "@/stores/auth"
 import { renderIcon } from "@/utils"
 
 const UserIcon = "ion:person-outline"
 const LogoutIcon = "ion:log-out-outline"
-const ContactIcon = "ic:outline-alternate-email"
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -25,20 +24,6 @@ const options = ref([
 		label: "Profile",
 		key: "route-Profile",
 		icon: renderIcon(UserIcon)
-	},
-	{
-		label: () =>
-			h(
-				"a",
-				{
-					href: "https://www.socfortress.co/contact_form.html",
-					target: "_blank",
-					rel: "noopenner noreferrer"
-				},
-				"Contact SOCFortress"
-			),
-		key: "contact-socfortress",
-		icon: renderIcon(ContactIcon)
 	},
 	{
 		label: "Logout",


### PR DESCRIPTION
## Summary
- Drop the **Contact SOCFortress** entry from the customer-portal user menu (`Toolbar/Avatar.vue`).
- Replace the **Made with … By SOCFortress** footer with `© Copyright {year} {portalTitle}`, falling back to `© Copyright {year}` when no portal title is configured (`MainFooter.vue`).

Closes #877.

## Test plan
- [ ] `cd customer-portal && pnpm dev` — log in as a customer user, confirm the avatar dropdown no longer shows "Contact SOCFortress".
- [ ] Confirm the footer renders `© Copyright {year} {portalTitle}` when a portal title is set via admin settings, and `© Copyright {year}` when it is blank.
- [ ] `pnpm type-check` — no new errors beyond the pre-existing `NEllipsis` warning in `components/alerts/List.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)