### PR TITLE
fix(security): render user-submitted fields as text to kill stored XSS (GHSA-8hqj-cqcc-5f6w)

### DIFF
--- a/customer-portal/src/components/alerts/AlertDetails/AlertComment.vue
+++ b/customer-portal/src/components/alerts/AlertDetails/AlertComment.vue
@@ -9,7 +9,7 @@
 				type="textarea"
 				:autosize="{ minRows: 3, maxRows: 10 }"
 			/>
-			<div v-else v-html="commentHtml"></div>
+			<div v-else class="whitespace-pre-wrap">{{ comment.comment }}</div>
 		</template>
 		<template #footer-extra>
 			<div v-if="editMode" class="flex items-center gap-2">
@@ -62,7 +62,7 @@
 import type { CommentItem } from "@/types/comments"
 import type { ApiError } from "@/types/common"
 import { NButton, NInput, NPopconfirm, useMessage } from "naive-ui"
-import { computed, ref } from "vue"
+import { ref } from "vue"
 import Api from "@/api"
 import CardEntity from "@/components/common/cards/CardEntity.vue"
 import Icon from "@/components/common/Icon.vue"
@@ -88,11 +88,6 @@ const editMode = ref(false)
 const newComment = ref<string | null>(null)
 const updating = ref(false)
 const deleting = ref(false)
