### PR TITLE
fix(agents): don't trigger a full sync when deleting a single agent

### DIFF
--- a/frontend/src/views/agents/Agents.vue
+++ b/frontend/src/views/agents/Agents.vue
@@ -34,7 +34,7 @@
 									hoverable
 									clickable
 									class="item-appear item-appear-bottom item-appear-005"
-									@delete="syncAgents()"
+									@delete="getAgents()"
 									@click="handleAgentClick(agent)"
 									@toggle-selection="toggleAgentSelection(agent)"
 								/>


### PR DESCRIPTION
## Summary

Fixes #879. Deleting a single agent triggered a full agent sync, which is slow and resource-heavy in environments with thousands of agents.

## Root cause

`frontend/src/views/agents/Agents.vue` wired the per-card `delete` event to `syncAgents()`:

```diff
-    @delete="syncAgents()"
+    @delete="getAgents()"
```

`syncAgents()` calls `POST /agents/sync`, which performs a full reconciliation against Wazuh and Velociraptor and then re-fetches the list. That's unnecessary after a single delete — the backend `DELETE /agents/{agent_id}/delete` endpoint already removes the agent from Wazuh, Velociraptor, and the database directly.

## Fix

Re-fetch the list with `getAgents()` (`GET /agents`) after a single delete, instead of forcing a full sync. This matches the **bulk-delete** path, which already does exactly this (`onBulkDeleteComplete` → `getAgents()`).

## Notes

- The explicit toolbar **Sync** button still calls `syncAgents()`, so users can run a full reconciliation on demand.
- `syncAgents()` remains referenced (toolbar), so no dead code.
- One-line change; behavior now consistent between single and bulk delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)