### PR TITLE
feat(license): allow re-purchasing stackable MSSP seat packs in the UI

### DIFF
--- a/backend/app/middleware/license.py
+++ b/backend/app/middleware/license.py
@@ -168,6 +168,10 @@ class Feature(BaseModel):
     info: str
     short_description: str
     full_description: str
+    # Stackable one-time seat packs (MSSP) carry the per-pack seat count; other
+    # features leave it null. Surfaced so the frontend can keep seat packs
+    # purchasable even when the tier is already owned.
+    mssp_seats: Optional[int] = None
 
 
 class GetSubscriptionCatalogFeaturesResponse(BaseModel):

--- a/frontend/src/components/license/LicenseCheckoutWizard.vue
+++ b/frontend/src/components/license/LicenseCheckoutWizard.vue
@@ -115,7 +115,10 @@ const subscriptionsLoaded = ref<SubscriptionFeature[]>([])
 const features = computed(() => featuresLoaded.value || featuresData?.value || [])
 const subscriptions = computed(() => subscriptionsLoaded.value || subscriptionsData?.value || [])
 const availableSubscriptions = computed<SubscriptionFeature[]>(() =>
-	subscriptions.value.filter(o => !features.value.includes(o.name))
+	// Stackable seat packs (mssp_seats set) stay purchasable even when the tier
+	// is already owned, so an existing MSSP customer can buy another pack;
+	// every other feature is hidden once owned.
+	subscriptions.value.filter(o => o.mssp_seats != null || !features.value.includes(o.name))
 )
 const isValid = computed(() => {
 	if (!checkoutForm.value.company_name) {

--- a/frontend/src/components/license/SubscriptionCard.vue
+++ b/frontend/src/components/license/SubscriptionCard.vue
@@ -10,8 +10,13 @@
 		>
 			<template #headerMain>{{ subscription.name }}</template>
 			<template #headerExtra>
-				<div class="text-primary">
-					{{ price(subscription.price) }}
+				<div class="flex items-center gap-2">
+					<n-tag v-if="subscription.mssp_seats" size="small" :bordered="false" type="success" round>
+						Stackable
+					</n-tag>
+					<div class="text-primary">
+						{{ price(subscription.price) }}
+					</div>
 				</div>
 			</template>
 			<template v-if="!hideDetails" #default>
@@ -85,7 +90,7 @@
 <script setup lang="ts">
 import type { CancelSubscriptionPayload } from "@/api/endpoints/license"
 import type { License, SubscriptionFeature } from "@/types/license.d"
-import { NButton, NModal, NPopconfirm, NSpin, useMessage } from "naive-ui"
+import { NButton, NModal, NPopconfirm, NSpin, NTag, useMessage } from "naive-ui"
 import { ref, toRefs } from "vue"
 import Api from "@/api"
 import CardEntity from "@/components/common/cards/CardEntity.vue"

--- a/frontend/src/types/license.d.ts
+++ b/frontend/src/types/license.d.ts
@@ -63,6 +63,8 @@ export interface SubscriptionFeature {
 	info: string
 	short_description: string
 	full_description: string
+	/** Set on stackable one-time seat packs (MSSP); null/undefined on other features. */
+	mssp_seats?: number
 }
 
 export interface CheckoutPayload {


### PR DESCRIPTION
## What

Unblocks the **frontend** half of MSSP seat-pack stacking. The backend already supports buying additional MSSP seats (CoPilot #919 + StripeCopilotIntegrator #4), but the checkout UI silently prevented it.

## The bug

`LicenseCheckoutWizard` builds its purchasable list by filtering out any feature you already own:

```js
subscriptions.value.filter(o => !features.value.includes(o.name))
```

So a customer who already owns `MSSP 10` never sees `MSSP 10` in the wizard and **cannot buy another pack** — defeating the whole "buy another 10" feature. First-time purchases worked; re-purchase (the actual use case) did not.

## Fix (data-driven, no backend logic change)

- **Backend** (`middleware/license.py`) — add `mssp_seats: Optional[int] = None` to the catalog `Feature` model. It's the `response_model` for `/subscription_features`, so FastAPI was **stripping** the field the license server already returns; this lets it reach the frontend.
- **Frontend type** (`types/license.d.ts`) — add `mssp_seats?: number` to `SubscriptionFeature`.
- **Wizard** (`LicenseCheckoutWizard.vue`) — keep features with `mssp_seats` in `availableSubscriptions` even when owned; everything else still hides once owned.
- **Card** (`SubscriptionCard.vue`) — show a `Stackable` badge on seat-pack cards.

## Behaviour

| Feature | Owned? | In wizard before | In wizard after |
|---|---|---|---|
| MSSP 10 (stackable) | yes | hidden ❌ | shown ✅ (badge: Stackable) |
| MSSP 10 (stackable) | no | shown | shown |
| THREAT INTEL (non-stackable) | yes | hidden | hidden (unchanged) |

Selecting the pack drives the existing checkout → the backend's one-time payment + seat increment handles the rest.

## Testing

- Backend compiles; frontend ESLint-clean and `vue-tsc` type-check passes (no license-related errors).

## Note (out of scope)

Owned MSSP tiers still render an "Unsubscribe" action via `SubscriptionCard` (one-time fees have no subscription to cancel) — pre-existing, and refund/decrement was previously agreed out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)