### PR TITLE
fix(auth): reject 2fa_pending tokens at session decode (GHSA-5m69-7h2p-6qfw)

### DIFF
--- a/backend/app/auth/utils.py
+++ b/backend/app/auth/utils.py
@@ -181,6 +181,13 @@ class AuthHandler:
         """
         try:
             payload = jwt.decode(token, self.secret, algorithms=["HS256"])
+            # Reject the short-lived "2fa_pending" token issued by /auth/token when
+            # 2FA is required. It is signed with the same JWT_SECRET as a real session
+            # token, but the second factor has NOT been completed yet, so it must never
+            # be accepted as a session. Only /auth/2fa/validate (via _decode_temp_token)
+            # may consume it. See GHSA-5m69-7h2p-6qfw.
+            if payload.get("type") == "2fa_pending":
+                return "2FA pending", []
             return payload["sub"], payload.get("scopes", [])
         except jwt.ExpiredSignatureError:
             return "Expired signature", []
@@ -226,6 +233,12 @@ class AuthHandler:
                 raise HTTPException(
                     status_code=401,
                     detail="Invalid token",
+                    headers={"WWW-Authenticate": authenticate_value},
+                )
+            if username == "2FA pending":
+                raise HTTPException(
+                    status_code=401,
+                    detail="Two-factor authentication required. Complete 2FA verification to obtain a session token.",
                     headers={"WWW-Authenticate": authenticate_value},
                 )
         except Exception as e:
@@ -304,6 +317,12 @@ class AuthHandler:
                 raise HTTPException(
                     status_code=401,
                     detail="Invalid token",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            if username == "2FA pending":
+                raise HTTPException(
+                    status_code=401,
+                    detail="Two-factor authentication required. Complete 2FA verification to obtain a session token.",
                     headers={"WWW-Authenticate": "Bearer"},
                 )
 

--- a/backend/tests/test_2fa_pending_token_rejection.py
+++ b/backend/tests/test_2fa_pending_token_rejection.py
@@ -1,0 +1,50 @@
+"""Regression tests for GHSA-5m69-7h2p-6qfw — 2FA bypass via token refresh.
+
+A "2fa_pending" token is issued by POST /auth/token when the account has 2FA
+enabled, but the second factor has NOT been completed. It is signed with the
+same JWT_SECRET as a real session token, so the decode chokepoint must reject
+it everywhere a session token is expected (e.g. /auth/refresh,
+/auth/me/customers). Only POST /auth/2fa/validate (via _decode_temp_token) may
+consume it.
+
+These are pure unit tests against the decode layer — no DB or app wiring.
+
+Run with: cd backend && python -m pytest tests/test_2fa_pending_token_rejection.py
+"""
+
+import os
+
+# AuthHandler loads JWT_SECRET at class-definition time, so it must be set
+# before importing the module under test.
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.auth.routes.totp import _create_temp_token  # noqa: E402
+from app.auth.routes.totp import _decode_temp_token  # noqa: E402
+from app.auth.utils import AuthHandler  # noqa: E402
+
+auth_handler = AuthHandler()
+
+
+def test_2fa_pending_token_is_rejected_by_decode_token():
+    temp_token = _create_temp_token("admin")
+    username, scopes = auth_handler.decode_token(temp_token)
+    # Must surface the dedicated sentinel, never the real subject/scopes.
+    assert username == "2FA pending"
+    assert scopes == []
+
+
+def test_full_session_token_still_decodes_normally():
+    # A normal session token carries scopes and no 2fa_pending type.
+    import jwt
+
+    payload = {"sub": "admin", "scopes": ["admin"]}
+    token = jwt.encode(payload, auth_handler.secret, algorithm="HS256")
+    username, scopes = auth_handler.decode_token(token)
+    assert username == "admin"
+    assert scopes == ["admin"]
+
+
+def test_2fa_validate_path_still_accepts_pending_token():
+    # The intended consumer must keep working — otherwise 2FA login is broken.
+    temp_token = _create_temp_token("admin")
+    assert _decode_temp_token(temp_token) == "admin"


### PR DESCRIPTION
## Security fix — GHSA-5m69-7h2p-6qfw (critical, CVSS 9.8)

**Two-Factor Authentication bypass via the token refresh endpoint.**

### Root cause
When 2FA is enabled, `POST /api/auth/token` returns a short-lived `2fa_pending` JWT signed with the same `JWT_SECRET` as a real session token. `AuthHandler.decode_token` never inspected the `type` claim, so the pending token was accepted by any dependency-guarded route. The unscoped `GET /api/auth/refresh` would then exchange it for a full-role access token **without the second factor ever being completed**, fully defeating 2FA. `GET /api/auth/me/customers` shared the same exposure.

### Fix
Reject any token carrying `type == "2fa_pending"` at the single decode chokepoint (`decode_token`), surfacing a dedicated `"2FA pending"` sentinel that both `get_current_user` and `require_any_scope` turn into a `401`. Fixing the chokepoint covers every current and future dependency-guarded route at once, rather than patching individual endpoints.

The `POST /api/auth/2fa/validate` path is unaffected: it decodes via its own `_decode_temp_token` helper, which explicitly *requires* the `2fa_pending` type. Normal 2FA login still works; only the bypass is closed.

### Tests
Adds `backend/tests/test_2fa_pending_token_rejection.py`:
- `2fa_pending` token is rejected by `decode_token` (sentinel, no real subject/scopes)
- normal session token still decodes correctly
- the `/2fa/validate` path still accepts the pending token (login not broken)

All backend tests pass (10 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)