### PR TITLE
feat(license): enforce stackable MSSP seat-pack allowance

### DIFF
--- a/backend/app/customers/routes/customers.py
+++ b/backend/app/customers/routes/customers.py
@@ -29,6 +29,7 @@ from app.healthchecks.agents.schema.agents import AgentHealthCheckResponse
 from app.healthchecks.agents.schema.agents import TimeCriteriaModel
 from app.healthchecks.agents.services.agents import velociraptor_agents_healthcheck
 from app.healthchecks.agents.services.agents import wazuh_agents_healthcheck
+from app.middleware.license import get_license_seat_allowance
 from app.middleware.license import is_feature_enabled
 
 customers_router = APIRouter()
@@ -140,9 +141,11 @@ async def mssp_license_check(session: AsyncSession):
     """
     Check if the current number of provisioned customers is within the allowed range based on the MSSP license type.
     - First customer is free (no license check)
-    - MSSP Unlimited: No limit
-    - MSSP 10: Up to 10 customers (0-9 current customers)
-    - MSSP 5: Up to 5 customers (0-4 current customers)
+    - Preferred: numeric "MSSP Seats" allowance (supports stacked seat packs, e.g. two MSSP 10 packs -> 20 seats)
+      and "MSSP Unlimited" (no limit).
+    - Legacy fallback (licenses provisioned before seat packs): boolean MSSP tiers
+      - MSSP 10: Up to 10 customers (0-9 current customers)
+      - MSSP 5: Up to 5 customers (0-4 current customers)
     """
     stmt = select(Customers)
     result = await session.execute(stmt)
@@ -155,6 +158,20 @@ async def mssp_license_check(session: AsyncSession):
         return
 
     error_message = "You have reached the maximum number of customers allowed for your license type. Please upgrade your license to provision more customers."
+
+    # Preferred path: numeric seat allowance. None means this license predates
+    # seat packs, so fall through to the legacy boolean tier ladder below.
+    seat_allowance = await get_license_seat_allowance(session)
+    if seat_allowance is not None:
+        if provisioned_customers < seat_allowance:
+            return
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"You have reached your licensed customer limit ({provisioned_customers}/{int(seat_allowance)} seats). "
+                "Please purchase additional MSSP seats to provision more customers."
+            ),
+        )
 
     # Try most permissive license first
     try:

