### PR TITLE
feat(portal): CSV export for customer-portal assets (#905)

### DIFF
--- a/customer-portal/src/components/agents/List.vue
+++ b/customer-portal/src/components/agents/List.vue
@@ -7,6 +7,19 @@
 				<Chip size="small" :value="loading ? 'Loading...' : paginatedTotal" label="items" />
 
 				<div class="flex items-center gap-2 whitespace-nowrap">
+					<n-button
+						size="small"
+						secondary
+						:disabled="loading || !paginatedTotal"
+						:focusable="false"
+						@click="exportCsv"
+					>
+						<template #icon>
+							<Icon name="carbon:download" />
+						</template>
+						Export CSV
+					</n-button>
+
 					<n-pagination
 						v-model:page="pagination.page"
 						v-model:page-size="pagination.pageSize"
@@ -61,7 +74,7 @@ import type { Agent } from "@/types/agents"
 import type { ApiError } from "@/types/common"
 import { useDebounceFn, useElementSize } from "@vueuse/core"
 import axios from "axios"
-import { NDataTable, NEmpty, NPagination, NTag, useMessage } from "naive-ui"
+import { NButton, NDataTable, NEmpty, NPagination, NTag, useMessage } from "naive-ui"
 import { computed, onBeforeMount, ref, useTemplateRef, watch } from "vue"
 import Api from "@/api"
 import Filters from "@/components/agents/Filters.vue"
@@ -69,7 +82,7 @@ import Chip from "@/components/common/Chip.vue"
 import Icon from "@/components/common/Icon.vue"
 import { useCustomerFilterStore } from "@/stores/customerFilter"
 import { useSettingsStore } from "@/stores/settings"
-import { getApiErrorMessage, getStatusColor } from "@/utils"
+import { downloadCsv, getApiErrorMessage, getStatusColor } from "@/utils"
 import { formatDate } from "@/utils/format"
 import AgentCriticalSelect from "./AgentCriticalSelect.vue"
 import AgentDetailsButton from "./AgentDetailsButton.vue"
@@ -240,6 +253,44 @@ const loadAgents = useDebounceFn(async () => {
 		}
 	}
 }, 400)
+
+function exportCsv() {
+	// Export the currently-filtered set so the download reflects what the user
+	// sees (active filters/search), not just the current page.
+	const rows = dataFiltered.value
+	if (!rows.length) {
+		message.warning("No assets to export")
+		return
+	}
+
+	const headers = [
+		"Hostname",
+		"Agent ID",
+		"IP Address",
+		"Operating System",
+		"Status",
+		"Last Seen",
+		"Critical Asset",
+		"Agent Version",
+		"Customer Code"
+	]
+
+	const csvRows = rows.map(agent => [
+		agent.hostname,
+		agent.agent_id,
+		agent.ip_address,
+		agent.os,
+		agent.wazuh_agent_status,
+		agent.wazuh_last_seen ? String(formatDate(agent.wazuh_last_seen, dFormats.datetime)) : "",
+		agent.critical_asset ? "Yes" : "No",
+		agent.wazuh_agent_version,
+		agent.customer_code
+	])
+
+	const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")
+	downloadCsv(`assets-export-${stamp}.csv`, headers, csvRows)
+	message.success(`Exported ${rows.length} asset${rows.length === 1 ? "" : "s"} to CSV`)
+}
 
 function handleCriticalAssetUpdated(payload: AgentCriticalUpdateSuccessPayload) {
 	const agent = data.value.find(a => a.agent_id === payload.agentId)

--- a/customer-portal/src/utils/index.ts
+++ b/customer-portal/src/utils/index.ts
@@ -3,6 +3,7 @@ import type { ApiError, OsTypesFull, Severity } from "@/types/common"
 import type { SafeAny } from "@/types/utils"
 import process from "node:process"
 import { isMobile as detectMobile } from "detect-touch-device"
+import { saveAs } from "file-saver"
 import isDateObject from "lodash/isDate"
 import _trim from "lodash/trim"
 import { h } from "vue"
@@ -427,4 +428,39 @@ export function trendClass(trend: string, invert?: boolean) {
 		return invert ? "text-error" : "text-success"
 	}
 	return "text-secondary"
+}
+
+type CsvCell = string | number | boolean | null | undefined
+
+/**
+ * Build a CSV string from headers + rows and trigger a browser download.
+ *
+ * Cells are RFC-4180 quoted when they contain commas/quotes/newlines, and any
+ * cell that would be interpreted as a formula by a spreadsheet app (leading
+ * `= + - @` or control chars) is prefixed with a single quote to neutralise
+ * CSV/formula injection. A UTF-8 BOM is prepended so Excel detects the encoding.
+ */
+export function downloadCsv(filename: string, headers: string[], rows: CsvCell[][]): void {
+	const formatCell = (value: CsvCell): string => {
+		if (value === null || value === undefined) {
+			return ""
+		}
+		let str = String(value)
+		// Neutralise spreadsheet formula injection.
+		if (/^[=+\-@\t\r]/.test(str)) {
+			str = `'${str}`
+		}
+		// RFC 4180 quoting.
+		if (/[",\r\n]/.test(str)) {
+			str = `"${str.replace(/"/g, '""')}"`
+		}
+		return str
+	}
+
+	const lines = [headers, ...rows].map(row => row.map(formatCell).join(","))
+	// Prepend a UTF-8 BOM so Excel detects the encoding (escaped, not a literal
+	// BOM char, to satisfy no-irregular-whitespace).
+	const csv = `\uFEFF${lines.join("\r\n")}`
+	const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+	saveAs(blob, filename)
 }


### PR DESCRIPTION
Closes #905.

## Summary
Adds an **Export CSV** button to the customer portal's assets (agents) list so customers can download their asset inventory for offline use, comparison, and auditing.

## What it does
- New button in the assets list header (next to pagination). Disabled while loading or when there are no rows.
- Exports the **currently-filtered** set — it respects the active status / OS / critical / search filters rather than only the visible page — so the download matches what the user is looking at.
- Columns: **Hostname, Agent ID, IP Address, Operating System, Status, Last Seen, Critical Asset, Agent Version, Customer Code** (covers the "Agent Name, IP, OS, Status, Last Seen, etc." the issue asked for).
- Filename: `assets-export-<timestamp>.csv`.
- Shows a success toast with the exported count; warns if there's nothing to export.

## Implementation
- New reusable `downloadCsv(filename, headers, rows)` util in `customer-portal/src/utils`, built on the already-present `file-saver` dependency. It:
  - RFC-4180-quotes cells containing commas/quotes/newlines,
  - prepends a UTF-8 BOM so Excel detects the encoding,
  - **neutralises CSV/formula injection** — any cell starting with `= + - @` (or a control char) is prefixed with a single quote, so a malicious hostname/label can't execute as a spreadsheet formula when the file is opened.
- Wired into `components/agents/List.vue` (`exportCsv()` builds rows from the filtered data).

No backend changes; purely a portal frontend addition.

## Testing
- `vue-tsc` type-check passes for the changed files (pre-existing `vue-echarts` module-resolution errors in my local env are unrelated).
- `eslint` passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)