-const NEWLINE_REGEX = /\n/g
-
-const commentHtml = computed(() => {
-	return comment.comment.replace(NEWLINE_REGEX, "<br>")
-})
 
 function setEditMode(mode: boolean) {
 	editMode.value = mode

--- a/customer-portal/src/components/cases/CaseDetails/CaseComment.vue
+++ b/customer-portal/src/components/cases/CaseDetails/CaseComment.vue
@@ -9,7 +9,7 @@
 				type="textarea"
 				:autosize="{ minRows: 3, maxRows: 10 }"
 			/>
-			<div v-else v-html="commentHtml"></div>
+			<div v-else class="whitespace-pre-wrap">{{ comment.comment }}</div>
 		</template>
 		<template #footer-extra>
 			<div v-if="editMode" class="flex items-center gap-2">
@@ -62,7 +62,7 @@
 import type { CommentItem } from "@/types/comments"
 import type { ApiError } from "@/types/common"
 import { NButton, NInput, NPopconfirm, useMessage } from "naive-ui"
-import { computed, ref } from "vue"
+import { ref } from "vue"
 import Api from "@/api"
 import CardEntity from "@/components/common/cards/CardEntity.vue"
 import Icon from "@/components/common/Icon.vue"
@@ -88,11 +88,6 @@ const editMode = ref(false)
 const newComment = ref<string | null>(null)
 const updating = ref(false)
 const deleting = ref(false)
-const NEWLINE_REGEX = /\n/g
-
-const commentHtml = computed(() => {
-	return comment.comment.replace(NEWLINE_REGEX, "<br>")
-})
 
 function setEditMode(mode: boolean) {
 	editMode.value = mode

--- a/frontend/src/components/soc/SocAlerts/SocAlertAssets/SocAlertAssetsItem.vue
+++ b/frontend/src/components/soc/SocAlerts/SocAlertAssets/SocAlertAssetsItem.vue
@@ -120,7 +120,7 @@
 							</a>
 						</template>
 						<template v-else>
-							<div v-html="descriptionFull"></div>
+							<div class="whitespace-pre-wrap">{{ descriptionFull }}</div>
 						</template>
 					</div>
 				</n-tab-pane>
@@ -164,7 +164,6 @@ const { routeAgent } = useNavigation()
 const showDetails = ref(false)
 
 const dFormats = useSettingsStore().dateFormat
-const ASSET_NEWLINE_REGEX = /\n/g
 
 const excerpt = computed(() => {
 	const text = asset.asset_description
@@ -174,9 +173,7 @@ const excerpt = computed(() => {
 })
 
 const descriptionFull = computed(() => {
-	const text = asset.asset_description
-
-	return text.replace(ASSET_NEWLINE_REGEX, "<br>") || "Empty"
+	return asset.asset_description || "Empty"
 })
 
 const properties = computed(() => {

--- a/frontend/src/components/soc/SocCases/SocCaseAssetsItem.vue
+++ b/frontend/src/components/soc/SocCases/SocCaseAssetsItem.vue
@@ -4,7 +4,7 @@
 			<template #headerMain>#{{ asset.asset_id }} - {{ asset.asset_uuid }}</template>
 			<template #default>
 				<div class="flex flex-col gap-1">
-					<div v-html="asset.asset_name"></div>
+					<div>{{ asset.asset_name }}</div>
 					<p v-if="asset.asset_description">
 						<template v-if="isUrlLike(asset.asset_description)">
 							<a
@@ -90,7 +90,7 @@
 							</a>
 						</template>
 						<template v-else>
-							<div v-html="descriptionFull"></div>
+							<div class="whitespace-pre-wrap">{{ descriptionFull }}</div>
 						</template>
 					</div>
 				</n-tab-pane>
@@ -135,12 +135,8 @@ const excerpt = computed(() => {
 	return truncated + (truncated !== text ? "..." : "")
 })
 
-const NEWLINE_REGEX = /\n/g
-
 const descriptionFull = computed(() => {
-	const text = asset.asset_description
-
-	return text.replace(NEWLINE_REGEX, "<br>") || "Empty"
+	return asset.asset_description || "Empty"
 })
 
 const tags = computed<{ key: string; value?: string }[]>(() => {

--- a/frontend/src/components/soc/SocCases/SocCaseItem.vue
+++ b/frontend/src/components/soc/SocCases/SocCaseItem.vue
@@ -37,7 +37,7 @@
 			</template>
 			<template #default>
 				<div class="flex flex-col gap-1">
-					<div v-html="baseInfo?.case_name"></div>
+					<div>{{ baseInfo?.case_name }}</div>
 					<p v-if="baseInfo?.case_description">
 						{{ excerpt }}
 					</p>

--- a/frontend/src/components/soc/SocCases/SocCaseNote.vue
+++ b/frontend/src/components/soc/SocCases/SocCaseNote.vue
@@ -20,7 +20,7 @@
 
 			<template #default>
 				<div class="flex flex-col gap-1">
-					<div v-html="note.note_title"></div>
+					<div>{{ note.note_title }}</div>
 					<p v-if="note.note_details.note_content">
 						{{ excerpt }}
 					</p>


### PR DESCRIPTION
## Summary

Fixes **GHSA-8hqj-cqcc-5f6w** — Stored Cross-Site Scripting → privileged account takeover (critical, CVSS 9.0).

User-submitted fields (alert/case comments, asset names/descriptions, case names, note titles) were rendered through Vue `v-html` with only a `\n → <br>` transform and **no HTML escaping**. A `customer_user` (lowest-privilege portal role) could store markup like `<img src=x onerror=...>` in a comment that then executed in any viewer's session — including a SOC analyst/admin — leading to token theft and account takeover.

## Change

Render all 7 affected sinks as **text instead of HTML**, relying on CSS `white-space: pre-wrap` for the multi-line behavior (the advisory's recommended fix #1). `{{ }}` interpolation HTML-escapes the content, so stored markup is shown literally and never executes. No sanitization dependency needed since none of these fields legitimately contain HTML. Dead `commentHtml`/`descriptionFull` regex helpers and now-unused `computed` imports were removed.

| File | Field |
|---|---|
| `customer-portal/.../AlertComment.vue` | alert comment body |
| `customer-portal/.../CaseComment.vue` | case comment body |
| `frontend/.../SocAlertAssetsItem.vue` | asset description |
| `frontend/.../SocCaseAssetsItem.vue` | asset name + description |
| `frontend/.../SocCaseItem.vue` | case name |
| `frontend/.../SocCaseNote.vue` | note title |

## Out of scope

- **Remaining `v-html` sinks** (`CodeSource.vue` ×2, `ScaResultItemDetails.vue`) render Shiki syntax-highlighter output, which HTML-escapes its input and is not fed by free-text portal fields — left untouched.
- **Token storage hardening** (advisory fix #3, move access/refresh tokens to httpOnly cookies) — that's a larger cross-cutting auth change (backend cookie handling, refresh flow, CSRF) and is intentionally **not** included. This PR removes the XSS at the source.

## Manual test notes

- Multi-line comments/asset descriptions still preserve line breaks (now via `pre-wrap`).
- URL-like asset descriptions still render as clickable links (that branch untouched).
- Regression check: posting `<img src=x onerror=alert(document.domain)>` in a comment now displays as literal text with no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)