### PR TITLE
fix(incidents): stop creating a 'not_applicable' index on the Wazuh indexer (#909)

### DIFF
--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -352,6 +352,14 @@ async def add_alert_to_document(
     Returns:
     - True if the update is successful, False otherwise.
     """
+    # Defense in depth (issue #909): never touch the "not_applicable" sentinel.
+    # It is not a real index — an es_client.update against it would auto-create
+    # a stray `not_applicable` index on the indexer. Velociraptor Sigma alerts
+    # with no backing Wazuh document carry this sentinel.
+    if alert.index_name == "not_applicable" or alert.alert_id == "not_applicable":
+        logger.info("Skipping document write-back for 'not_applicable' sentinel index/id")
+        return None
+
     es_client = await create_wazuh_indexer_client_async("Wazuh-Indexer")
     try:
         await es_client.update(
@@ -868,8 +876,16 @@ async def create_alert_full(
                         session=session,
                     )
 
-            # Update the document reference if needed
-            if alert_payload.index_name and alert_payload.index_id:
+            # Update the document reference if needed. Skip the "not_applicable"
+            # sentinel (Velociraptor Sigma alerts with no backing Wazuh document
+            # use it) — writing to it would auto-create a stray `not_applicable`
+            # index on the indexer (issue #909).
+            if (
+                alert_payload.index_name
+                and alert_payload.index_id
+                and alert_payload.index_name != "not_applicable"
+                and alert_payload.index_id != "not_applicable"
+            ):
                 await add_alert_to_document(
                     CreateAlertRequest(index_name=alert_payload.index_name, alert_id=alert_payload.index_id),
                     existing_alert_id,


### PR DESCRIPTION
Fixes #909.

## Problem
When an alert is created via Velociraptor's Sigma and the index is `not_applicable`, a stray index named `not_applicable` appears on the Wazuh indexer.

## Root cause
Velociraptor Sigma alerts with no backing Wazuh document are created with the sentinel `index_name="not_applicable"` / `index_id="not_applicable"` (see `velo_sigma.py`). In `create_alert_full`, the **existing-alert** path (when the Sigma alert matches an already-open alert) called `add_alert_to_document` guarded only by:

```python
if alert_payload.index_name and alert_payload.index_id:
```

`"not_applicable"` is a truthy string, so the guard passed and the code issued `es_client.update(index="not_applicable", ...)`. The indexer auto-creates a missing index on update → the stray `not_applicable` index.

The **new-alert** velo-sigma path already `return`s before its own write-back, so only the existing-alert path was affected.

## Fix (two layers)
1. **Call site** — the existing-alert write-back now skips the `not_applicable` sentinel, mirroring the exact guard the threshold-alert path already uses (`incident_alert.py` route line ~410).
2. **Defense in depth** — `add_alert_to_document` itself no-ops (returns `None`, logs) when the index/id is `not_applicable`, so no current or future caller can auto-create it. This also covers the other existing-alert update path at line ~1311.

No schema or behavior change for real Wazuh-backed alerts — they carry real index names and write back exactly as before.

## Testing
Verified the change is syntactically valid and audited every `add_alert_to_document` call site to confirm the in-function guard covers them all. (Per maintainer direction, no unit test added for this one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)