### PR TITLE
feat(integrations): forward alerts to SOCFortress MDR per customer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,3 +160,12 @@ MCP_VELOCIRAPTOR_AUTH_TOKEN=velociraptor-token
 MCP_VELOCIRAPTOR_SERVER_ENABLED=true
 MCP_VELOCIRAPTOR_HOST=0.0.0.0
 MCP_VELOCIRAPTOR_PORT=8001
+
+# SOCFortress MDR Forwarding
+# When enabled, alerts for customers that have the "SOCFortress MDR" integration
+# deployed are forwarded to the MDR server (POST /api/v1/alerts/copilot). The
+# per-customer collector UUID is entered in the integration UI; MDR_COLLECTOR_UUID
+# below is only a single-tenant fallback.
+MDR_ENABLED=false
+MDR_SERVER_URL=https://mdr-server.socfortress.co:8443
+MDR_COLLECTOR_UUID=

--- a/backend/app/db/db_populate.py
+++ b/backend/app/db/db_populate.py
@@ -346,6 +346,7 @@ def get_available_integrations_list():
         ("BitDefender", "Integrate BitDefender with SOCFortress."),
         ("CATO", "Integrate CATO NETWORKS with SOCFortress."),
         ("DefenderForEndpoint", "Integrate DefenderForEndpoint with SOCFortress."),
+        ("SOCFortress MDR", "Forward alerts to the SOCFortress MDR server for this customer."),
         # ... Add more available integrations as needed ...
     ]
 
@@ -488,6 +489,7 @@ async def get_available_integrations_auth_keys_list(session: AsyncSession):
         ("DefenderForEndpoint", "CLIENT_ID"),
         ("DefenderForEndpoint", "CLIENT_SECRET"),
         ("DefenderForEndpoint", "SYSLOG_PORT"),
+        ("SOCFortress MDR", "COLLECTOR_UUID"),
         # ... Add more available integrations auth keys as needed ...
     ]
     logger.info("Getting available integrations auth keys.")

--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -655,6 +655,17 @@ async def handle_customer_notifications(
             ),
         )
 
+    # Forward alerts (not cases) to SOCFortress MDR when the customer has the
+    # integration deployed. Best-effort: never breaks alert creation.
+    if type == "alert":
+        from app.incidents.services.mdr_forwarder import forward_alert_to_mdr
+
+        await forward_alert_to_mdr(
+            customer_code=customer_code,
+            alert_payload=alert_payload,
+            session=session,
+        )
+
 
 # ! OLD FUNCTION ! #
 # async def create_alert_full(

