### PR TITLE
fix(security): require auth on six unauthenticated API routes (GHSA-xh98-w6qh-cr44)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ SSO_STATE_SECRET=REPLACE_ME
 TOTP_ENCRYPTION_KEY=REPLACE_ME
 GRAYLOG_API_HEADER_VALUE=ab73de7a-6f61-4dde-87cd-3af5175a7281
 VELOCIRAPTOR_API_HEADER_VALUE=ab73de7a-6f61-4dde-87cd-3af5175a7281
+# Shared secret required on the Grafana-invoked /api/agents/dashboard/agents route
+# (GHSA-xh98-w6qh-cr44). Unlike the two values above, this one FAILS CLOSED: if it is
+# left blank the route is denied for everyone. Generate a unique random value per
+# deployment (e.g. `openssl rand -hex 32`) and set the same value as a request header
+# named `grafana` in your Grafana dashboard's datasource. Do NOT reuse the default above.
+GRAFANA_API_HEADER_VALUE=
 
 MYSQL_URL=copilot-mysql
 # ! Avoid using special characters in the password ! #

--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -1,6 +1,7 @@
 import asyncio
 import csv
 import io
+import os
 from datetime import datetime
 from datetime import timedelta
 from typing import List
@@ -261,10 +262,29 @@ async def get_agents(current_user: User = Depends(AuthHandler().get_current_user
         raise HTTPException(status_code=500, detail=f"Failed to fetch agents: {e}")
 
 
+# Function to validate the Grafana shared-secret header.
+# Modeled on verify_graylog_header (app/active_response/routes/graylog.py), but
+# fails closed: it does NOT fall back to a hardcoded default secret. A default
+# baked into the open-source repo would let anyone reproduce it and bypass the
+# check (the same class of bug as the JWT_SECRET default in GHSA-4gxj-hw3c-3x2x).
+# GRAFANA_API_HEADER_VALUE must be set or the route is denied. See GHSA-xh98-w6qh-cr44.
+async def verify_grafana_header(grafana: Optional[str] = Header(None)):
+    """Verify that a Grafana-invoked request carries the correct shared-secret header."""
+    expected_header = os.getenv("GRAFANA_API_HEADER_VALUE")
+    if not expected_header:
+        logger.error("GRAFANA_API_HEADER_VALUE is not configured; denying Grafana dashboard request")
+        raise HTTPException(status_code=403, detail="Grafana header authentication is not configured")
+    if grafana != expected_header:
+        logger.error("Invalid or missing Grafana header")
+        raise HTTPException(status_code=403, detail="Invalid or missing Grafana header")
+    return grafana
+
+
 @agents_router.get(
     "/dashboard/agents",
     response_model=AgentsResponse,
     description="Get all Wazuh agents for a specific customer (Grafana dashboard use)",
+    dependencies=[Depends(verify_grafana_header)],
 )
 async def get_customer_agents_for_dashboard(
     customer_code: Optional[str] = Header(None, description="Customer code to filter agents by"),

--- a/backend/app/connectors/wazuh_indexer/routes/monitoring.py
+++ b/backend/app/connectors/wazuh_indexer/routes/monitoring.py
@@ -184,6 +184,7 @@ async def get_output_shard_number_to_be_set_based_on_nodes_route() -> int:
 @wazuh_indexer_router.get(
     "/resize_wazuh_index_fields",
     description="Resize Wazuh Index fields",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def resize_wazuh_index_fields_route():
     """

--- a/backend/app/incidents/routes/incident_alert.py
+++ b/backend/app/incidents/routes/incident_alert.py
@@ -79,6 +79,7 @@ async def get_index_names_route() -> IndexNamesResponse:
 @incidents_alerts_router.get(
     "/alerts/not-created",
     description="Get alerts not created in CoPilot",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def get_alerts_not_created_route() -> AlertsPayload:
     """
@@ -217,6 +218,7 @@ async def create_alert_manual_route(
     "/create/auto",
     response_model=AutoCreateAlertResponse,
     description="Is invoked by the scheduler to create an incident alert in CoPilot",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def create_alert_auto_route(
     session: AsyncSession = Depends(get_db),

--- a/backend/app/integrations/carbonblack/routes/provision.py
+++ b/backend/app/integrations/carbonblack/routes/provision.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import Security
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.utils import AuthHandler
 from app.db.db_session import get_db
 from app.integrations.carbonblack.schema.provision import ProvisionCarbonBlackRequest
 from app.integrations.carbonblack.schema.provision import ProvisionCarbonBlackResponse
@@ -20,6 +22,7 @@ integration_carbonblack_provision_scheduler_router = APIRouter()
     "/provision",
     response_model=ProvisionCarbonBlackResponse,
     description="Provision a CarbonBlack integration.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def provision_carbonblack_route(
     provision_carbonblack_request: ProvisionCarbonBlackRequest,
@@ -58,6 +61,7 @@ async def provision_carbonblack_route(
     "/test",
     response_model=ProvisionCarbonBlackResponse,
     description="Invoke a CarbonBlack integration for testing",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def test() -> ProvisionCarbonBlackResponse:
     """


### PR DESCRIPTION
## Summary

Closes the **GHSA-xh98-w6qh-cr44** advisory (High / CWE-200). Six `/api/*` routes shipped with **no authentication dependency**, letting an unauthenticated attacker enumerate cross-tenant agent inventories, read the live alert backlog, trigger external EDR workflows, and destructively modify monitoring indices.

| Route | Before | After |
|---|---|---|
| `GET /api/agents/dashboard/agents` | none | `verify_grafana_header` (shared secret) |
| `GET /api/incidents/.../alerts/not-created` | none | admin/analyst JWT |
| `POST /api/incidents/.../create/auto` | none | admin/analyst JWT |
| `POST /api/carbonblack/provision` | none | admin/analyst JWT |
| `GET /api/carbonblack/test` | none | admin/analyst JWT |
| `GET /api/wazuh-indexer/resize_wazuh_index_fields` | none | admin/analyst JWT |

## Why this is safe for the scheduler

The "scheduler-invoked" routes (`create/auto`, `resize_wazuh_index_fields`) and the Carbon Black collection are called **in-process** as Python functions by APScheduler jobs (`invoke_alert_creation.py`, `wazuh_index_resize.py`, `invoke_carbonblack.py`) — not over HTTP. The `scheduler_login()` HTTP-token helper is unused dead code. Because the new auth is applied as decorator-level `dependencies=[...]` (which doesn't alter the function signature), the in-process callers are unaffected.

## Grafana route — shared secret, fail-closed

`/agents/dashboard/agents` is genuinely consumed by externally-configured Grafana dashboards, so per the advisory's Option 2 it uses a `verify_grafana_header` dependency modeled on the existing `verify_graylog_header`.

**Key difference:** it **fails closed**. Unlike the legacy `verify_graylog_header` / `verify_velociraptor_header` (which fall back to the hardcoded default `ab73de7a-…`), this check denies the request when `GRAFANA_API_HEADER_VALUE` is unset. A default secret baked into an open-source repo is publicly known and would reintroduce the bypass — the same class of issue as the `JWT_SECRET` default the app already hard-blocks at boot (GHSA-4gxj-hw3c-3x2x).

## Operator action required

- Set **`GRAFANA_API_HEADER_VALUE`** in `.env` (e.g. `openssl rand -hex 32`) and configure your Grafana datasource to send it as the `grafana` request header. Until set, `/dashboard/agents` returns `403` (secure default).
- **No `docker-compose.yml` change needed** — `copilot-backend` uses `env_file: .env`, so the new variable is passed through automatically (same as the existing header secrets).

## Out of scope (noted for follow-up)
- CORS hardening (advisory Option 3) intentionally **not** included — kept separate to avoid breaking frontend/portal origins.
- The legacy `verify_graylog_header` / `verify_velociraptor_header` hardcoded-default secrets are a latent weakness worth a separate hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)