### PR TITLE
feat(velociraptor): configurable quarantine artifact name (#913)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,13 @@ MCP_WAZUH_SERVER_ENABLED=true
 VELOCIRAPTOR_API_KEY=/app/velociraptor-config.yaml # Dont change this
 VELOCIRAPTOR_SSL_VERIFY=false
 VELOCIRAPTOR_TIMEOUT=30
+# Quarantine artifact overrides. Leave unset to use Velociraptor's built-in
+# artifacts. On Velociraptor 0.76.x+ the built-in Linux.Remediation.Quarantine
+# runs a "forbidden connection test" that can roll back a working quarantine;
+# point this at a custom artifact (which Velociraptor won't let you override in
+# place) to avoid it. See issue #913.
+# VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT=Custom.Linux.Remediation.Quarantine
+# VELOCIRAPTOR_WINDOWS_QUARANTINE_ARTIFACT=Custom.Windows.Remediation.Quarantine
 
 # Velociraptor MCP Server Configuration
 MCP_VELOCIRAPTOR_AUTH_TOKEN=velociraptor-token

--- a/backend/app/connectors/velociraptor/routes/artifacts.py
+++ b/backend/app/connectors/velociraptor/routes/artifacts.py
@@ -27,6 +27,7 @@ from app.connectors.velociraptor.services.artifacts import (
 )
 from app.connectors.velociraptor.services.artifacts import get_artifacts
 from app.connectors.velociraptor.services.artifacts import quarantine_host
+from app.connectors.velociraptor.services.artifacts import resolve_quarantine_artifact
 from app.connectors.velociraptor.services.artifacts import run_artifact_collection
 from app.connectors.velociraptor.services.artifacts import run_file_collection
 from app.connectors.velociraptor.services.artifacts import run_remote_command
@@ -538,11 +539,17 @@ async def quarantine(
     logger.info(f"Received request to quarantine host {quarantine_body}")
     result = await get_all_artifacts_for_hostname(quarantine_body.hostname, session)
     artifact_names = [artifact.name for artifact in result.artifacts]
-    if quarantine_body.artifact_name not in artifact_names:
+    # Resolve any configured custom-artifact override (e.g.
+    # Custom.Linux.Remediation.Quarantine) BEFORE validating existence, so we
+    # check that the artifact CoPilot will actually invoke is present on the host
+    # rather than the built-in name it replaces. See issue #913.
+    effective_artifact = resolve_quarantine_artifact(quarantine_body.artifact_name)
+    if effective_artifact not in artifact_names:
         raise HTTPException(
             status_code=400,
-            detail=f"Artifact name {quarantine_body.artifact_name.value} does not apply for hostname {quarantine_body.hostname} or does not exist",
+            detail=f"Artifact name {effective_artifact} does not apply for hostname {quarantine_body.hostname} or does not exist",
         )
+    quarantine_body.artifact_name = effective_artifact
     # Add the velociraptor_id to the run_command_body object
     # Add the velociraptor_id to the quarantine_body object
     quarantine_body.velociraptor_id = await get_velociraptor_id(

--- a/backend/app/connectors/velociraptor/services/artifacts.py
+++ b/backend/app/connectors/velociraptor/services/artifacts.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from typing import Dict
 from typing import List
@@ -989,6 +990,36 @@ async def run_remote_command(run_command_body: RunCommandBody) -> RunCommandResp
         )
 
 
+# Built-in Velociraptor quarantine artifacts. Velociraptor 0.76.x+ added a
+# "forbidden connection test" step to the built-in Linux artifact that reaches an
+# external URL after applying nftables rules; when that test fails in locked-down
+# environments the artifact rolls the quarantine back even though the firewall
+# rules applied correctly. Velociraptor won't let you override a built-in
+# artifact, so operators ship a Custom.Linux.Remediation.Quarantine that drops
+# the test. The env vars below let a deployment redirect CoPilot at the custom
+# artifact with no code or frontend change. See issue #913.
+DEFAULT_LINUX_QUARANTINE_ARTIFACT = "Linux.Remediation.Quarantine"
+DEFAULT_WINDOWS_QUARANTINE_ARTIFACT = "Windows.Remediation.Quarantine"
+
+
+def resolve_quarantine_artifact(requested_artifact) -> str:
+    """Map a built-in quarantine artifact name to its configured override.
+
+    The frontend always sends the built-in name (Linux/Windows). A deployment can
+    redirect either one to a custom artifact via the
+    ``VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT`` / ``VELOCIRAPTOR_WINDOWS_QUARANTINE_ARTIFACT``
+    env vars. Any other (already-custom) name is returned unchanged, so the
+    function is idempotent and safe to call more than once per request. Accepts
+    either the ``QuarantineArtifactsEnum`` or a plain string.
+    """
+    name = requested_artifact.value if hasattr(requested_artifact, "value") else str(requested_artifact)
+    if name == DEFAULT_LINUX_QUARANTINE_ARTIFACT:
+        return os.environ.get("VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT", "").strip() or DEFAULT_LINUX_QUARANTINE_ARTIFACT
+    if name == DEFAULT_WINDOWS_QUARANTINE_ARTIFACT:
+        return os.environ.get("VELOCIRAPTOR_WINDOWS_QUARANTINE_ARTIFACT", "").strip() or DEFAULT_WINDOWS_QUARANTINE_ARTIFACT
+    return name
+
+
 async def quarantine_host(quarantine_body: QuarantineBody) -> QuarantineResponse:
     """
     Quarantine a host.
@@ -1001,7 +1032,9 @@ async def quarantine_host(quarantine_body: QuarantineBody) -> QuarantineResponse
     """
     velociraptor_service = await UniversalService.create("Velociraptor")
     try:
-        quarantine_body.artifact_name = quarantine_body.artifact_name.value
+        # Resolve any configured custom-artifact override (idempotent if the
+        # route already resolved it). See issue #913.
+        quarantine_body.artifact_name = resolve_quarantine_artifact(quarantine_body.artifact_name)
         quarantine_body.action = quarantine_body.action.value
         if quarantine_body.action == "quarantine":
             query = create_query(

--- a/backend/tests/test_quarantine_artifact_resolution.py
+++ b/backend/tests/test_quarantine_artifact_resolution.py
@@ -17,12 +17,16 @@ from unittest.mock import patch
 
 os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
 
-from app.connectors.velociraptor.schema.artifacts import QuarantineArtifactsEnum  # noqa: E402
+from app.connectors.velociraptor.schema.artifacts import (  # noqa: E402
+    QuarantineArtifactsEnum,
+)
 from app.connectors.velociraptor.services.artifacts import (  # noqa: E402
     DEFAULT_LINUX_QUARANTINE_ARTIFACT,
-    DEFAULT_WINDOWS_QUARANTINE_ARTIFACT,
-    resolve_quarantine_artifact,
 )
+from app.connectors.velociraptor.services.artifacts import (
+    DEFAULT_WINDOWS_QUARANTINE_ARTIFACT,
+)
+from app.connectors.velociraptor.services.artifacts import resolve_quarantine_artifact
 
 CUSTOM_LINUX = "Custom.Linux.Remediation.Quarantine"
 

--- a/backend/tests/test_quarantine_artifact_resolution.py
+++ b/backend/tests/test_quarantine_artifact_resolution.py
@@ -1,0 +1,66 @@
+"""Tests for configurable Velociraptor quarantine artifact resolution (issue #913).
+
+Velociraptor 0.76.x+ added a "forbidden connection test" to the built-in
+Linux.Remediation.Quarantine artifact that can roll back a working quarantine.
+Operators ship a Custom.Linux.Remediation.Quarantine instead, but CoPilot was
+hard-coded to the built-in name. resolve_quarantine_artifact lets a deployment
+redirect the built-in names to custom artifacts via env vars, transparently to
+the frontend (which keeps sending the built-in name).
+
+Pure-function unit tests — no DB or Velociraptor server.
+
+Run with: cd backend && python -m pytest tests/test_quarantine_artifact_resolution.py
+"""
+
+import os
+from unittest.mock import patch
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.connectors.velociraptor.schema.artifacts import QuarantineArtifactsEnum  # noqa: E402
+from app.connectors.velociraptor.services.artifacts import (  # noqa: E402
+    DEFAULT_LINUX_QUARANTINE_ARTIFACT,
+    DEFAULT_WINDOWS_QUARANTINE_ARTIFACT,
+    resolve_quarantine_artifact,
+)
+
+CUSTOM_LINUX = "Custom.Linux.Remediation.Quarantine"
+
+
+def test_defaults_when_no_env_override():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT", None)
+        os.environ.pop("VELOCIRAPTOR_WINDOWS_QUARANTINE_ARTIFACT", None)
+        assert resolve_quarantine_artifact(DEFAULT_LINUX_QUARANTINE_ARTIFACT) == DEFAULT_LINUX_QUARANTINE_ARTIFACT
+        assert resolve_quarantine_artifact(DEFAULT_WINDOWS_QUARANTINE_ARTIFACT) == DEFAULT_WINDOWS_QUARANTINE_ARTIFACT
+
+
+def test_linux_env_override_is_applied():
+    with patch.dict(os.environ, {"VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT": CUSTOM_LINUX}):
+        assert resolve_quarantine_artifact(DEFAULT_LINUX_QUARANTINE_ARTIFACT) == CUSTOM_LINUX
+        # Windows is untouched by the Linux override.
+        assert resolve_quarantine_artifact(DEFAULT_WINDOWS_QUARANTINE_ARTIFACT) == DEFAULT_WINDOWS_QUARANTINE_ARTIFACT
+
+
+def test_accepts_enum_member():
+    with patch.dict(os.environ, {"VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT": CUSTOM_LINUX}):
+        assert resolve_quarantine_artifact(QuarantineArtifactsEnum.linux_quarantine) == CUSTOM_LINUX
+
+
+def test_resolution_is_idempotent():
+    # The route resolves once and stores the string; quarantine_host resolves
+    # again. Resolving an already-custom name must return it unchanged.
+    with patch.dict(os.environ, {"VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT": CUSTOM_LINUX}):
+        once = resolve_quarantine_artifact(DEFAULT_LINUX_QUARANTINE_ARTIFACT)
+        twice = resolve_quarantine_artifact(once)
+        assert once == twice == CUSTOM_LINUX
+
+
+def test_blank_env_var_falls_back_to_default():
+    with patch.dict(os.environ, {"VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT": "   "}):
+        assert resolve_quarantine_artifact(DEFAULT_LINUX_QUARANTINE_ARTIFACT) == DEFAULT_LINUX_QUARANTINE_ARTIFACT
+
+
+def test_unknown_artifact_returned_unchanged():
+    other = "Generic.Client.Info"
+    assert resolve_quarantine_artifact(other) == other


### PR DESCRIPTION
Closes #913.

## Problem
CoPilot is hard-coded to invoke the built-in `Linux.Remediation.Quarantine` / `Windows.Remediation.Quarantine` artifacts. Starting with Velociraptor **0.76.x**, the built-in Linux artifact added a *forbidden connection test* that reaches an external URL (e.g. google.com) after applying nftables rules. In locked-down production environments that test fails, and Velociraptor then **rolls the quarantine back** even though the firewall rules applied correctly.

Velociraptor doesn't allow overriding a built-in artifact in place — operators must ship a `Custom.Linux.Remediation.Quarantine` (with the test removed). But CoPilot had no way to invoke a custom artifact. Downgrading Velociraptor isn't an option (CVE-2026-5329).

## Fix (the issue's preferred option: configurable via env)
New `resolve_quarantine_artifact()` maps a built-in artifact name to a deployment-configured override:

- `VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT`
- `VELOCIRAPTOR_WINDOWS_QUARANTINE_ARTIFACT`

Both default to the built-in names, so **existing deployments are unchanged**. The frontend keeps sending the built-in name; the backend swaps in the override transparently — no frontend or API change.

The quarantine **route resolves the override before validating** that the artifact exists on the host, so the existence check (`get_all_artifacts_for_hostname`) validates the artifact CoPilot will actually invoke (e.g. `Custom.Linux.Remediation.Quarantine`) rather than the built-in name it replaces. Resolution is idempotent (safe — the route resolves once and `quarantine_host` resolves again) and accepts either the `QuarantineArtifactsEnum` or a plain string.

Both env vars are documented in `.env.example`.

### Usage
```
VELOCIRAPTOR_LINUX_QUARANTINE_ARTIFACT=Custom.Linux.Remediation.Quarantine
```
Restart the backend; Linux quarantine now invokes the custom artifact. Leave unset to keep the built-in behavior.

## Tests
`backend/tests/test_quarantine_artifact_resolution.py` — defaults when unset, env override applied (Linux override doesn't affect Windows), accepts enum members, idempotency, blank-env fallback, unknown-name passthrough. Full backend suite: 29 passed.

## Note
This implements the env-config option. I did not add the "fallback if custom unavailable" behavior on purpose — silently falling back from a custom artifact to the built-in one would reintroduce the exact forbidden-connection-test rollback this fixes, without the operator noticing. Explicit config + the existing host-side existence check (which returns a clear 400 if the configured artifact is missing) is the safer contract. Happy to add fallback if you'd prefer it.