### PR TITLE
fix(users): reliably populate a user's assigned customers in Assign Customer (#899)

### DIFF
--- a/frontend/src/components/users/AssignCustomer.vue
+++ b/frontend/src/components/users/AssignCustomer.vue
@@ -146,4 +146,19 @@ watch(showModal, newVal => {
 		loadCurrentAccess()
 	}
 })
+
+// This instance is reused across table rows, so the bound user can change while
+// mounted. Reload that user's access if it changes while the modal is open, and
+// clear stale state otherwise so a previous user's data is never shown. See #899.
+watch(
+	() => props.user?.id,
+	() => {
+		if (showModal.value) {
+			loadCurrentAccess()
+		} else {
+			currentAccess.value = []
+			formModel.value.customerCodes = []
+		}
+	}
+)
 </script>

--- a/frontend/src/components/users/UsersList.vue
+++ b/frontend/src/components/users/UsersList.vue
@@ -153,7 +153,13 @@ function getRoleTagType(roleName: string | null | undefined) {
 	}
 }
 
-const options = [
+// Computed (not a static array) so the dropdown re-renders whenever `selectedUser`
+// changes. The render closures below read `selectedUser.value`, but the parent
+// template never references it directly — if `options` were a stable array
+// reference, NDropdown would never re-render and the child modals (kept mounted by
+// `display-directive="show"`) would keep a stale `user` prop, intermittently
+// showing the wrong user's data or nothing at all. See issue #899.
+const options = computed(() => [
 	{
 		key: "AssignRole",
 		type: "render",
@@ -202,7 +208,7 @@ const options = [
 				onLoading: updateLoadingDelete
 			})
 	}
-]
+])
 
 function updateLoadingDelete(value: boolean) {
 	loadingDelete.value = value


### PR DESCRIPTION
## Summary

Closes #899. On the `/users` page, opening **Assign Customer** for a user only *sometimes* showed/pre-selected that user's current customer access — flaky behavior.

## Root cause

In `UsersList.vue`, the per-row action dropdown used a **static `const options` array** whose render closures read `selectedUser.value`. The parent template never references `selectedUser` directly, and every row's `<n-dropdown :options>` received the same stable array reference — so changing `selectedUser` (via `@click="selectedUser = user"`) never forced `NDropdown` to re-render. Combined with `display-directive="show"` keeping the menu (and the `AssignCustomer` modal inside it) mounted, the modal kept a **stale `user` prop**, usually the initial `undefined`. `AssignCustomer.loadCurrentAccess()` then hit its `if (!props.user) return` guard and silently populated nothing. It was intermittent because an unrelated re-render occasionally refreshed the closures with the correct user — the "sometimes it works" symptom.

## Fix

- **`UsersList.vue`** — `options` is now a `computed(() => [...])` keyed on `selectedUser`, so each selection yields a new array reference, forcing the dropdown to re-render its render closures with the current user. This also fixes the identical latent bug in the sibling row actions (`AssignRole`, `AssignTags`, `ChangePassword`, `DeleteUser`).
- **`AssignCustomer.vue`** — reload access when the bound user changes while the modal is open, and clear stale state otherwise, so a previous user's data is never shown.

## Verification

`pnpm type-check` and `eslint` pass. Manually confirmed by the maintainer on the `/users` page — current access now populates consistently across users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)