### PR TITLE
fix(security): restrict GET /api/connectors/{id} to admin only (GHSA-c5pw-2h98-r798)

### DIFF
--- a/backend/app/connectors/routes.py
+++ b/backend/app/connectors/routes.py
@@ -58,7 +58,10 @@ async def get_connectors(
     "/{connector_id}",
     response_model=ConnectorListResponse,
     description="Fetch a specific connector",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    # Admin-only: this response includes plaintext connector_password / connector_api_key,
+    # so it must match the admin-only list endpoint above and must not be reachable by the
+    # analyst role. See GHSA-c5pw-2h98-r798.
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
 )
 async def get_connector(
     connector_id: int,


### PR DESCRIPTION
## Summary

Fixes **GHSA-c5pw-2h98-r798** (High, CVSS 8.5). The `GET /api/connectors/{connector_id}` endpoint returns plaintext `connector_password` and `connector_api_key` in its response, but was gated with `require_any_scope("admin", "analyst")`. Any **analyst**-role user could enumerate connector IDs and harvest the deployment-wide root credentials for every integrated security tool (Wazuh-Indexer/Manager, Graylog, Velociraptor, Grafana, …) — direct admin access to each platform.

## Fix

One-line authorization change (the advisory's recommended Option 1):

```diff
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
```

This aligns the per-ID endpoint with the **already-admin-only** list endpoint `GET /api/connectors`. The analyst role can no longer fetch individual connector records.

## Scope notes

- **`POST /api/connectors/verify/{id}` left unchanged** (still admin+analyst): its `VerifyConnectorResponse` only returns `{connectionSuccessful, message}` — no secrets.
- **Frontend impact: none for the fix.** The list endpoint was already admin-only, so analysts already received 403s on the connectors page and could not enumerate connectors. The edit form (which pre-fills secrets) is only reachable by admins.
- Chose Option 1 over Option 2 (redact secrets to `*_set: bool`) because the admin edit form reads the plaintext values back to pre-fill fields — redaction would require coordinated frontend changes.

## Out of scope (tracked follow-up)

- **Plaintext storage at rest (CWE-256)** — advisory Option 3 (Fernet-encrypt the columns like `TOTP_ENCRYPTION_KEY`) is a larger change requiring a data migration, service-layer decryption, and key management. Not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)