--- a/backend/app/middleware/license.py
+++ b/backend/app/middleware/license.py
@@ -611,6 +611,48 @@ async def is_feature_enabled(feature_name: str, session: AsyncSession, message: 
         raise HTTPException(status_code=500, detail=f"Unable to verify license: {str(e)}")
 
 
+# Name of the numeric data object on the license that carries the total MSSP
+# customer-seat allowance, and the boolean "unlimited" tier.
+SEATS_FEATURE_NAME = "MSSP Seats"
+UNLIMITED_FEATURE_NAME = "MSSP Unlimited"
+
+
+async def get_license_seat_allowance(session: AsyncSession) -> Optional[float]:
+    """
+    Return the numeric MSSP customer-seat allowance for the active license.
+
+    Reads the license fresh from the license server (so a just-completed seat
+    purchase is reflected immediately, bypassing the 1h feature cache) and
+    inspects its dataObjects:
+
+    - "MSSP Unlimited" enabled -> float("inf")
+    - "MSSP Seats" present     -> its intValue (total purchased seats)
+    - neither present          -> None, signalling the caller to fall back to
+      the legacy boolean MSSP tier ladder (licenses provisioned before seat
+      packs existed).
+
+    Returns None (rather than raising) on any license-server error so the
+    caller can decide how to degrade.
+    """
+    license = await get_license(session)
+
+    try:
+        result = await send_post_request("verify-license", data={"license_key": license.license_key})
+        normalized_result = normalize_api_response(result)
+        data_objects = normalized_result["data"]["license"].get("dataObjects", [])
+    except Exception as e:
+        logger.error(f"Unable to read MSSP seat allowance from license server: {str(e)}")
+        return None
+
+    seats = None
+    for data_object in data_objects:
+        if data_object.get("name") == UNLIMITED_FEATURE_NAME and data_object.get("intValue", 0) >= 1:
+            return float("inf")
+        if data_object.get("name") == SEATS_FEATURE_NAME:
+            seats = data_object.get("intValue")
+    return seats
+
+
 async def send_get_request(endpoint: str) -> Dict[str, Any]:
     """
     Sends a GET request to the Shuffle service.

--- a/frontend/src/api/endpoints/license.ts
+++ b/frontend/src/api/endpoints/license.ts
@@ -59,6 +59,10 @@ export default {
 	retrieveDockerCompose() {
 		return HttpClient.post<FlaskBaseResponse & { docker_compose: string }>(`/license/retrieve-docker-compose`)
 	},
+	/** Force-clear the server-side license feature cache so a just-completed purchase (e.g. extra MSSP seats) is reflected immediately instead of after the 1h TTL. */
+	invalidateCache() {
+		return HttpClient.post<FlaskBaseResponse>(`/license/invalidate_cache`)
+	},
 	// TODO-FE: remove, deprecated
 	/** @deprecated */
 	extendLicense(period: number) {

--- a/frontend/src/components/license/LicenseDetails.vue
+++ b/frontend/src/components/license/LicenseDetails.vue
@@ -1,6 +1,14 @@
 <template>
 	<n-spin :show="loading" content-class="flex grow flex-col" class="flex flex-col overflow-hidden">
 		<div v-if="license" class="flex flex-col gap-4">
+			<div class="flex items-center justify-end">
+				<n-button size="small" secondary :loading="refreshing" @click="refreshLicense">
+					<template #icon>
+						<Icon :name="RefreshIcon" :size="14" />
+					</template>
+					Refresh license
+				</n-button>
+			</div>
 			<CardKV v-if="!hideKey">
 				<template #key>
 					<span class="flex items-center gap-3">
@@ -88,7 +96,7 @@
 <script setup lang="ts">
 import type { License, LicenseFeatures } from "@/types/license.d"
 import _startCase from "lodash/startCase"
-import { NSpin, useMessage } from "naive-ui"
+import { NButton, NSpin, useMessage } from "naive-ui"
 import { computed, onBeforeMount, onMounted, ref, toRefs } from "vue"
 import Api from "@/api"
 import Badge from "@/components/common/Badge.vue"
@@ -124,11 +132,13 @@ const CustomerIcon = "carbon:user"
 const CheckIcon = "carbon:checkmark-outline"
 const FeaturesIcon = "material-symbols:checklist"
 const ConfigIcon = "carbon:settings"
+const RefreshIcon = "carbon:renew"
 
 const message = useMessage()
 const loadingLicense = ref(false)
 const loadingFeatures = ref(false)
 const loadingDockerCompose = ref(false)
+const refreshing = ref(false)
 const dFormats = useSettingsStore().dateFormat
 
 const licenseLoaded = ref<License | null>(null)
@@ -210,15 +220,37 @@ function retrieveDockerCompose() {
 		})
 }
 
-function load() {
-	if (!license.value) {
+function load(force = false) {
+	if (force || !license.value) {
 		getLicense()
 	}
-	if (!hideFeatures.value && !features.value.length) {
+	if (!hideFeatures.value && (force || !features.value.length)) {
 		getLicenseFeatures()
 	}
 
 	retrieveDockerCompose()
+}
+
+function refreshLicense() {
+	refreshing.value = true
+
+	Api.license
+		.invalidateCache()
+		.then(res => {
+			if (res.data.success) {
+				message.success("License cache refreshed")
+				// Re-fetch so newly-purchased features / MSSP seats show immediately.
+				load(true)
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch(err => {
+			message.error(err.response?.data?.message || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			refreshing.value = false
+		})
 }
 
 function sanitizeKey(text: string) {


### PR DESCRIPTION
## What

Adds CoPilot-side enforcement for **stackable MSSP customer seats** — e.g. a customer who buys two MSSP 10 packs can provision up to 20 customers. Pairs with the license-server changes in [StripeCopilotIntegrator#feat/mssp-seat-packs](https://github.com/socfortress/StripeCopilotIntegrator).

## Changes

- **`mssp_license_check`** (`customers/routes/customers.py`) now enforces a numeric **`MSSP Seats`** allowance (and `MSSP Unlimited`) first, and **falls back to the existing boolean MSSP tier ladder** when the license has no `MSSP Seats` object — so licenses provisioned before seat packs keep working unchanged.
- **`get_license_seat_allowance()`** (`middleware/license.py`) reads the license **fresh** from the license server (bypassing the 1h feature cache), returning `inf` for Unlimited, the seat integer, or `None` to signal the legacy fallback.
- **"Refresh license" button** (`LicenseDetails.vue` + `api/endpoints/license.ts`) — invalidates the server-side license cache via the existing `POST /license/invalidate_cache` route and force-reloads details/features, so a just-completed purchase shows immediately instead of after the 1h TTL.

## Behaviour

| License state | Cap |
|---|---|
| `MSSP Seats = 20` | 20 customers |
| `MSSP Unlimited` | unlimited |
| legacy boolean `MSSP 10` (no seats object) | 10 (unchanged) |
| first customer | always free |

Fails closed on license-server error (unchanged from today).

## Testing

- Backend compiles; black-clean (≤140).
- Seat math / fallback logic validated against the companion license-server branch.
- Frontend ESLint-clean.