### PR TITLE
fix(authz): enforce tenant scoping on indexer reads (GHSA-ch48-63px-6wp2)

### DIFF
--- a/backend/app/incidents/routes/incident_alert.py
+++ b/backend/app/incidents/routes/incident_alert.py
@@ -94,7 +94,12 @@ async def get_alerts_not_created_route() -> AlertsPayload:
 @incidents_alerts_router.post(
     "/alert/details",
     description="Get the details of a single alert",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    # NOTE: customer_user is intentionally excluded. This reads an arbitrary
+    # index_name + alert_id directly from the indexer with no per-tenant check,
+    # so allowing the multi-tenant portal role enabled cross-tenant SIEM reads
+    # (GHSA-ch48-63px-6wp2). admin/analyst are all-tenant by design; the customer
+    # portal never calls this route (it uses /incidents/db_operations/* instead).
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def get_single_alert_details_route(
     create_alert_request: CreateAlertRequestRoute,
@@ -121,7 +126,12 @@ async def get_single_alert_details_route(
 @incidents_alerts_router.post(
     "/alert/timeline",
     description="Get the timeline of an alert",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    # NOTE: customer_user is intentionally excluded. This reads an arbitrary
+    # index_name + alert_id directly from the indexer with no per-tenant check,
+    # so allowing the multi-tenant portal role enabled cross-tenant SIEM reads
+    # (GHSA-ch48-63px-6wp2). admin/analyst are all-tenant by design; the customer
+    # portal never calls this route (it uses /incidents/db_operations/* instead).
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def get_alert_timeline_route(
     alert: CreateAlertRequestRoute,

--- a/backend/app/integrations/copilot_searches/routes/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/routes/copilot_searches.py
@@ -556,7 +556,12 @@ async def refresh_rules():
     "/execute",
     response_model=ExecuteSearchResponse,
     description="Execute a detection rule search against the Wazuh indexer",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    # NOTE: customer_user is intentionally excluded. This endpoint passes a
+    # caller-supplied index_pattern and CUSTOMER_CODE straight to the indexer
+    # with no per-tenant restriction, so allowing the multi-tenant portal role
+    # enabled cross-tenant SIEM reads (GHSA-ch48-63px-6wp2). admin/analyst are
+    # all-tenant by design; the customer portal never calls this route.
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def execute_search(request: ExecuteSearchRequest):
     """

--- a/backend/app/siem/routes/dashboards.py
+++ b/backend/app/siem/routes/dashboards.py
@@ -178,10 +178,11 @@ async def disable_dashboard_endpoint(
 )
 async def panel_data_endpoint(
     request: PanelDataRequest,
+    current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> PanelDataResponse:
     logger.info(f"Fetching panel data for dashboard {request.dashboard_id} (timerange={request.timerange})")
-    data = await get_panel_data(request.dashboard_id, request.timerange, db)
+    data = await get_panel_data(request.dashboard_id, request.timerange, db, current_user)
     return PanelDataResponse(
         panels=data["results"],
         template=data["template"],

--- a/backend/app/siem/services/dashboards.py
+++ b/backend/app/siem/services/dashboards.py
@@ -11,11 +11,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.connectors.wazuh_indexer.utils.universal import AlertsQueryBuilder
+from app.auth.models.users import User
 from app.connectors.wazuh_indexer.utils.universal import (
     create_wazuh_indexer_client_async,
 )
 from app.db.universal_models import EnabledDashboards
 from app.db.universal_models import EventSources
+from app.middleware.customer_access import customer_access_handler
 from app.siem.schema.dashboards import DashboardCategory
 from app.siem.schema.dashboards import DashboardCategoryWithTemplates
 from app.siem.schema.dashboards import DashboardTemplate
@@ -201,6 +203,7 @@ async def get_panel_data(
     dashboard_id: int,
     timerange: str,
     db: AsyncSession,
+    current_user: User,
 ) -> Dict[str, Any]:
     """Execute each panel's query and return aggregated data for ECharts."""
 
@@ -211,6 +214,14 @@ async def get_panel_data(
     dashboard = result.scalars().first()
     if not dashboard:
         raise HTTPException(status_code=404, detail="Enabled dashboard not found")
+
+    # Enforce per-tenant access BEFORE running any indexer query. The dashboard's
+    # customer_code is resolved server-side from the id, so a caller could
+    # otherwise enumerate dashboard ids to read another tenant's panel data
+    # (GHSA-ch48-63px-6wp2). admin/analyst are all-tenant; customer_user is
+    # limited to their assigned customers.
+    if not await customer_access_handler.check_customer_access(current_user, dashboard.customer_code, db):
+        raise HTTPException(status_code=403, detail=f"Access denied to customer {dashboard.customer_code}")
 
     # Load the event source to get index_pattern + time_field
     es_result = await db.execute(

--- a/backend/tests/test_panel_data_tenant_access.py
+++ b/backend/tests/test_panel_data_tenant_access.py
@@ -1,0 +1,95 @@
+"""Regression tests for GHSA-ch48-63px-6wp2 — cross-tenant SIEM read.
+
+The SIEM dashboard panel-data endpoint resolves a dashboard's customer_code
+server-side from a caller-supplied dashboard_id, then runs indexer queries. It
+is reachable by the lowest-privilege customer_user (portal) role, so it must
+reject a caller who is not authorized for that dashboard's customer BEFORE any
+indexer query runs — otherwise a portal user enumerates dashboard ids to read
+another tenant's data.
+
+These are unit tests against get_panel_data with a mocked DB session; no real
+DB or indexer is touched. The access gate sits before the event-source load, so
+an *authorized* caller falls through to a 404 ("Event source not found") here —
+that 404 is the signal the tenant gate was passed, not a failure.
+
+Run with: cd backend && python -m pytest tests/test_panel_data_tenant_access.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.auth.models.users import RoleEnum  # noqa: E402
+from app.siem.services.dashboards import get_panel_data  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+DASHBOARD_CUSTOMER = "TENANT_B"
+
+
+def _scalar_result(*, first=None, all_=None):
+    """Build a mock that mimics `await session.execute(...)` → result.scalars()."""
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.first.return_value = first
+    scalars.all.return_value = all_ if all_ is not None else []
+    result.scalars.return_value = scalars
+    return result
+
+
+def _session(execute_results):
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=execute_results)
+    return session
+
+
+def test_customer_user_without_access_is_denied():
+    dashboard = SimpleNamespace(id=1, customer_code=DASHBOARD_CUSTOMER, event_source_id=10)
+    user = SimpleNamespace(id=42, role_id=RoleEnum.customer_user.value)
+    # 1st execute: dashboard load. 2nd execute: the user's customer-access lookup
+    # (assigned only to TENANT_A, NOT the dashboard's TENANT_B).
+    session = _session([
+        _scalar_result(first=dashboard),
+        _scalar_result(all_=["TENANT_A"]),
+    ])
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_panel_data(dashboard_id=1, timerange="24h", db=session, current_user=user))
+    assert exc.value.status_code == 403
+    assert DASHBOARD_CUSTOMER in exc.value.detail
+
+
+def test_customer_user_with_access_passes_the_gate():
+    dashboard = SimpleNamespace(id=1, customer_code=DASHBOARD_CUSTOMER, event_source_id=10)
+    user = SimpleNamespace(id=7, role_id=RoleEnum.customer_user.value)
+    # Assigned to the dashboard's own tenant -> gate passes -> falls through to
+    # the event-source load, which we stub as missing (404).
+    session = _session([
+        _scalar_result(first=dashboard),
+        _scalar_result(all_=[DASHBOARD_CUSTOMER]),
+        _scalar_result(first=None),  # event source not found
+    ])
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_panel_data(dashboard_id=1, timerange="24h", db=session, current_user=user))
+    assert exc.value.status_code == 404  # passed tenant gate, failed later
+
+
+def test_admin_passes_the_gate_for_any_tenant():
+    dashboard = SimpleNamespace(id=1, customer_code=DASHBOARD_CUSTOMER, event_source_id=10)
+    user = SimpleNamespace(id=1, role_id=RoleEnum.admin.value)
+    # Admin is wildcard: no access-lookup query is issued, so the 2nd execute is
+    # the event-source load (stubbed missing).
+    session = _session([
+        _scalar_result(first=dashboard),
+        _scalar_result(first=None),  # event source not found
+    ])
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_panel_data(dashboard_id=1, timerange="24h", db=session, current_user=user))
+    assert exc.value.status_code == 404  # passed tenant gate, failed later


### PR DESCRIPTION
## Security fix — GHSA-ch48-63px-6wp2 (high, CVSS 7.7)

**Cross-tenant SIEM data read via unscoped indexer endpoints.**

### Root cause
Several indexer-backed endpoints were reachable by the lowest-privilege multi-tenant portal role (`customer_user`) and accepted a caller-supplied `index_pattern` / `CUSTOMER_CODE` / `id` with **no intersection against the caller's `UserCustomerAccess`**. A portal user of one tenant could read another tenant's alert documents — or every tenant at once via `index_pattern=wazuh-alerts-*`. The reporter confirmed it live against `copilot-backend:latest`. This is a **class** of endpoints, not one route.

### Fixes
**Drop `customer_user` from the scope** (these pass a caller-controlled index/id straight to the indexer with no per-tenant restriction, and the customer portal never calls them — it uses `/incidents/db_operations/*` and the already-scoped `/siem/events/*`; `admin`/`analyst` are all-tenant by design):
- `POST /api/copilot_searches/execute`
- `POST /api/incidents/alerts/alert/details`
- `POST /api/incidents/alerts/alert/timeline`

**Enforce tenant access** (the customer portal *does* use this one, so the role stays):
- `POST /api/siem/dashboards/panel-data` — `get_panel_data` resolves the dashboard's `customer_code` server-side from the id, so it now calls `check_customer_access` **before running any indexer query** and returns `403` for a caller not authorized for that tenant. `admin`/`analyst` keep wildcard access.

### Scope verification
Audited every API path the customer portal calls (`customer-portal/src/api/`): of the four affected endpoints, only `panel-data` is used by the portal. The other three are SOC-analyst (main app) features, so removing `customer_user` does not affect any client. The sibling `/siem/events/*` routes already enforce `check_customer_access`.

### Tests
Adds `backend/tests/test_panel_data_tenant_access.py` (pure unit, mocked session, no `pytest-asyncio` dependency):
- unauthorized `customer_user` → `403` before any indexer query
- authorized `customer_user` → passes the tenant gate
- `admin` → passes the gate for any tenant

Full backend suite: 16 passed.