### PR TITLE
fix(wazuh-manager): tolerate missing group checksum fields across Wazuh versions

### DIFF
--- a/backend/app/connectors/wazuh_manager/schema/groups.py
+++ b/backend/app/connectors/wazuh_manager/schema/groups.py
@@ -12,8 +12,11 @@ class WazuhGroup(BaseModel):
 
     name: str = Field(..., description="Group name")
     count: int = Field(..., description="Number of agents belonging to the group")
-    mergedSum: str = Field(..., description="Checksum of merged configuration files")
-    configSum: str = Field(..., description="Checksum of configuration files")
+    # Both checksum fields vary by Wazuh version: 4.9.0 returns only configSum, while
+    # other builds still return mergedSum. Keep them optional so the connector tolerates
+    # any Wazuh version (mirrors app/integrations/utils/schema.py). See issue #885.
+    mergedSum: Optional[str] = Field(None, description="Checksum of merged configuration files")
+    configSum: Optional[str] = Field(None, description="Checksum of configuration files")
     model_config = ConfigDict(extra="ignore")
 
 


### PR DESCRIPTION
## Summary

Fixes #885. `WazuhGroup` required both `mergedSum` and `configSum`, but the Wazuh `/groups` endpoint returns different checksum fields depending on the manager version. Wazuh **4.9.0** returns only `configSum`, which tripped the required `mergedSum` field and broke group listing with:

```
Error fetching groups: 1 validation error for WazuhGroupsResponse
results.0.mergedSum
  Field required [type=missing, ...]
```

The fields are still documented in the [4.9 API reference](https://documentation.wazuh.com/4.9/user-manual/api/reference.html#tag/Groups/operation/api.controllers.agent_controller.get_list_group), and other ≥ 4.9.0 builds still return `mergedSum` — so the presence of each checksum field varies by version.

## Fix

Make **both** `mergedSum` and `configSum` `Optional` in `app/connectors/wazuh_manager/schema/groups.py`:

```diff
-    mergedSum: str = Field(..., description="Checksum of merged configuration files")
-    configSum: str = Field(..., description="Checksum of configuration files")
+    mergedSum: Optional[str] = Field(None, description="Checksum of merged configuration files")
+    configSum: Optional[str] = Field(None, description="Checksum of configuration files")
```

## Why this is safe

- Nothing downstream reads `mergedSum`/`configSum` — they're only declared in this schema.
- The model already carries `model_config = ConfigDict(extra="ignore")`.
- This matches the precedent already in `app/integrations/utils/schema.py`, where both fields are declared `Optional[str]`.

The connector now tolerates any Wazuh version regardless of which checksum fields the `/groups` response includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)