--- a/backend/app/incidents/services/mdr_forwarder.py
+++ b/backend/app/incidents/services/mdr_forwarder.py
@@ -1,0 +1,168 @@
+"""
+Forward newly-created CoPilot alerts to the SOCFortress MDR server.
+
+When MDR forwarding is enabled (MDR_ENABLED) and a customer has the
+"SOCFortress MDR" integration deployed, this module POSTs the alert's indexer
+pointers + CoPilot alert ID to the MDR server:
+
+    POST {MDR_SERVER_URL}/api/v1/alerts/copilot
+    {
+        "collector_uuid":   <MDR_COLLECTOR_UUID>,
+        "index_name":       <Wazuh Indexer index name>,
+        "index_id":         <Wazuh Indexer document id>,
+        "copilot_alert_id": <CoPilot alert id>
+    }
+
+The MDR server authenticates the request by the collector UUID (no bearer
+token) and then tasks the customer's collector to fetch the authoritative
+document from the Wazuh Indexer. Forwarding is best-effort: failures are logged
+and never propagate to alert creation.
+"""
+
+import os
+from typing import Optional
+
+import httpx
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy.orm import joinedload
+
+from app.incidents.schema.incident_alert import CreatedAlertPayload
+from app.integrations.models.customer_integration_settings import CustomerIntegrations
+from app.integrations.models.customer_integration_settings import IntegrationSubscription
+
+# Name of the customer integration that gates MDR forwarding. Must match the
+# integration_service_name stored in the customer_integrations table and the
+# catalog entry seeded in app/db/db_populate.py.
+MDR_INTEGRATION_NAME = "SOCFortress MDR"
+
+_MDR_TIMEOUT_S = 30.0
+
+
+def _mdr_config() -> dict:
+    """Read global MDR forwarding config from the environment (see settings.py)."""
+    return {
+        "enabled": os.getenv("MDR_ENABLED", "False").lower() in ("true", "1", "yes"),
+        "server_url": os.getenv("MDR_SERVER_URL", "").rstrip("/"),
+        # Per-customer COLLECTOR_UUID (integration auth key) takes precedence; this
+        # env value is only a fallback for single-tenant CoPilot deployments.
+        "collector_uuid_fallback": os.getenv("MDR_COLLECTOR_UUID", ""),
+    }
+
+
+async def get_mdr_collector_uuid(
+    customer_code: str,
+    session: AsyncSession,
+) -> Optional[str]:
+    """
+    Return the MDR collector UUID for a customer, or None if the customer is not
+    an MDR customer.
+
+    Gating: the customer must have the "SOCFortress MDR" integration with
+    deployed=True. The collector UUID comes from that integration's COLLECTOR_UUID
+    auth key (per-customer); if absent, falls back to the MDR_COLLECTOR_UUID env
+    var (single-tenant convenience). Returns None if neither is available.
+    """
+    result = await session.execute(
+        select(CustomerIntegrations)
+        .options(
+            joinedload(CustomerIntegrations.integration_subscriptions).joinedload(
+                IntegrationSubscription.integration_auth_keys,
+            ),
+        )
+        .where(CustomerIntegrations.customer_code == customer_code)
+        .where(CustomerIntegrations.integration_service_name == MDR_INTEGRATION_NAME)
+        .where(CustomerIntegrations.deployed == True),  # noqa: E712 (SQLModel needs ==)
+    )
+    integration = result.scalars().unique().first()
+    if integration is None:
+        return None
+
+    for subscription in integration.integration_subscriptions:
+        for auth_key in subscription.integration_auth_keys:
+            if auth_key.auth_key_name == "COLLECTOR_UUID" and auth_key.auth_value:
+                return auth_key.auth_value
+
+    # Deployed but no per-customer COLLECTOR_UUID stored — fall back to env.
+    return _mdr_config()["collector_uuid_fallback"] or None
+
+
+async def forward_alert_to_mdr(
+    customer_code: str,
+    alert_payload: CreatedAlertPayload,
+    session: AsyncSession,
+) -> None:
+    """
+    Forward a freshly-created alert to the MDR server (best-effort, never raises).
+
+    Args:
+        customer_code: The customer the alert belongs to.
+        alert_payload: The created alert payload (carries alert_id + index pointers).
+        session: Async DB session, used to check the customer's integration.
+    """
+    try:
+        config = _mdr_config()
+
+        if not config["enabled"]:
+            return
+
+        if not config["server_url"]:
+            logger.warning(
+                "MDR_ENABLED is set but MDR_SERVER_URL is not configured — "
+                "skipping MDR forward",
+            )
+            return
+
+        # Need indexer pointers to forward; threshold/aggregation alerts that have
+        # no individual document cannot be fetched by the collector.
+        if not alert_payload.index_name or not alert_payload.index_id:
+            logger.info(
+                f"Skipping MDR forward for customer {customer_code}: alert has no "
+                f"index_name/index_id (likely a threshold/aggregation alert)",
+            )
+            return
+
+        if alert_payload.alert_id is None:
+            logger.warning(
+                f"Skipping MDR forward for customer {customer_code}: alert_id is not set",
+            )
+            return
+
+        # Gate: customer must have the SOCFortress MDR integration deployed. The
+        # collector UUID is resolved per-customer (auth key) with env fallback.
+        collector_uuid = await get_mdr_collector_uuid(customer_code, session)
+        if not collector_uuid:
+            # Not an MDR customer (or deployed without a collector UUID) — nothing to do.
+            return
+
+        url = f"{config['server_url']}/api/v1/alerts/copilot"
+        body = {
+            "collector_uuid": collector_uuid,
+            "index_name": alert_payload.index_name,
+            "index_id": alert_payload.index_id,
+            "copilot_alert_id": alert_payload.alert_id,
+        }
+
+        logger.info(
+            f"Forwarding CoPilot alert {alert_payload.alert_id} (customer {customer_code}) "
+            f"to MDR at {url}",
+        )
+
+        async with httpx.AsyncClient(timeout=_MDR_TIMEOUT_S) as client:
+            response = await client.post(url, json=body)
+
+        if response.status_code >= 400:
+            logger.error(
+                f"MDR forward failed for alert {alert_payload.alert_id} "
+                f"(HTTP {response.status_code}): {response.text[:300]}",
+            )
+            return
+
+        logger.info(
+            f"MDR forward accepted for alert {alert_payload.alert_id}: "
+            f"{response.text[:200]}",
+        )
+    except Exception as e:
+        # Best-effort: never let MDR forwarding break alert creation.
+        logger.error(f"MDR forward errored (non-fatal): {e!r}")

