### PR TITLE
feat(customer-portal): multi-customer filter to scope portal data

### DIFF
--- a/backend/app/customer_portal/routes/dashboard.py
+++ b/backend/app/customer_portal/routes/dashboard.py
@@ -1,5 +1,9 @@
+from typing import List
+from typing import Optional
+
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import Query
 from loguru import logger
 from sqlalchemy import func
 from sqlalchemy import select
@@ -24,11 +28,12 @@ customer_portal_dashboard_router = APIRouter()
     response_model=CustomerDashboardStatsResponse,
 )
 async def get_customer_dashboard_stats(
+    customer_codes: Optional[List[str]] = Query(None, description="Optional subset of customer codes to scope the stats to"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Get total alerts, cases, and agents for the logged-in customer."""
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(current_user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(current_user, customer_codes, db)
     logger.info(f"Fetching dashboard stats for user {current_user.username}, customers: {accessible_customers}")
 
     if "*" in accessible_customers:
@@ -58,11 +63,12 @@ async def get_customer_dashboard_stats(
     response_model=CustomerDashboardAlertStatsResponse,
 )
 async def get_customer_dashboard_alert_stats(
+    customer_codes: Optional[List[str]] = Query(None, description="Optional subset of customer codes to scope the stats to"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Get alert counts (total, open, in-progress, closed) for the logged-in customer."""
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(current_user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(current_user, customer_codes, db)
     logger.info(f"Fetching dashboard alert stats for user {current_user.username}, customers: {accessible_customers}")
 
     if "*" in accessible_customers:
@@ -97,11 +103,12 @@ async def get_customer_dashboard_alert_stats(
     response_model=CustomerDashboardCaseStatsResponse,
 )
 async def get_customer_dashboard_case_stats(
+    customer_codes: Optional[List[str]] = Query(None, description="Optional subset of customer codes to scope the stats to"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Get case counts (total, open, in-progress, closed) for the logged-in customer."""
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(current_user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(current_user, customer_codes, db)
     logger.info(f"Fetching dashboard case stats for user {current_user.username}, customers: {accessible_customers}")
 
     if "*" in accessible_customers:

--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -1206,19 +1206,20 @@ async def list_alerts_endpoint(
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
     order: str = Query("desc", pattern="^(asc|desc)$"),
+    customer_codes: Optional[List[str]] = Query(None, description="Optional subset of customer codes to scope the results to"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """List alerts with automatic customer and tag filtering"""
     logger.info(f"Listing alerts for user: {current_user.username} with role_id: {current_user.role_id}")
 
-    alerts = await list_alerts_for_user(current_user, db, page, page_size, order)
+    alerts = await list_alerts_for_user(current_user, db, page, page_size, order, customer_codes=customer_codes)
 
     # Get totals with both customer and tag filtering
-    total = await alert_total_for_user(current_user, db)
-    open_alerts = await alerts_open_for_user(current_user, db)
-    in_progress = await alerts_in_progress_for_user(current_user, db)
-    closed = await alerts_closed_for_user(current_user, db)
+    total = await alert_total_for_user(current_user, db, customer_codes=customer_codes)
+    open_alerts = await alerts_open_for_user(current_user, db, customer_codes=customer_codes)
+    in_progress = await alerts_in_progress_for_user(current_user, db, customer_codes=customer_codes)
+    closed = await alerts_closed_for_user(current_user, db, customer_codes=customer_codes)
 
     return AlertOutResponse(
         alerts=alerts,
@@ -1781,18 +1782,19 @@ async def list_cases_endpoint(
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
     order: str = Query("desc", pattern="^(asc|desc)$"),
+    customer_codes: Optional[List[str]] = Query(None, description="Optional subset of customer codes to scope the results to"),
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """List cases with automatic customer filtering and pagination"""
     logger.info(f"Listing cases for user: {current_user.username} with role_id: {current_user.role_id}")
 
-    cases = await list_cases_for_user(current_user, db, page, page_size, order)
+    cases = await list_cases_for_user(current_user, db, page, page_size, order, customer_codes=customer_codes)
 
-    total = await case_total_for_user(current_user, db)
-    open_cases = await cases_open_for_user(current_user, db)
-    in_progress = await cases_in_progress_for_user(current_user, db)
-    closed = await cases_closed_for_user(current_user, db)
+    total = await case_total_for_user(current_user, db, customer_codes=customer_codes)
+    open_cases = await cases_open_for_user(current_user, db, customer_codes=customer_codes)
+    in_progress = await cases_in_progress_for_user(current_user, db, customer_codes=customer_codes)
+    closed = await cases_closed_for_user(current_user, db, customer_codes=customer_codes)
 
     return CaseOutResponse(
         cases=cases,

--- a/backend/app/incidents/services/db_operations.py
+++ b/backend/app/incidents/services/db_operations.py
@@ -244,7 +244,7 @@ async def alerts_open_by_customer_codes(db: AsyncSession, customer_codes: List[s
     return len(result.scalars().all())
 
 
-async def alert_total_for_user(user: User, db: AsyncSession) -> int:
+async def alert_total_for_user(user: User, db: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get total alerts count with customer and tag filtering"""
     from sqlalchemy import and_
     from sqlalchemy import exists
@@ -253,7 +253,7 @@ async def alert_total_for_user(user: User, db: AsyncSession) -> int:
     filters = []
 
     # Customer filtering
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, db)
     if "*" not in accessible_customers:
         filters.append(Alert.customer_code.in_(accessible_customers))
 
@@ -290,7 +290,7 @@ async def alert_total_for_user(user: User, db: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def alerts_open_for_user(user: User, db: AsyncSession) -> int:
+async def alerts_open_for_user(user: User, db: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get open alerts count with customer and tag filtering"""
     from sqlalchemy import and_
     from sqlalchemy import exists
@@ -299,7 +299,7 @@ async def alerts_open_for_user(user: User, db: AsyncSession) -> int:
     filters = [Alert.status == "OPEN"]
 
     # Customer filtering
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, db)
     if "*" not in accessible_customers:
         filters.append(Alert.customer_code.in_(accessible_customers))
 
@@ -336,7 +336,7 @@ async def alerts_open_for_user(user: User, db: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def alerts_in_progress_for_user(user: User, db: AsyncSession) -> int:
+async def alerts_in_progress_for_user(user: User, db: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get in-progress alerts count with customer and tag filtering"""
     from sqlalchemy import and_
     from sqlalchemy import exists
@@ -345,7 +345,7 @@ async def alerts_in_progress_for_user(user: User, db: AsyncSession) -> int:
     filters = [Alert.status == "IN_PROGRESS"]
 
     # Customer filtering
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, db)
     if "*" not in accessible_customers:
         filters.append(Alert.customer_code.in_(accessible_customers))
 
@@ -382,7 +382,7 @@ async def alerts_in_progress_for_user(user: User, db: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def alerts_closed_for_user(user: User, db: AsyncSession) -> int:
+async def alerts_closed_for_user(user: User, db: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get closed alerts count with customer and tag filtering"""
     from sqlalchemy import and_
     from sqlalchemy import exists
@@ -391,7 +391,7 @@ async def alerts_closed_for_user(user: User, db: AsyncSession) -> int:
     filters = [Alert.status == "CLOSED"]
 
     # Customer filtering
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, db)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, db)
     if "*" not in accessible_customers:
         filters.append(Alert.customer_code.in_(accessible_customers))
 
@@ -2596,6 +2596,7 @@ async def list_alerts_for_user(
     page: int = 1,
     page_size: int = 25,
     order: str = "desc",
+    customer_codes: Optional[List[str]] = None,
 ) -> List[AlertOut]:
     """List alerts filtered by user's customer access and tag access"""
     from sqlalchemy import and_
@@ -2617,7 +2618,7 @@ async def list_alerts_for_user(
     filters = []
 
     # 1. Apply customer filtering
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, session)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, session)
     if "*" not in accessible_customers:
         filters.append(Alert.customer_code.in_(accessible_customers))
 
@@ -2694,11 +2695,11 @@ async def list_alerts_for_user(
     return alerts_out
 
 
-async def case_total_for_user(user: User, session: AsyncSession) -> int:
+async def case_total_for_user(user: User, session: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get total cases count with customer filtering"""
     base_query = select(func.count(Case.id))
 
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, session)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, session)
     if "*" not in accessible_customers:
         base_query = base_query.where(Case.customer_code.in_(accessible_customers))
 
@@ -2706,11 +2707,11 @@ async def case_total_for_user(user: User, session: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def cases_open_for_user(user: User, session: AsyncSession) -> int:
+async def cases_open_for_user(user: User, session: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get open cases count with customer filtering"""
     base_query = select(func.count(Case.id)).where(Case.case_status == "OPEN")
 
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, session)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, session)
     if "*" not in accessible_customers:
         base_query = base_query.where(Case.customer_code.in_(accessible_customers))
 
@@ -2718,11 +2719,11 @@ async def cases_open_for_user(user: User, session: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def cases_in_progress_for_user(user: User, session: AsyncSession) -> int:
+async def cases_in_progress_for_user(user: User, session: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get in-progress cases count with customer filtering"""
     base_query = select(func.count(Case.id)).where(Case.case_status == "IN_PROGRESS")
 
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, session)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, session)
     if "*" not in accessible_customers:
         base_query = base_query.where(Case.customer_code.in_(accessible_customers))
 
@@ -2730,11 +2731,11 @@ async def cases_in_progress_for_user(user: User, session: AsyncSession) -> int:
     return result.scalar_one()
 
 
-async def cases_closed_for_user(user: User, session: AsyncSession) -> int:
+async def cases_closed_for_user(user: User, session: AsyncSession, customer_codes: Optional[List[str]] = None) -> int:
     """Get closed cases count with customer filtering"""
     base_query = select(func.count(Case.id)).where(Case.case_status == "CLOSED")
 
-    accessible_customers = await customer_access_handler.get_user_accessible_customers(user, session)
+    accessible_customers = await customer_access_handler.resolve_effective_customers(user, customer_codes, session)
     if "*" not in accessible_customers:
         base_query = base_query.where(Case.customer_code.in_(accessible_customers))
 
@@ -2748,6 +2749,7 @@ async def list_cases_for_user(
     page: int = 1,
     page_size: int = 25,
     order: str = "desc",
+    customer_codes: Optional[List[str]] = None,
 ) -> List[CaseOut]:
     """List cases filtered by user's customer access with pagination"""
 
@@ -2763,8 +2765,14 @@ async def list_cases_for_user(
         selectinload(Case.comments),
     )
 
-    # Apply customer filtering
-    filtered_query = await customer_access_handler.filter_query_by_customer_access(user, session, base_query, Case.customer_code)
+    # Apply customer filtering (optionally narrowed to a requested subset)
+    filtered_query = await customer_access_handler.filter_query_by_customer_access(
+        user,
+        session,
+        base_query,
+        Case.customer_code,
+        requested_customers=customer_codes,
+    )
 
     # Apply ordering and pagination
     final_query = filtered_query.order_by(order_by).offset(offset).limit(page_size)

--- a/backend/app/middleware/customer_access.py
+++ b/backend/app/middleware/customer_access.py
@@ -39,19 +39,62 @@ class CustomerAccessHandler:
         # Specific customer access
         return customer_code in accessible_customers
 
-    async def filter_query_by_customer_access(self, user: User, session: AsyncSession, base_query, customer_code_field):
-        """Filter any query by user's customer access"""
+    async def resolve_effective_customers(
+        self,
+        user: User,
+        requested_customers: Optional[List[str]],
+        session: AsyncSession,
+    ) -> List[str]:
+        """Resolve the customer codes a query should be filtered to.
+
+        Combines the user's *accessible* customers with an optional *requested*
+        subset (e.g. a portal customer filter), so a caller can narrow the view
+        without ever escaping their own access scope.
+
+        Returns either:
+          - ``["*"]`` — no filtering needed (wildcard access and no requested subset), or
+          - a concrete list of customer codes to filter on. An empty list means the
+            requested subset resolved to nothing the user may see, and callers should
+            treat it as "match no rows" (``column.in_([])``).
+        """
         accessible_customers = await self.get_user_accessible_customers(user, session)
 
-        # Admin/analyst see everything
+        # No subset requested -> preserve existing behaviour (may be ["*"]).
+        if not requested_customers:
+            return accessible_customers
+
+        # Wildcard access (admin/analyst): any requested subset is allowed as-is.
+        if "*" in accessible_customers:
+            return list(requested_customers)
+
+        # Scoped user: only honor requested codes they actually have access to.
+        return [code for code in requested_customers if code in accessible_customers]
+
+    async def filter_query_by_customer_access(
+        self,
+        user: User,
+        session: AsyncSession,
+        base_query,
+        customer_code_field,
+        requested_customers: Optional[List[str]] = None,
+    ):
+        """Filter any query by user's customer access.
+
+        When ``requested_customers`` is provided, the query is further narrowed to
+        that subset (intersected with the user's access — see
+        ``resolve_effective_customers``).
+        """
+        accessible_customers = await self.resolve_effective_customers(user, requested_customers, session)
+
+        # Admin/analyst see everything (no subset requested)
         if "*" in accessible_customers:
             return base_query
 
-        # Customer users see only their data
+        # Customer users (or anyone with a requested subset) see only matching data
         if accessible_customers:
             return base_query.where(customer_code_field.in_(accessible_customers))
 
-        # No access - return empty result
+        # No access / requested subset resolved to nothing - return empty result
         return base_query.where(False)
 
     def require_customer_access(self, customer_code: Optional[str] = None):

--- a/customer-portal/src/api/endpoints/alerts.ts
+++ b/customer-portal/src/api/endpoints/alerts.ts
@@ -2,6 +2,7 @@ import type { Alert, AlertsFilters, AlertsListResponse, AlertStatus } from "@/ty
 import type { CommentItem } from "@/types/comments"
 import type { CommonResponse, Pagination } from "@/types/common"
 import { HttpClient } from "../httpClient"
+import { withCustomerCodes } from "../params"
 
 export interface AlertCommentPayload {
 	alertId: number
@@ -14,11 +15,11 @@ export default {
 	/**
 	 * Get all alerts with customer access control
 	 */
-	getAlerts({ page = 1, pageSize = 25, order = "desc" }: Pagination, signal?: AbortSignal) {
-		return HttpClient.get<CommonResponse<AlertsListResponse>>("/incidents/db_operations/alerts", {
-			params: { page, page_size: pageSize, order },
-			signal
-		})
+	getAlerts({ page = 1, pageSize = 25, order = "desc" }: Pagination, signal?: AbortSignal, customerCodes?: string[]) {
+		return HttpClient.get<CommonResponse<AlertsListResponse>>(
+			"/incidents/db_operations/alerts",
+			withCustomerCodes(customerCodes, { params: { page, page_size: pageSize, order }, signal })
+		)
 	},
 
 	/**

--- a/customer-portal/src/api/endpoints/cases.ts
+++ b/customer-portal/src/api/endpoints/cases.ts
@@ -2,6 +2,7 @@ import type { Case, CaseDataStoreFile, CasesFilters, CasesListResponse, CaseStat
 import type { CommentItem } from "@/types/comments"
 import type { CommonResponse, Pagination } from "@/types/common"
 import { HttpClient } from "../httpClient"
+import { withCustomerCodes } from "../params"
 
 export interface CasePayload {
 	case_name: string
@@ -22,11 +23,11 @@ export default {
 	/**
 	 * Get all cases with customer access control
 	 */
-	getCases({ page = 1, pageSize = 25, order = "desc" }: Pagination, signal?: AbortSignal) {
-		return HttpClient.get<CommonResponse<CasesListResponse>>("/incidents/db_operations/cases", {
-			params: { page, page_size: pageSize, order },
-			signal
-		})
+	getCases({ page = 1, pageSize = 25, order = "desc" }: Pagination, signal?: AbortSignal, customerCodes?: string[]) {
+		return HttpClient.get<CommonResponse<CasesListResponse>>(
+			"/incidents/db_operations/cases",
+			withCustomerCodes(customerCodes, { params: { page, page_size: pageSize, order }, signal })
+		)
 	},
 
 	/**

--- a/customer-portal/src/api/endpoints/portal.ts
+++ b/customer-portal/src/api/endpoints/portal.ts
@@ -1,18 +1,19 @@
 import type { CommonResponse } from "@/types/common"
 import type { AlertsStats, CasesStats, DashboardStats, PortalSettings } from "@/types/portal"
 import { HttpClient } from "../httpClient"
+import { withCustomerCodes } from "../params"
 
 export default {
 	getSettings() {
 		return HttpClient.get<CommonResponse<{ settings: PortalSettings }>>("/customer_portal/settings")
 	},
-	dashboardStats() {
-		return HttpClient.get<CommonResponse<DashboardStats>>("/customer_portal/dashboard/stats")
+	dashboardStats(customerCodes?: string[]) {
+		return HttpClient.get<CommonResponse<DashboardStats>>("/customer_portal/dashboard/stats", withCustomerCodes(customerCodes))
 	},
-	alertsStats() {
-		return HttpClient.get<CommonResponse<AlertsStats>>("/customer_portal/dashboard/alert-stats")
+	alertsStats(customerCodes?: string[]) {
+		return HttpClient.get<CommonResponse<AlertsStats>>("/customer_portal/dashboard/alert-stats", withCustomerCodes(customerCodes))
 	},
-	casesStats() {
-		return HttpClient.get<CommonResponse<CasesStats>>("/customer_portal/dashboard/case-stats")
+	casesStats(customerCodes?: string[]) {
+		return HttpClient.get<CommonResponse<CasesStats>>("/customer_portal/dashboard/case-stats", withCustomerCodes(customerCodes))
 	}
 }

--- a/customer-portal/src/api/params.ts
+++ b/customer-portal/src/api/params.ts
@@ -1,0 +1,22 @@
+import type { AxiosRequestConfig } from "axios"
+
+/**
+ * Merge an optional multi-customer filter into an axios request config.
+ *
+ * When `customerCodes` has entries they are appended as repeated query params
+ * (`customer_codes=a&customer_codes=b`) — the shape FastAPI's
+ * `List[str] = Query(...)` expects — via `paramsSerializer: { indexes: null }`.
+ * When empty/undefined the original config is returned untouched, so callers
+ * fall back to "all accessible customers" exactly as before.
+ */
+export function withCustomerCodes(customerCodes?: string[], config: AxiosRequestConfig = {}): AxiosRequestConfig {
+	if (!customerCodes?.length) {
+		return config
+	}
+
+	return {
+		...config,
+		params: { ...(config.params ?? {}), customer_codes: customerCodes },
+		paramsSerializer: { indexes: null }
+	}
+}

--- a/customer-portal/src/app-layouts/HorizontalNav/HeaderBar.vue
+++ b/customer-portal/src/app-layouts/HorizontalNav/HeaderBar.vue
@@ -4,11 +4,13 @@
 		<n-scrollbar class="grow" x-scrollable>
 			<Navbar :collapsed="false" mode="horizontal" />
 		</n-scrollbar>
+		<CustomerFilter class="customer-filter-slot" />
 	</div>
 </template>
 
 <script lang="ts" setup>
 import { NScrollbar } from "naive-ui"
+import CustomerFilter from "@/app-layouts/common/CustomerFilter.vue"
 import Logo from "@/app-layouts/common/Logo.vue"
 import Navbar from "@/app-layouts/common/Navbar"
 </script>
@@ -29,6 +31,11 @@ import Navbar from "@/app-layouts/common/Navbar"
 
 	.nav {
 		padding-top: 10px;
+		margin-right: var(--view-padding);
+	}
+
+	.customer-filter-slot {
+		flex-shrink: 0;
 		margin-right: var(--view-padding);
 	}
 

--- a/customer-portal/src/app-layouts/common/CustomerFilter.vue
+++ b/customer-portal/src/app-layouts/common/CustomerFilter.vue
@@ -1,0 +1,43 @@
+<template>
+	<NSelect
+		v-if="options.length > 1"
+		v-model:value="selected"
+		multiple
+		clearable
+		size="small"
+		class="customer-filter"
+		:options
+		:max-tag-count="2"
+		placeholder="All customers"
+		:consistent-menu-width="false"
+	/>
+</template>
+
+<script lang="ts" setup>
+import { NSelect } from "naive-ui"
+import { computed, onMounted } from "vue"
+import { useAuthStore } from "@/stores/auth"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
+
+const authStore = useAuthStore()
+const customerFilterStore = useCustomerFilterStore()
+
+const options = computed(() => authStore.accessibleCustomerCodes.map(code => ({ label: code, value: code })))
+
+const selected = computed<string[]>({
+	get: () => customerFilterStore.selectedCustomerCodes,
+	set: (codes: string[]) => customerFilterStore.setSelected(codes)
+})
+
+// Drop any persisted selection the current user can no longer access.
+onMounted(() => {
+	customerFilterStore.pruneToAccessible(authStore.accessibleCustomerCodes)
+})
+</script>
+
+<style lang="scss" scoped>
+.customer-filter {
+	min-width: 200px;
+	max-width: 280px;
+}
+</style>

--- a/customer-portal/src/components/alerts/AlertsOverviewStatsCards.vue
+++ b/customer-portal/src/components/alerts/AlertsOverviewStatsCards.vue
@@ -32,11 +32,12 @@
 import type { ApiError } from "@/types/common"
 import type { AlertsStats } from "@/types/portal"
 import { NSpin, useMessage } from "naive-ui"
-import { onBeforeMount, ref } from "vue"
+import { onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
 import CardStats from "@/components/common/cards/CardStats.vue"
 import Icon from "@/components/common/Icon.vue"
 import { ICONS } from "@/const"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { getApiErrorMessage } from "@/utils"
 
 const stats = ref<AlertsStats>({
@@ -48,12 +49,13 @@ const stats = ref<AlertsStats>({
 
 const loading = ref(false)
 const message = useMessage()
+const customerFilterStore = useCustomerFilterStore()
 
 function fetchStats() {
 	loading.value = true
 
 	Api.portal
-		.alertsStats()
+		.alertsStats(customerFilterStore.queryCustomerCodes)
 		.then(res => {
 			stats.value = res.data
 		})
@@ -68,4 +70,7 @@ function fetchStats() {
 onBeforeMount(() => {
 	fetchStats()
 })
+
+// Refetch whenever the global customer filter changes.
+watch(() => customerFilterStore.selectedCustomerCodes, fetchStats, { deep: true })
 </script>

--- a/customer-portal/src/components/alerts/List.vue
+++ b/customer-portal/src/components/alerts/List.vue
@@ -205,7 +205,11 @@ const loadAlerts = useDebounceFn(async () => {
 					)
 					break
 				default:
-					response = await Api.alerts.getAlerts(paginationPayload, abortController.signal)
+					response = await Api.alerts.getAlerts(
+						paginationPayload,
+						abortController.signal,
+						customerFilterStore.queryCustomerCodes
+					)
 					break
 			}
 		} else {

--- a/customer-portal/src/components/alerts/List.vue
+++ b/customer-portal/src/components/alerts/List.vue
@@ -64,7 +64,7 @@ import type { Alert, AlertsListResponse, AlertStatus } from "@/types/alerts"
 import type { ApiError, CommonResponse, Pagination } from "@/types/common"
 import { useDebounceFn, useElementSize } from "@vueuse/core"
 import axios from "axios"
-import { NDataTable, NEllipsis, NEmpty, NPagination, NTag, useMessage } from "naive-ui"
+import { NDataTable, NEmpty, NPagination, NTag, useMessage } from "naive-ui"
 import { computed, ref, useTemplateRef, watch } from "vue"
 import Api from "@/api"
 import AlertDetailsButton from "@/components/alerts/AlertDetailsButton.vue"
@@ -72,6 +72,7 @@ import AlertStatusSelect from "@/components/alerts/AlertStatusSelect.vue"
 import Filters from "@/components/alerts/Filters.vue"
 import Chip from "@/components/common/Chip.vue"
 import Icon from "@/components/common/Icon.vue"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { useSettingsStore } from "@/stores/settings"
 import { getApiErrorMessage, getStatusColor } from "@/utils"
 import { formatDate } from "@/utils/format"
@@ -80,6 +81,7 @@ const message = useMessage()
 const data = ref<Alert[]>([])
 const loading = ref(false)
 const dFormats = useSettingsStore().dateFormat
+const customerFilterStore = useCustomerFilterStore()
 
 const { width: headerWidthRef } = useElementSize(useTemplateRef("headerRef"))
 const pageSizes = [10, 25, 50, 100]
@@ -207,7 +209,11 @@ const loadAlerts = useDebounceFn(async () => {
 					break
 			}
 		} else {
-			response = await Api.alerts.getAlerts(paginationPayload, abortController.signal)
+			response = await Api.alerts.getAlerts(
+				paginationPayload,
+				abortController.signal,
+				customerFilterStore.queryCustomerCodes
+			)
 		}
 
 		data.value = response.data.alerts
@@ -233,7 +239,7 @@ function handleStatusUpdateSuccess(payload: AlertStatusUpdateSuccessPayload) {
 	}
 }
 
-watch([() => pagination.value.pageSize, () => filters.value.value], resetPage, {
+watch([() => pagination.value.pageSize, () => filters.value.value, () => customerFilterStore.selectedCustomerCodes], resetPage, {
 	deep: true,
 	immediate: true
 })

--- a/customer-portal/src/components/cases/CasesOverviewStatsCards.vue
+++ b/customer-portal/src/components/cases/CasesOverviewStatsCards.vue
@@ -32,11 +32,12 @@
 import type { ApiError } from "@/types/common"
 import type { CasesStats } from "@/types/portal"
 import { NSpin, useMessage } from "naive-ui"
-import { onBeforeMount, ref } from "vue"
+import { onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
 import CardStats from "@/components/common/cards/CardStats.vue"
 import Icon from "@/components/common/Icon.vue"
 import { ICONS } from "@/const"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { getApiErrorMessage } from "@/utils"
 
 const stats = ref<CasesStats>({
@@ -48,12 +49,13 @@ const stats = ref<CasesStats>({
 
 const loading = ref(false)
 const message = useMessage()
+const customerFilterStore = useCustomerFilterStore()
 
 function fetchStats() {
 	loading.value = true
 
 	Api.portal
-		.casesStats()
+		.casesStats(customerFilterStore.queryCustomerCodes)
 		.then(res => {
 			stats.value = res.data
 		})
@@ -68,4 +70,7 @@ function fetchStats() {
 onBeforeMount(() => {
 	fetchStats()
 })
+
+// Refetch whenever the global customer filter changes.
+watch(() => customerFilterStore.selectedCustomerCodes, fetchStats, { deep: true })
 </script>

--- a/customer-portal/src/components/cases/List.vue
+++ b/customer-portal/src/components/cases/List.vue
@@ -210,7 +210,7 @@ const loadCases = useDebounceFn(async () => {
 					break
 			}
 		} else {
-			response = await Api.cases.getCases(paginationPayload, abortController.signal)
+			response = await Api.cases.getCases(paginationPayload, abortController.signal, customerFilterStore.queryCustomerCodes)
 		}
 
 		data.value = response.data.cases

--- a/customer-portal/src/components/cases/List.vue
+++ b/customer-portal/src/components/cases/List.vue
@@ -76,6 +76,7 @@ import CreateCaseButton from "@/components/cases/CreateCaseButton.vue"
 import Filters from "@/components/cases/Filters.vue"
 import Chip from "@/components/common/Chip.vue"
 import Icon from "@/components/common/Icon.vue"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { useSettingsStore } from "@/stores/settings"
 import { getApiErrorMessage, getStatusColor } from "@/utils"
 import { formatDate } from "@/utils/format"
@@ -84,6 +85,7 @@ const message = useMessage()
 const data = ref<Case[]>([])
 const loading = ref(false)
 const dFormats = useSettingsStore().dateFormat
+const customerFilterStore = useCustomerFilterStore()
 
 const { width: headerWidthRef } = useElementSize(useTemplateRef("headerRef"))
 const pageSizes = [10, 25, 50, 100]
@@ -204,7 +206,7 @@ const loadCases = useDebounceFn(async () => {
 					)
 					break
 				default:
-					response = await Api.cases.getCases(paginationPayload, abortController.signal)
+					response = await Api.cases.getCases(paginationPayload, abortController.signal, customerFilterStore.queryCustomerCodes)
 					break
 			}
 		} else {
@@ -265,7 +267,7 @@ function handleStatusUpdateSuccess(payload: CaseStatusUpdateSuccessPayload) {
 	}
 }
 
-watch([() => pagination.value.pageSize, () => filters.value.value], resetPage, {
+watch([() => pagination.value.pageSize, () => filters.value.value, () => customerFilterStore.selectedCustomerCodes], resetPage, {
 	deep: true,
 	immediate: true
 })

--- a/customer-portal/src/components/overview/OverviewStatsCards.vue
+++ b/customer-portal/src/components/overview/OverviewStatsCards.vue
@@ -26,17 +26,19 @@
 import type { ApiError } from "@/types/common"
 import type { DashboardStats } from "@/types/portal"
 import { NSpin, useMessage } from "naive-ui"
-import { onBeforeMount, ref } from "vue"
+import { onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
 import CardStats from "@/components/common/cards/CardStats.vue"
 import Icon from "@/components/common/Icon.vue"
 import { useNavigation } from "@/composables/common/useNavigation"
 import { ICONS } from "@/const"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { getApiErrorMessage } from "@/utils"
 
 const { routeAlertsList, routeCasesList, routeAgentsList } = useNavigation()
 const loading = ref(false)
 const message = useMessage()
+const customerFilterStore = useCustomerFilterStore()
 const stats = ref<DashboardStats>({
 	total_alerts: 0,
 	total_cases: 0,
@@ -46,7 +48,7 @@ const stats = ref<DashboardStats>({
 function fetchStats() {
 	loading.value = true
 	Api.portal
-		.dashboardStats()
+		.dashboardStats(customerFilterStore.queryCustomerCodes)
 		.then(res => {
 			stats.value = res.data
 		})
@@ -61,4 +63,7 @@ function fetchStats() {
 onBeforeMount(() => {
 	fetchStats()
 })
+
+// Refetch whenever the global customer filter changes.
+watch(() => customerFilterStore.selectedCustomerCodes, fetchStats, { deep: true })
 </script>

--- a/customer-portal/src/stores/auth.ts
+++ b/customer-portal/src/stores/auth.ts
@@ -6,6 +6,7 @@ import _capitalize from "lodash/capitalize"
 import _castArray from "lodash/castArray"
 import { acceptHMRUpdate, defineStore } from "pinia"
 import Api from "@/api"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { RouteRole } from "@/types/auth"
 import { getAvatar } from "@/utils"
 import { jwtRoleToUserRole } from "@/utils/auth"
@@ -26,6 +27,7 @@ export const useAuthStore = defineStore("auth", {
 				refresh_token: payload.refresh_token,
 				username: jwtPayload.sub || "",
 				customer_code: jwtPayload.customer_codes?.[0] || null,
+				customer_codes: jwtPayload.customer_codes ?? [],
 				role: jwtRoleToUserRole(jwtPayload.scopes)
 			}
 		},
@@ -38,6 +40,7 @@ export const useAuthStore = defineStore("auth", {
 		setLogout() {
 			this.user = null
 
+			useCustomerFilterStore().clear()
 			removePersistentSessionKey()
 		},
 		async login(payload: LoginPayload) {
@@ -83,6 +86,9 @@ export const useAuthStore = defineStore("auth", {
 		},
 		userCustomerCode(state): string | null {
 			return state.user?.customer_code || null
+		},
+		accessibleCustomerCodes(state): string[] {
+			return state.user?.customer_codes ?? []
 		},
 		userName(state): string | null {
 			return state.user?.username || null

--- a/customer-portal/src/stores/customerFilter.ts
+++ b/customer-portal/src/stores/customerFilter.ts
@@ -1,0 +1,50 @@
+import { acceptHMRUpdate, defineStore } from "pinia"
+
+/**
+ * Holds the Customer Portal's global multi-customer filter.
+ *
+ * An empty `selectedCustomerCodes` means "All accessible customers" (the default,
+ * preserving the previous behaviour). When one or more codes are selected, portal
+ * data is scoped to that subset. The backend always intersects the requested codes
+ * with the user's accessible customers, so a stale/invalid code here can never widen
+ * access — at worst it is ignored.
+ */
+export const useCustomerFilterStore = defineStore("customer-filter", {
+	state: () => ({
+		selectedCustomerCodes: [] as string[]
+	}),
+	actions: {
+		setSelected(codes: string[]) {
+			this.selectedCustomerCodes = [...codes]
+		},
+		clear() {
+			this.selectedCustomerCodes = []
+		},
+		/** Drop any selected codes the user no longer has access to. */
+		pruneToAccessible(accessibleCodes: string[]) {
+			if (!this.selectedCustomerCodes.length) {
+				return
+			}
+			this.selectedCustomerCodes = this.selectedCustomerCodes.filter(code => accessibleCodes.includes(code))
+		}
+	},
+	getters: {
+		isFiltering(state): boolean {
+			return state.selectedCustomerCodes.length > 0
+		},
+		/**
+		 * The value to pass to customer-scoped API calls: the selected subset, or
+		 * `undefined` when nothing is selected (meaning "all accessible").
+		 */
+		queryCustomerCodes(state): string[] | undefined {
+			return state.selectedCustomerCodes.length ? state.selectedCustomerCodes : undefined
+		}
+	},
+	persist: {
+		pick: ["selectedCustomerCodes"]
+	}
+})
+
+if (import.meta.hot) {
+	import.meta.hot.accept(acceptHMRUpdate(useCustomerFilterStore, import.meta.hot))
+}

--- a/customer-portal/src/types/auth.ts
+++ b/customer-portal/src/types/auth.ts
@@ -26,6 +26,7 @@ export interface AuthUser {
 	role: AuthUserRole | string | null
 	username: string | null
 	customer_code: string | null
+	customer_codes: string[]
 }
 
 export interface AuthResponse {

--- a/customer-portal/src/views/Overview.vue
+++ b/customer-portal/src/views/Overview.vue
@@ -39,11 +39,12 @@
 import type { DashboardAlert, DashboardCase } from "@/components/overview/types"
 import type { ApiError } from "@/types/common"
 import { NSpin, useMessage } from "naive-ui"
-import { onBeforeMount, ref } from "vue"
+import { onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
 import OverviewRecentAlerts from "@/components/overview/OverviewRecentAlerts.vue"
 import OverviewRecentCases from "@/components/overview/OverviewRecentCases.vue"
 import OverviewStatsCards from "@/components/overview/OverviewStatsCards.vue"
+import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { getApiErrorMessage } from "@/utils"
 
 const loadingAlerts = ref(false)
@@ -51,13 +52,18 @@ const loadingCases = ref(false)
 const message = useMessage()
 const recentAlerts = ref<DashboardAlert[]>([])
 const recentCases = ref<DashboardCase[]>([])
+const customerFilterStore = useCustomerFilterStore()
 
 async function fetchAlerts() {
 	loadingAlerts.value = true
 
 	try {
 		// Fetch alerts, cases, and agents data using our API services
-		const alertsResponse = await Api.alerts.getAlerts({ page: 1, pageSize: 10, order: "desc" })
+		const alertsResponse = await Api.alerts.getAlerts(
+			{ page: 1, pageSize: 10, order: "desc" },
+			undefined,
+			customerFilterStore.queryCustomerCodes
+		)
 
 		const alerts = alertsResponse.data.alerts || []
 
@@ -84,7 +90,11 @@ async function fetchCases() {
 
 	try {
 		// Fetch alerts, cases, and agents data using our API services
-		const casesResponse = await Api.cases.getCases({ page: 1, pageSize: 10, order: "desc" })
+		const casesResponse = await Api.cases.getCases(
+			{ page: 1, pageSize: 10, order: "desc" },
+			undefined,
+			customerFilterStore.queryCustomerCodes
+		)
 
 		const cases = casesResponse.data.cases || []
 
@@ -111,4 +121,14 @@ onBeforeMount(() => {
 	fetchAlerts()
 	fetchCases()
 })
+
+// Refetch whenever the global customer filter changes.
+watch(
+	() => customerFilterStore.selectedCustomerCodes,
+	() => {
+		fetchAlerts()
+		fetchCases()
+	},
+	{ deep: true }
+)
 </script>


### PR DESCRIPTION
## Summary

Implements #873 (core slice). Adds a **multi-select customer filter** to the Customer Portal header so a user assigned to multiple customers can focus the portal on one or many customers. Empty selection = **all accessible** (preserves current behavior).

This slice scopes the **dashboard stats** and the **primary alerts & cases lists**. The status/source/assigned-to sub-filter endpoints are a documented fast-follow (see Scope below).

## Backend (optional + access-preserving)

- **`CustomerAccessHandler.resolve_effective_customers(user, requested, session)`** — intersects a requested subset with the user's accessible customers. A scoped `customer_user` can never request a customer they lack access to; an empty intersection resolves to "match no rows". Admin/analyst (wildcard) may narrow to any subset.
- **`filter_query_by_customer_access(...)`** gains an optional `requested_customers` arg (used by the cases path).
- Optional **`customer_codes` query param** threaded through:
  - `customer_portal/dashboard/{stats,alert-stats,case-stats}`
  - `incidents/db_operations` **`/alerts`** and **`/cases`** list endpoints + their `*_for_user` total helpers.
- The param is **optional**, so the main analyst frontend (which never sends it) is completely unaffected.

**Security:** the requested subset is always intersected with the JWT user's access server-side — the filter can only ever *narrow*, never widen, what a user can see.

## Customer portal

- Auth store/types expose **all** JWT `customer_codes` (previously only the first was kept).
- New persisted **`customer-filter`** Pinia store holds `selectedCustomerCodes`; cleared on logout and pruned to the user's accessible codes on mount.
- **`CustomerFilter.vue`** header selector — only rendered when the user has >1 accessible customer.
- **`withCustomerCodes()`** API helper serializes the subset as repeated `customer_codes=` params (the shape FastAPI's `List[str]` expects), via `paramsSerializer: { indexes: null }`.
- Overview (stat cards + recent alerts/cases) and the alerts/cases list views pass the selection and refetch when it changes.

## Scope / follow-ups (intentionally out of this slice)

- **Sub-filter endpoints** (`/alerts/status`, `/alerts/source`, `/cases/status`, `/cases/assigned-to`, …) are not yet customer-scoped — they branch through different service paths with a pre-existing multi-customer quirk. When a customer filter *and* a status/source sub-filter are both active, the sub-filtered view currently shows all accessible data for that sub-filter (still always within the user's access — never a disclosure). Tracked as a follow-up.
- **Agents / SIEM** scoping (SIEM already takes an explicit customer_code).
- Selector shows customer **codes** (the identifiers in the JWT); friendly names could be a later enhancement.
- The header filter lives in the desktop header bar (hidden at the mobile breakpoint, like the rest of the nav).

## Verification

- `pnpm type-check` (customer-portal) passes.
- `eslint` clean on all changed files (also removed a pre-existing unused `NEllipsis` import that was failing type-check).
- Backend changed modules compile.

Refs #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)