### PR TITLE
fix(security): sandbox case-report template rendering (GHSA-7q83-228r-wfh5)

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -1,5 +1,5 @@
 import io
-import mimetypes
+import os
 from typing import List
 from typing import Optional
 
@@ -2566,11 +2566,33 @@ async def upload_case_report_template_endpoint(
     file: UploadFile = File(...),
     db: AsyncSession = Depends(get_db),
 ):
-    # Check if the file type is a .docx or .html
-    mime_type, _ = mimetypes.guess_type(file.filename)
-    allowed_mime_types = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/html"]  # .docx  # .html
-    if mime_type not in allowed_mime_types:
+    # Validate by extension AND by actual file content, not just the
+    # filename-guessed MIME type. The rendered template body is executed by a
+    # Jinja2 engine when a privileged user later generates a report, so we must
+    # ensure the uploaded bytes really are the file type they claim to be
+    # (GHSA-7q83-228r-wfh5).
+    file_name = file.filename or ""
+    extension = os.path.splitext(file_name)[1].lower()
+    if extension not in (".docx", ".html"):
         raise HTTPException(status_code=400, detail="Invalid file type. Only .docx and .html files are allowed.")
+
+    header = await file.read(8)
+    await file.seek(0)
+
+    if extension == ".docx":
+        # .docx is an OOXML package -> a ZIP archive (PK\x03\x04 / empty/spanned variants).
+        if not header.startswith((b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")):
+            raise HTTPException(status_code=400, detail="File content does not match a valid .docx document.")
+    else:  # .html
+        # Reject binary/archive content masquerading as HTML.
+        if header.startswith((b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")):
+            raise HTTPException(status_code=400, detail="File content does not match a valid .html document.")
+        try:
+            (await file.read()).decode("utf-8")
+        except UnicodeDecodeError:
+            raise HTTPException(status_code=400, detail="File content does not match a valid .html document.")
+        finally:
+            await file.seek(0)
 
     if await report_template_exists(file.filename, db):
         raise HTTPException(status_code=400, detail="File name already exists for this template")
@@ -2584,7 +2606,7 @@ async def upload_case_report_template_endpoint(
 
 @incidents_db_operations_router.delete(
     "/case-report-template/{file_name}",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def delete_case_report_template_endpoint(file_name: str, db: AsyncSession = Depends(get_db)):
     await delete_report_template(file_name, db)

--- a/backend/app/incidents/services/reports.py
+++ b/backend/app/incidents/services/reports.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from docxtpl import DocxTemplate
 from fastapi.responses import FileResponse
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.data_store.data_store_operations import download_data_store
 
@@ -79,9 +80,18 @@ def save_template_to_tempfile(template_file_content: bytes) -> str:
 
 
 def render_document_with_context(template_path: str, context: Dict[str, Dict[str, str]]) -> str:
-    """Load and render the document template with the given context."""
+    """Load and render the document template with the given context.
+
+    The template body is attacker-controllable (case-report templates can be
+    uploaded by privileged users and rendered later). Render through a
+    Jinja2 ``SandboxedEnvironment`` so that template expressions cannot reach
+    Python internals / ``os`` and achieve remote code execution
+    (GHSA-7q83-228r-wfh5). ``autoescape`` is enabled because docxtpl inserts
+    rendered values into the document's XML.
+    """
     doc = DocxTemplate(template_path)
-    doc.render(context)
+    jinja_env = SandboxedEnvironment(autoescape=True)
+    doc.render(context, jinja_env=jinja_env)
     with NamedTemporaryFile(delete=False, suffix=".docx") as tmp:
         doc.save(tmp.name)
         return tmp.name

--- a/backend/app/incidents/services/reports_pdf.py
+++ b/backend/app/incidents/services/reports_pdf.py
@@ -6,8 +6,9 @@ from typing import Optional
 
 import pdfkit
 from fastapi.responses import FileResponse
-from jinja2 import Environment
 from jinja2 import FileSystemLoader
+from jinja2 import select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 from app.data_store.data_store_operations import download_data_store
 
@@ -78,11 +79,22 @@ def create_case_context_pdf(case) -> Dict[str, Dict[str, str]]:
 
 
 def render_html_template(template_path: str, context: Dict[str, Dict[str, str]]) -> str:
-    """Render the Jinja HTML template with the provided context."""
+    """Render the Jinja HTML template with the provided context.
+
+    The template body is attacker-controllable (case-report templates can be
+    uploaded by privileged users and rendered later). Use a
+    ``SandboxedEnvironment`` so template expressions cannot reach Python
+    internals / ``os`` and achieve remote code execution, and enable
+    autoescaping so context values cannot inject HTML/script into the
+    rendered report (GHSA-7q83-228r-wfh5).
+    """
     template_dir = os.path.dirname(template_path)
     template_name = os.path.basename(template_path)
 
-    env = Environment(loader=FileSystemLoader(template_dir))
+    env = SandboxedEnvironment(
+        loader=FileSystemLoader(template_dir),
+        autoescape=select_autoescape(["html", "htm", "xml"], default=True),
+    )
     template = env.get_template(template_name)
     rendered_html = template.render(context)
 
@@ -127,8 +139,12 @@ def convert_html_to_pdf(html_path: str) -> str:
         if path_to_wkhtmltopdf is None:
             raise FileNotFoundError("No valid wkhtmltopdf executable found. Ensure wkhtmltopdf is installed and accessible.")
 
-        # Generate the PDF from HTML using the valid wkhtmltopdf path
-        pdfkit.from_file(html_path, pdf_path, configuration=config)
+        # Generate the PDF from HTML using the valid wkhtmltopdf path.
+        # Disable local file access so a malicious template cannot read files
+        # off the backend host or reach internal services (SSRF) via the
+        # renderer (GHSA-7q83-228r-wfh5).
+        options = {"disable-local-file-access": None}
+        pdfkit.from_file(html_path, pdf_path, configuration=config, options=options)
     except Exception as e:
         raise RuntimeError(f"Failed to convert HTML to PDF: {str(e)}")
 


### PR DESCRIPTION
## Summary

Fixes **GHSA-7q83-228r-wfh5** — Stored Server-Side Template Injection → Remote Code Execution (CVSS 9.0, critical) via customer-uploadable case-report templates.

A case-report template was rendered by a **non-sandboxed Jinja2 engine**, so an attacker-controlled template body executed arbitrary Python **as root** when an admin/analyst later generated a report (a routine action). The PoC confirmed `uid=0(root)` on `ghcr.io/socfortress/copilot-backend:latest`.

## Changes

- **Sandbox both render paths.** `services/reports.py` (DOCX) and `services/reports_pdf.py` (HTML/PDF) now render through a Jinja2 `SandboxedEnvironment`. This is the RCE-killer.
- **Autoescape the HTML path** (`select_autoescape`) — also closes stored XSS in the rendered report.
- **Harden the PDF renderer** — `wkhtmltopdf` now runs with `--disable-local-file-access`, removing the local-file-read / SSRF primitive.
- **Close the remaining auth hole** — the case-report-template **delete** route still allowed `customer_user` (upload/list/download were already restricted to admin/analyst). A low-priv user could delete the org's default template so a poisoned one took its place. Now admin/analyst only.
- **Real content validation on upload** — replaced filename-only `mimetypes.guess_type` with extension + magic-byte checks (`.docx` must be an OOXML/ZIP package; `.html` must be non-binary UTF-8 text).

## Verification

- Sandbox **blocks** the exact PoC payload (`lipsum.__globals__["os"].popen("id")` → `SecurityError`) on both the DOCX and HTML paths.
- Autoescape neutralizes `<script>` injected via context values.
- The real default `.docx` and `.html` templates still render correctly through the sandboxed environments (tested against docxtpl 0.20.2 — `render(..., jinja_env=...)` confirmed valid).

## Out of scope

The advisory also suggested adding a `customer_code` column to tenant-scope the template store. Intentionally **not** included — templates are deployment-wide assets (there's a disk-seeded default-template concept), and with delete/upload restricted to admin/analyst **plus** sandboxed rendering, both the RCE and the cross-tenant poisoning vector are closed without a schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)