--- a/backend/app/incidents/services/mdr_forwarder.py
+++ b/backend/app/incidents/services/mdr_forwarder.py
@@ -30,7 +30,9 @@ from sqlalchemy.orm import joinedload
 
 from app.incidents.schema.incident_alert import CreatedAlertPayload
 from app.integrations.models.customer_integration_settings import CustomerIntegrations
-from app.integrations.models.customer_integration_settings import IntegrationSubscription
+from app.integrations.models.customer_integration_settings import (
+    IntegrationSubscription,
+)
 
 # Name of the customer integration that gates MDR forwarding. Must match the
 # integration_service_name stored in the customer_integrations table and the
@@ -109,8 +111,7 @@ async def forward_alert_to_mdr(
 
         if not config["server_url"]:
             logger.warning(
-                "MDR_ENABLED is set but MDR_SERVER_URL is not configured — "
-                "skipping MDR forward",
+                "MDR_ENABLED is set but MDR_SERVER_URL is not configured — " "skipping MDR forward",
             )
             return
 
@@ -145,8 +146,7 @@ async def forward_alert_to_mdr(
         }
 
         logger.info(
-            f"Forwarding CoPilot alert {alert_payload.alert_id} (customer {customer_code}) "
-            f"to MDR at {url}",
+            f"Forwarding CoPilot alert {alert_payload.alert_id} (customer {customer_code}) " f"to MDR at {url}",
         )
 
         async with httpx.AsyncClient(timeout=_MDR_TIMEOUT_S) as client:
@@ -154,14 +154,12 @@ async def forward_alert_to_mdr(
 
         if response.status_code >= 400:
             logger.error(
-                f"MDR forward failed for alert {alert_payload.alert_id} "
-                f"(HTTP {response.status_code}): {response.text[:300]}",
+                f"MDR forward failed for alert {alert_payload.alert_id} " f"(HTTP {response.status_code}): {response.text[:300]}",
             )
             return
 
         logger.info(
-            f"MDR forward accepted for alert {alert_payload.alert_id}: "
-            f"{response.text[:200]}",
+            f"MDR forward accepted for alert {alert_payload.alert_id}: " f"{response.text[:200]}",
         )
     except Exception as e:
         # Best-effort: never let MDR forwarding break alert creation.

--- a/backend/app/integrations/markdown/socfortress_mdr.md
+++ b/backend/app/integrations/markdown/socfortress_mdr.md
@@ -1,0 +1,29 @@
+# SOCFortress MDR
+
+Forward this customer's alerts to the SOCFortress MDR server.
+
+When deployed, every alert created in CoPilot for this customer is sent to the
+MDR server (`POST /api/v1/alerts/copilot`). The MDR server then tasks the
+customer's collector to fetch the authoritative document from the Wazuh Indexer
+and runs its analysis. Alert status changes made in MDR are pushed back to
+CoPilot automatically.
+
+## Requirements
+
+- The MDR server must be reachable from CoPilot. Set `MDR_ENABLED=true` and
+  `MDR_SERVER_URL` (e.g. `https://mdr-server.socfortress.co:8443`) in CoPilot's
+  `.env`.
+- The customer must have a registered collector on the MDR side.
+
+## Auth keys
+
+| Key | Description |
+| --- | --- |
+| `COLLECTOR_UUID` | The MDR collector UUID assigned to this customer. Used to authenticate the alert hand-off to the MDR server. |
+
+## Deploy
+
+After adding the integration with the customer's `COLLECTOR_UUID`, click
+**Deploy**. Provisioning validates the collector UUID and marks the integration
+active — no Graylog/Grafana resources are created (the MDR server pulls alerts
+on demand via the collector).

--- a/backend/app/integrations/socfortress_mdr/routes/provision.py
+++ b/backend/app/integrations/socfortress_mdr/routes/provision.py
@@ -16,9 +16,7 @@ from app.integrations.socfortress_mdr.schema.provision import (
 from app.integrations.socfortress_mdr.schema.provision import (
     ProvisionSOCFortressMDRResponse,
 )
-from app.integrations.socfortress_mdr.services.provision import (
-    INTEGRATION_NAME,
-)
+from app.integrations.socfortress_mdr.services.provision import INTEGRATION_NAME
 from app.integrations.socfortress_mdr.services.provision import (
     provision_socfortress_mdr,
 )

--- a/backend/app/integrations/socfortress_mdr/routes/provision.py
+++ b/backend/app/integrations/socfortress_mdr/routes/provision.py
@@ -1,0 +1,98 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import Security
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.utils import AuthHandler
+from app.db.db_session import get_db
+from app.integrations.routes import find_customer_integration
+from app.integrations.routes import get_customer_integrations_by_customer_code
+from app.integrations.schema import CustomerIntegrations
+from app.integrations.schema import CustomerIntegrationsResponse
+from app.integrations.socfortress_mdr.schema.provision import (
+    ProvisionSOCFortressMDRRequest,
+)
+from app.integrations.socfortress_mdr.schema.provision import (
+    ProvisionSOCFortressMDRResponse,
+)
+from app.integrations.socfortress_mdr.services.provision import (
+    INTEGRATION_NAME,
+)
+from app.integrations.socfortress_mdr.services.provision import (
+    provision_socfortress_mdr,
+)
+
+integration_socfortress_mdr_router = APIRouter()
+
+
+async def get_customer_integration_response(
+    customer_code: str,
+    session: AsyncSession,
+) -> CustomerIntegrationsResponse:
+    """Retrieve the integration settings for a customer (404 if none)."""
+    customer_integration_response = await get_customer_integrations_by_customer_code(
+        customer_code,
+        session,
+    )
+    if customer_integration_response.available_integrations == []:
+        raise HTTPException(
+            status_code=404,
+            detail="Customer integration settings not found.",
+        )
+    return customer_integration_response
+
+
+def extract_collector_uuid(customer_integration: CustomerIntegrations) -> str:
+    """Pull the COLLECTOR_UUID auth-key value off the SOCFortress MDR subscription."""
+    for subscription in customer_integration.integration_subscriptions:
+        if subscription.integration_service.service_name == INTEGRATION_NAME:
+            for auth_key in subscription.integration_auth_keys:
+                if auth_key.auth_key_name == "COLLECTOR_UUID":
+                    return auth_key.auth_value
+    raise HTTPException(
+        status_code=404,
+        detail=(
+            "COLLECTOR_UUID auth key not found for the SOCFortress MDR integration. "
+            "Add the integration with a COLLECTOR_UUID before deploying."
+        ),
+    )
+
+
+@integration_socfortress_mdr_router.post(
+    "/provision",
+    response_model=ProvisionSOCFortressMDRResponse,
+    description="Provision SOCFortress MDR integration for a customer.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def provision_socfortress_mdr_route(
+    provision_request: ProvisionSOCFortressMDRRequest,
+    session: AsyncSession = Depends(get_db),
+) -> ProvisionSOCFortressMDRResponse:
+    """
+    Provision SOCFortress MDR for a customer: validate the COLLECTOR_UUID auth key
+    is present, then mark the integration deployed (enabling alert forwarding).
+    """
+    customer_integration_response = await get_customer_integration_response(
+        provision_request.customer_code,
+        session,
+    )
+
+    customer_integration = await find_customer_integration(
+        provision_request.customer_code,
+        provision_request.integration_name,
+        customer_integration_response,
+    )
+
+    collector_uuid = extract_collector_uuid(customer_integration)
+    if not collector_uuid or not collector_uuid.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="COLLECTOR_UUID is empty. Provide the MDR collector UUID before deploying.",
+        )
+
+    return await provision_socfortress_mdr(
+        customer_code=provision_request.customer_code,
+        collector_uuid=collector_uuid,
+        session=session,
+    )

--- a/backend/app/integrations/socfortress_mdr/schema/provision.py
+++ b/backend/app/integrations/socfortress_mdr/schema/provision.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class ProvisionSOCFortressMDRRequest(BaseModel):
+    customer_code: str = Field(
+        ...,
+        description="The customer code.",
+        examples=["00001"],
+    )
+    integration_name: str = Field(
+        "SOCFortress MDR",
+        description="The integration name.",
+        examples=["SOCFortress MDR"],
+    )
+
+
+class ProvisionSOCFortressMDRResponse(BaseModel):
+    success: bool
+    message: str

--- a/backend/app/integrations/socfortress_mdr/services/provision.py
+++ b/backend/app/integrations/socfortress_mdr/services/provision.py
@@ -59,8 +59,7 @@ async def provision_socfortress_mdr(
         ProvisionSOCFortressMDRResponse
     """
     logger.info(
-        f"Provisioning SOCFortress MDR integration for customer {customer_code} "
-        f"(collector {collector_uuid})",
+        f"Provisioning SOCFortress MDR integration for customer {customer_code} " f"(collector {collector_uuid})",
     )
     await update_customer_integration_table(customer_code, session)
     return ProvisionSOCFortressMDRResponse(

--- a/backend/app/integrations/socfortress_mdr/services/provision.py
+++ b/backend/app/integrations/socfortress_mdr/services/provision.py
@@ -1,0 +1,69 @@
+from loguru import logger
+from sqlalchemy import and_
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.integrations.models.customer_integration_settings import CustomerIntegrations
+from app.integrations.socfortress_mdr.schema.provision import (
+    ProvisionSOCFortressMDRResponse,
+)
+
+INTEGRATION_NAME = "SOCFortress MDR"
+
+
+async def update_customer_integration_table(
+    customer_code: str,
+    session: AsyncSession,
+) -> None:
+    """
+    Set `deployed = True` on the customer's "SOCFortress MDR" integration row.
+
+    Args:
+        customer_code (str): The customer code.
+        session (AsyncSession): The async database session.
+    """
+    logger.info(f"Marking SOCFortress MDR integration deployed for customer {customer_code}")
+    await session.execute(
+        update(CustomerIntegrations)
+        .where(
+            and_(
+                CustomerIntegrations.customer_code == customer_code,
+                CustomerIntegrations.integration_service_name == INTEGRATION_NAME,
+            ),
+        )
+        .values(deployed=True),
+    )
+    await session.commit()
+
+
+async def provision_socfortress_mdr(
+    customer_code: str,
+    collector_uuid: str,
+    session: AsyncSession,
+) -> ProvisionSOCFortressMDRResponse:
+    """
+    Provision the SOCFortress MDR integration for a customer.
+
+    Unlike most integrations there is no Graylog/Grafana infrastructure to stand
+    up here — the MDR server and the customer's collector already exist. The MDR
+    server pulls alerts on demand via the collector. Provisioning therefore just
+    records the COLLECTOR_UUID (already validated by the route) and marks the
+    integration deployed so alert forwarding is enabled for this customer.
+
+    Args:
+        customer_code (str): The customer code.
+        collector_uuid (str): The MDR collector UUID for this customer.
+        session (AsyncSession): The async database session.
+
+    Returns:
+        ProvisionSOCFortressMDRResponse
+    """
+    logger.info(
+        f"Provisioning SOCFortress MDR integration for customer {customer_code} "
+        f"(collector {collector_uuid})",
+    )
+    await update_customer_integration_table(customer_code, session)
+    return ProvisionSOCFortressMDRResponse(
+        success=True,
+        message="SOCFortress MDR integration provisioned successfully.",
+    )

--- a/backend/app/routers/socfortress_mdr.py
+++ b/backend/app/routers/socfortress_mdr.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+from app.integrations.socfortress_mdr.routes.provision import (
+    integration_socfortress_mdr_router,
+)
+
+# Instantiate the APIRouter
+router = APIRouter()
+
+# Include the SOCFortress MDR related routes
+router.include_router(
+    integration_socfortress_mdr_router,
+    prefix="/socfortress_mdr",
+    tags=["SOCFortress MDR"],
+)

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -47,7 +47,6 @@ from app.routers import alert_creation_settings
 from app.routers import auth
 from app.routers import bitdefender
 from app.routers import carbonblack
-from app.routers import socfortress_mdr
 from app.routers import cato
 from app.routers import connectors
 from app.routers import copilot_action
@@ -86,6 +85,7 @@ from app.routers import scheduler
 from app.routers import scoutsuite
 from app.routers import shuffle
 from app.routers import siem
+from app.routers import socfortress_mdr
 from app.routers import stack_provisioning
 from app.routers import sublime
 from app.routers import talon

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -47,6 +47,7 @@ from app.routers import alert_creation_settings
 from app.routers import auth
 from app.routers import bitdefender
 from app.routers import carbonblack
+from app.routers import socfortress_mdr
 from app.routers import cato
 from app.routers import connectors
 from app.routers import copilot_action
@@ -214,6 +215,7 @@ api_router.include_router(carbonblack.router)
 api_router.include_router(network_connectors.router)
 api_router.include_router(crowdstrike.router)
 api_router.include_router(bitdefender.router)
+api_router.include_router(socfortress_mdr.router)
 api_router.include_router(scoutsuite.router)
 api_router.include_router(nuclei.router)
 api_router.include_router(duo.router)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -45,5 +45,5 @@ SQLALCHEMY_TRACK_MODIFICATIONS = env.bool(
 # to fetch the authoritative indexer document. One CoPilot stack maps to one
 # MDR collector, so the collector UUID and MDR base URL are global env values.
 MDR_ENABLED = env.bool("MDR_ENABLED", default=False)
-MDR_SERVER_URL = env.str("MDR_SERVER_URL", default="")  # e.g. https://mdr-server.socfortress.co:8443
+MDR_SERVER_URL = env.str("MDR_SERVER_URL", default="https://mdr-server.socfortress.co")
 MDR_COLLECTOR_UUID = env.str("MDR_COLLECTOR_UUID", default="")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -35,3 +35,15 @@ SQLALCHEMY_TRACK_MODIFICATIONS = env.bool(
     "SQLALCHEMY_TRACK_MODIFICATIONS",
     default=False,
 )
+
+# ---------------------------------------------------------------------------
+# SOCFortress MDR forwarding
+# ---------------------------------------------------------------------------
+# When enabled, newly-created alerts for customers that have the "SOCFortress
+# MDR" integration deployed are forwarded to the MDR server's
+# POST /api/v1/alerts/copilot endpoint. The MDR server then tasks the collector
+# to fetch the authoritative indexer document. One CoPilot stack maps to one
+# MDR collector, so the collector UUID and MDR base URL are global env values.
+MDR_ENABLED = env.bool("MDR_ENABLED", default=False)
+MDR_SERVER_URL = env.str("MDR_SERVER_URL", default="")  # e.g. https://mdr-server.socfortress.co:8443
+MDR_COLLECTOR_UUID = env.str("MDR_COLLECTOR_UUID", default="")

--- a/frontend/src/api/endpoints/integrations.ts
+++ b/frontend/src/api/endpoints/integrations.ts
@@ -132,6 +132,12 @@ export default {
 			customer_code: customerCode,
 			integration_name: integrationName || "DefenderForEndpoint"
 		})
+	},
+	socfortressMdrProvision(customerCode: string, integrationName: string) {
+		return HttpClient.post<FlaskBaseResponse>(`/socfortress_mdr/provision`, {
+			customer_code: customerCode,
+			integration_name: integrationName || "SOCFortress MDR"
+		})
 	}
 	// #endregion
 }

--- a/frontend/src/components/customers/integrations/CustomerIntegrationActions.vue
+++ b/frontend/src/components/customers/integrations/CustomerIntegrationActions.vue
@@ -58,6 +58,7 @@ const isDarktrace = computed(() => serviceName.value === "Darktrace")
 const isBitdefender = computed(() => serviceName.value === "BitDefender")
 const isCato = computed(() => serviceName.value === "CATO")
 const isDefenderForEndpoint = computed(() => serviceName.value === "DefenderForEndpoint")
+const isSOCFortressMdr = computed(() => serviceName.value === "SOCFortress MDR")
 const isDeployEnabled = computed(
 	() =>
 		(isOffice365.value ||
@@ -67,7 +68,8 @@ const isDeployEnabled = computed(
 			isDarktrace.value ||
 			isBitdefender.value ||
 			isCato.value ||
-			isDefenderForEndpoint.value) &&
+			isDefenderForEndpoint.value ||
+			isSOCFortressMdr.value) &&
 		!integration.deployed
 )
 
@@ -105,6 +107,9 @@ function provision() {
 	}
 	if (isDefenderForEndpoint.value) {
 		apiCall = Api.integrations.defenderForEndpointProvision(customerCode.value, serviceName.value)
+	}
+	if (isSOCFortressMdr.value) {
+		apiCall = Api.integrations.socfortressMdrProvision(customerCode.value, serviceName.value)
 	}
 
 	if (!apiCall) {


### PR DESCRIPTION
## Summary

Adds a **SOCFortress MDR** customer integration that forwards newly-created CoPilot alerts to the MDR server, gated per-customer. When a customer has the integration **deployed**, every alert created for that customer is POSTed to the MDR server's `POST /api/v1/alerts/copilot` with the alert's Wazuh Indexer pointers + the CoPilot alert id. The MDR server then tasks that customer's collector to fetch the authoritative document and analyze it. (Status changes made in MDR are pushed back to CoPilot by the collector — that side lives in the MDR server/collector repos.)

## How an admin enables it (UI)

Customers → *customer* → Integrations → **Add Integration** → **SOCFortress MDR** → enter `COLLECTOR_UUID` → Save → **Deploy**.

- Deploy calls `POST /socfortress_mdr/provision`, which validates the `COLLECTOR_UUID` and sets `customer_integrations.deployed = True` (the flag the forwarder gates on).

## Changes

**Backend**
- **Catalog** (`app/db/db_populate.py`): seed `SOCFortress MDR` + `COLLECTOR_UUID` auth key (idempotent on restart, so it appears in the UI automatically).
- **Provision module** (`app/integrations/socfortress_mdr/` + `app/routers/socfortress_mdr.py`, registered in `copilot.py`): mirrors the existing integration provision pattern (BitDefender). No Graylog/Grafana infra is created — the MDR server pulls alerts on demand — so provisioning just validates the collector UUID and flips `deployed=True`.
- **Forwarder** (`app/incidents/services/mdr_forwarder.py`): hooked into `handle_customer_notifications` (every alert-creation path). Resolves the collector UUID **per-customer** from the integration's `COLLECTOR_UUID` auth key (`MDR_COLLECTOR_UUID` env is a single-tenant fallback). Best-effort — never breaks alert creation; skips alerts with no `index_name`/`index_id` (e.g. threshold/aggregation alerts).
- **Config** (`settings.py`, `.env.example`): `MDR_ENABLED`, `MDR_SERVER_URL`, `MDR_COLLECTOR_UUID`.

**Frontend**
- `api/endpoints/integrations.ts`: `socfortressMdrProvision()`.
- `CustomerIntegrationActions.vue`: enable + wire the Deploy button for the new integration (per-integration wiring is hardcoded in the frontend, so it must be added explicitly).

## Deploy notes
- Set `MDR_ENABLED=true` and `MDR_SERVER_URL` in CoPilot's `.env`.
- A backend restart is required once so catalog seeding adds the integration to `available_integrations`.

## Testing
- Backend changes verified by `py_compile`. Frontend changes verified by inspection against the existing provision pattern (not executed in CI locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)