### PR TITLE
fix(customer-portal): repair self-service password change (#896)

### DIFF
--- a/backend/app/auth/models/users.py
+++ b/backend/app/auth/models/users.py
@@ -200,6 +200,10 @@ class PasswordResetToken(BaseModel):
 
 class PasswordReset(BaseModel):
     username: str
+    # Optional: when supplied (e.g. customer-portal self-service flow) the route verifies it
+    # against the stored hash before changing the password. Admin/analyst reset flows that
+    # already prove identity via the JWT may omit it, preserving backwards compatibility.
+    current_password: Optional[str] = None
     # 8-72 chars — bcrypt's 72-byte input limit (matches UserInput).
     new_password: str = Field(
         max_length=72,

--- a/backend/app/auth/routes/auth.py
+++ b/backend/app/auth/routes/auth.py
@@ -315,6 +315,8 @@ async def reset_password_me(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     await auth_handler.verify_reset_token_me(token, user)
+    if request.current_password is not None and not auth_handler.verify_password(request.current_password, user.password):
+        raise HTTPException(status_code=400, detail="Current password is incorrect")
     hashed_pwd = auth_handler.get_password_hash(request.new_password)
     user.password = hashed_pwd
     session.add(user)

--- a/customer-portal/src/api/endpoints/auth.ts
+++ b/customer-portal/src/api/endpoints/auth.ts
@@ -18,9 +18,10 @@ export default {
 		return HttpClient.post<CommonResponse<AuthResponse>>("/auth/refresh", { refresh_token: refreshToken })
 	},
 
-	resetPassword(username: string, newPassword: string) {
+	resetPassword(username: string, newPassword: string, currentPassword: string) {
 		return HttpClient.post<CommonResponse>("/auth/reset-password/me", {
 			username,
+			current_password: currentPassword,
 			new_password: newPassword
 		})
 	}

--- a/customer-portal/src/components/auth/ChangePasswordModal.vue
+++ b/customer-portal/src/components/auth/ChangePasswordModal.vue
@@ -62,6 +62,7 @@ import { NButton, NForm, NFormItem, NInput, NModal, useMessage } from "naive-ui"
 import { computed, ref } from "vue"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
+import { useAuthStore } from "@/stores/auth"
 import { getApiErrorMessage } from "@/utils"
 
 const emit = defineEmits<{
@@ -73,6 +74,7 @@ const isOpen = defineModel<boolean>("open", { default: false })
 const loading = defineModel<boolean>("loading", { default: false })
 
 const message = useMessage()
+const authStore = useAuthStore()
 const currentPassword = ref("")
 const newPassword = ref("")
 const confirmPassword = ref("")
@@ -104,29 +106,26 @@ async function handleSubmit() {
 		return
 	}
 
-	// Validate password length
-	if (newPassword.value.length < 8) {
-		message.error("Password must be at least 8 characters long")
+	// Mirror the backend complexity requirements so the user gets a clear message
+	// instead of an opaque 422 from the API.
+	if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&#])[A-Za-z\d@$!%*?&#]{8,72}$/.test(newPassword.value)) {
+		message.error(
+			"Password must be 8-72 characters and include an uppercase letter, a lowercase letter, a number, and a special character (@$!%*?&#)"
+		)
+		return
+	}
+
+	const username = authStore.userName
+	if (!username) {
+		message.error("Authentication required. Please log in again.")
 		return
 	}
 
 	loading.value = true
 
 	try {
-		// Get token and username from localStorage
-		const token = localStorage.getItem("customer-portal-auth-token")
-		const userStr = localStorage.getItem("customer-portal-user")
-
-		if (!token || !userStr) {
-			message.error("Authentication required. Please log in again.")
-			return
-		}
-
-		const user = JSON.parse(userStr)
-		const username = user.username
-
-		// Call the reset-password/me endpoint
-		const response = await Api.auth.resetPassword(username, newPassword.value)
+		// Token is injected by the HTTP client from the auth store.
+		const response = await Api.auth.resetPassword(username, newPassword.value, currentPassword.value)
 
 		if (response.data.success) {
 			message.success("Password changed successfully!")


### PR DESCRIPTION
Closes #896

## Problem

Customer-portal users could not change their password. Clicking **Change Password** and submitting produced `Authentication required. Please log in again.`

**Root cause:** `ChangePasswordModal.vue` read the JWT and user from `localStorage.getItem("customer-portal-auth-token")` / `"customer-portal-user")` — keys that don't exist. The portal auth store persists encrypted via secure-ls under `__persisted-session__auth`, so both lookups returned `null` and the modal bailed before calling the API.

## Changes

**Frontend (customer-portal)**
- `ChangePasswordModal.vue` — source `username` from `useAuthStore()` instead of phantom localStorage keys. The Bearer token is already injected by `httpClient`, so no manual token handling is needed. Forwards the already-collected current password, and validates the new password against the backend's full complexity rules client-side (previously only checked length ≥ 8, which silently 422'd on weak passwords).
- `api/endpoints/auth.ts` — `resetPassword()` now forwards `current_password`.

**Backend**
- `PasswordReset` schema gains an optional `current_password`.
- `/auth/reset-password/me` verifies `current_password` against the stored hash **when supplied** (400 on mismatch). Optional so the analyst UI — which uses the same endpoint without a current password — keeps working.

The "Current Password" field the portal already displayed is now meaningful: previously it was collected and discarded, so anyone with a live session could change the password without knowing the old one.

## Testing
- `pnpm type-check` passes (customer-portal)
- Backend files syntax-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)