### PR TITLE
fix(ai-analyst): reject report submissions missing body fields

### DIFF
--- a/backend/app/ai_analyst/schema/ai_analyst.py
+++ b/backend/app/ai_analyst/schema/ai_analyst.py
@@ -136,8 +136,7 @@ class SubmitReportRequest(BaseModel):
         ]
         if missing:
             raise ValueError(
-                f"Report body fields must be non-empty: {', '.join(missing)}. "
-                "A report missing these persists a blank row in CoPilot."
+                f"Report body fields must be non-empty: {', '.join(missing)}. " "A report missing these persists a blank row in CoPilot.",
             )
         return self
 

--- a/backend/app/ai_analyst/schema/ai_analyst.py
+++ b/backend/app/ai_analyst/schema/ai_analyst.py
@@ -7,6 +7,7 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import field_validator
+from pydantic import model_validator
 
 # --- Enums ---
 
@@ -116,6 +117,29 @@ class SubmitReportRequest(BaseModel):
         if v is None:
             return v
         return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", v)
+
+    @model_validator(mode="after")
+    def require_report_body(self):
+        """Reject reports missing any human-readable body field.
+
+        The agent populates these from CLAUDE.md context; when a long-lived
+        session compacts, the field list can drop out and the agent calls this
+        with only job_id/alert_id/customer_code. Without this guard the row
+        persists with NULL bodies and surfaces as an empty report in CoPilot.
+        Runs after strip_control_characters, so all-control-char values that
+        collapse to "" are caught here too.
+        """
+        missing = [
+            name
+            for name in ("severity_assessment", "summary", "report_markdown", "recommended_actions")
+            if not (getattr(self, name) and str(getattr(self, name)).strip())
+        ]
+        if missing:
+            raise ValueError(
+                f"Report body fields must be non-empty: {', '.join(missing)}. "
+                "A report missing these persists a blank row in CoPilot."
+            )
+        return self
 
 
 class SubmitIocRequest(BaseModel):

--- a/backend/tests/test_submit_report_validation.py
+++ b/backend/tests/test_submit_report_validation.py
@@ -28,9 +28,7 @@ def test_complete_report_is_accepted():
     assert req.report_markdown == "# Full report\n\nDetails."
 
 
-@pytest.mark.parametrize(
-    "field", ["severity_assessment", "summary", "report_markdown", "recommended_actions"]
-)
+@pytest.mark.parametrize("field", ["severity_assessment", "summary", "report_markdown", "recommended_actions"])
 def test_missing_body_field_is_rejected(field):
     payload = {k: v for k, v in COMPLETE.items() if k != field}
     with pytest.raises(ValidationError) as excinfo:

--- a/backend/tests/test_submit_report_validation.py
+++ b/backend/tests/test_submit_report_validation.py
@@ -1,0 +1,60 @@
+"""Tests for SubmitReportRequest body-completeness validation.
+
+A report submitted without its human-readable body fields must be rejected, not
+silently persisted as a blank row. These are pure Pydantic-model tests — no DB
+or app wiring required.
+
+Run with: cd backend && pip install pytest && python -m pytest tests/
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai_analyst.schema.ai_analyst import SubmitReportRequest
+
+COMPLETE = dict(
+    job_id="copilot-inv-1-abc",
+    alert_id=1,
+    customer_code="acme",
+    severity_assessment="High",
+    summary="Short tl;dr.",
+    report_markdown="# Full report\n\nDetails.",
+    recommended_actions="Isolate host.",
+)
+
+
+def test_complete_report_is_accepted():
+    req = SubmitReportRequest(**COMPLETE)
+    assert req.report_markdown == "# Full report\n\nDetails."
+
+
+@pytest.mark.parametrize(
+    "field", ["severity_assessment", "summary", "report_markdown", "recommended_actions"]
+)
+def test_missing_body_field_is_rejected(field):
+    payload = {k: v for k, v in COMPLETE.items() if k != field}
+    with pytest.raises(ValidationError) as excinfo:
+        SubmitReportRequest(**payload)
+    assert field in str(excinfo.value)
+
+
+@pytest.mark.parametrize("field", ["summary", "report_markdown", "recommended_actions"])
+def test_blank_or_whitespace_body_field_is_rejected(field):
+    payload = {**COMPLETE, field: "   "}
+    with pytest.raises(ValidationError) as excinfo:
+        SubmitReportRequest(**payload)
+    assert field in str(excinfo.value)
+
+
+def test_control_chars_only_body_is_rejected():
+    # strip_control_characters collapses this to "" before require_report_body runs.
+    payload = {**COMPLETE, "report_markdown": "\x00\x01\x02"}
+    with pytest.raises(ValidationError) as excinfo:
+        SubmitReportRequest(**payload)
+    assert "report_markdown" in str(excinfo.value)
+
+
+def test_minimal_call_missing_all_bodies_is_rejected():
+    # The exact failure mode from production: agent sends only the identifiers.
+    with pytest.raises(ValidationError):
+        SubmitReportRequest(job_id="j", alert_id=1, customer_code="acme")


### PR DESCRIPTION
## Summary

`SubmitReportRequest` accepted reports with all four body fields (`severity_assessment`, `summary`, `report_markdown`, `recommended_actions`) omitted or blank — and the service persisted the row anyway with `NULL` bodies, surfacing as an empty report in CoPilot.

This is the server-side guard for a production failure mode: when a long-lived agent (Claude Code) session compacts, the report schema can drop out of context and the agent calls the tool with only `job_id` / `alert_id` / `customer_code`. (Talon PR #7 re-injects the schema into the prompt to make the agent *try* to send the body; this PR makes the API *reject* it loudly if the body is ever missing again — belt and suspenders.)

## Change

`backend/app/ai_analyst/schema/ai_analyst.py` — add a `@model_validator(mode="after")` to `SubmitReportRequest` that raises (→ FastAPI **422**) when any body field is `None` or whitespace-only. It runs *after* the existing `strip_control_characters` validator, so values that collapse to `""` (all control chars) are caught too. No DB migration, no service-layer change.

## Tests

Adds `backend/tests/` (the first tests in `backend/`) covering: complete submission accepted; each missing field rejected; blank/whitespace rejected; control-char-only rejected; and the exact production case (identifiers only) rejected.

```
cd backend && pip install pytest pydantic && python -m pytest tests/
# 10 passed
```

I ran this locally against `pydantic>=2,<3` — all 10 pass.

> Note: `backend/` has no existing test harness (no `pytest` in requirements, no CI test step that I could find). These tests are self-contained (only need `pydantic`) and runnable as above, but won't auto-run until a harness is wired up. Happy to add that in a follow-up if useful.

## Optional follow-up (not in this PR)

DB-level `nullable=False` on the three columns (`universal_models.py`) would be true defense-in-depth, but needs an Alembic migration plus backfilling/removing existing blank rows. The schema guard prevents new ones; the migration can come separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)