### PR TITLE
fix(security): restrict data-store upload route to admin/analyst (GHSA-6j26-wcv6-gp3f)

### DIFF
--- a/backend/app/data_store/data_store_routes.py
+++ b/backend/app/data_store/data_store_routes.py
@@ -33,7 +33,13 @@ agent_data_store_router = APIRouter()
     "/upload",
     response_model=FileUploadResponse,
     description="Upload a file to the data store",
-    dependencies=[Depends(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    # Restricted to admin/analyst: this route accepts caller-controlled
+    # bucket_name and object_name with no allow-list, tenant prefix, or content
+    # validation, so a customer_user could overwrite any object in any bucket
+    # cross-tenant (GHSA-6j26-wcv6-gp3f). The customer portal uploads case files
+    # via /incidents/db_operations/case/data-store/upload, not this route, so
+    # removing customer_user here does not affect the portal.
+    dependencies=[Depends(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def upload_file(
     file: UploadFile = File(...),


### PR DESCRIPTION
## Summary

Fixes **GHSA-6j26-wcv6-gp3f** — Cross-Tenant Arbitrary Object-Store Write via the data-store upload endpoint (high, CVSS 8.x).

`POST /api/agent_data_store/upload` accepted the `customer_user` role and let the caller choose both `bucket_name` and `object_name`, with no allow-list, no per-tenant prefix, and no content validation. Buckets are created on demand and writes are upserts, so a `customer_user` scoped to one tenant could overwrite **any object in any bucket** — including another tenant's `sysmon-configs/<code>/sysmon_config.xml` (pushed to that tenant's endpoints), case evidence, forensic artifacts, and report templates.

## Change

Remove `customer_user` from the upload route's scope — **admin/analyst only** (one-line dependency change + explanatory comment).

## Why this is safe for the customer portal

I traced every file-upload path before changing this:

- The customer portal **never** calls `/api/agent_data_store/upload` (zero references in `customer-portal/src/`).
- The portal's "upload file to a case" feature uses a **different** route: `POST /incidents/db_operations/case/data-store/upload` (`customer-portal/src/api/endpoints/cases.ts:197`), which is scoped per `case_id` and keeps `customer_user` — unaffected by this change.
- The main `frontend/` app only uses the read/download/delete artifact sub-routes (already admin/analyst, delete admin-only).
- There are no alert file-upload routes at all.

So the route this advisory targets has no legitimate `customer_user` consumer.

## Scope note

This closes the cross-tenant write vector by gating the route. The advisory also notes on-demand bucket creation and missing content validation in `upload_file_to_datastore` — intentionally left as-is, since the route is now restricted to trusted admin/analyst roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)