### PR TITLE
fix(security): fail closed on webhook header secrets (GHSA-x8gc-f8p4-frc2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,17 @@ WEBAUTHN_RP_ID=localhost
 WEBAUTHN_RP_NAME=SOCFortress CoPilot
 WEBAUTHN_ORIGINS=https://localhost:5173
 
-GRAYLOG_API_HEADER_VALUE=ab73de7a-6f61-4dde-87cd-3af5175a7281
-VELOCIRAPTOR_API_HEADER_VALUE=ab73de7a-6f61-4dde-87cd-3af5175a7281
-# Shared secret required on the Grafana-invoked /api/agents/dashboard/agents route
-# (GHSA-xh98-w6qh-cr44). Unlike the two values above, this one FAILS CLOSED: if it is
-# left blank the route is denied for everyone. Generate a unique random value per
-# deployment (e.g. `openssl rand -hex 32`) and set the same value as a request header
-# named `grafana` in your Grafana dashboard's datasource. Do NOT reuse the default above.
+# Shared secrets required on the webhook routes that are gated by a header instead of a
+# JWT: GRAYLOG_API_HEADER_VALUE protects /api/graylog/invoke (active-response) and the
+# /api/incidents/alerts/create/threshold|velo-sigma alert-injection routes;
+# VELOCIRAPTOR_API_HEADER_VALUE and GRAFANA_API_HEADER_VALUE protect their respective
+# routes. All three FAIL CLOSED: if left blank the route is denied for everyone, so there
+# is no guessable default to exploit (GHSA-x8gc-f8p4-frc2, GHSA-xh98-w6qh-cr44 — same class
+# as the JWT_SECRET default in GHSA-4gxj-hw3c-3x2x). Generate a unique random value per
+# deployment (e.g. `openssl rand -hex 32`) and send it as the matching request header
+# (`Graylog`, `Velociraptor`, `grafana`). Do NOT commit a real value or reuse one secret.
+GRAYLOG_API_HEADER_VALUE=
+VELOCIRAPTOR_API_HEADER_VALUE=
 GRAFANA_API_HEADER_VALUE=
 
 MYSQL_URL=copilot-mysql

--- a/backend/app/active_response/routes/graylog.py
+++ b/backend/app/active_response/routes/graylog.py
@@ -15,11 +15,17 @@ active_response_graylog_router = APIRouter()
 
 
 # Function to validate the Graylog header
+# Fails closed: GRAYLOG_API_HEADER_VALUE must be configured or the route is denied for
+# everyone. Previously this fell back to a constant hardcoded here and shipped in
+# .env.example, so any default deployment was reachable unauthenticated (GHSA-x8gc-f8p4-frc2,
+# same class of bug as the JWT_SECRET default in GHSA-4gxj-hw3c-3x2x). Mirrors
+# verify_grafana_header (GHSA-xh98-w6qh-cr44).
 async def verify_graylog_header(graylog: str = Header(None)):
     """Verify that the request has the correct Graylog header."""
-    # Get the header value from environment variable or use "ab73de7a-6f61-4dde-87cd-3af5175a7281" as default
-    expected_header = os.getenv("GRAYLOG_API_HEADER_VALUE", "ab73de7a-6f61-4dde-87cd-3af5175a7281")
-
+    expected_header = os.getenv("GRAYLOG_API_HEADER_VALUE")
+    if not expected_header:
+        logger.error("GRAYLOG_API_HEADER_VALUE is not configured; denying Graylog webhook request")
+        raise HTTPException(status_code=403, detail="Graylog header authentication is not configured")
     if graylog != expected_header:
         logger.error("Invalid or missing Graylog header")
         raise HTTPException(status_code=403, detail="Invalid or missing Graylog header")

--- a/backend/app/active_response/schema/graylog.py
+++ b/backend/app/active_response/schema/graylog.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from typing import Any
 from typing import Dict
@@ -7,6 +8,14 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
+
+# Active-response command names are bare script identifiers (e.g. "domain_sinkhole",
+# "windows_firewall", or any custom script an operator deploys). They are forwarded to the
+# Wazuh manager active-response API, so constrain them to a safe token shape — no shell
+# metacharacters, path separators, or whitespace — while still allowing arbitrary
+# operator-defined script names (GHSA-x8gc-f8p4-frc2).
+COMMAND_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 class ReplayInfo(BaseModel):
@@ -25,6 +34,13 @@ class GraylogEventFields(BaseModel):
     # Allow additional fields
     additional_fields: Dict[str, Any] = Field(default_factory=dict, alias="__extra__")
     model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    @field_validator("COMMAND")
+    @classmethod
+    def _validate_command(cls, v: str) -> str:
+        if not COMMAND_NAME_PATTERN.fullmatch(v):
+            raise ValueError("COMMAND must be a bare active-response script name (letters, digits, '_' or '-', max 64 chars)")
+        return v
 
 
 class GraylogThresholdEventFields(BaseModel):

--- a/backend/app/incidents/routes/incident_alert.py
+++ b/backend/app/incidents/routes/incident_alert.py
@@ -49,11 +49,16 @@ incidents_alerts_router = APIRouter()
 
 
 # Function to validate the Velociraptor header
+# Fails closed: VELOCIRAPTOR_API_HEADER_VALUE must be configured or the route is denied for
+# everyone. Previously this fell back to a constant hardcoded here and shipped in
+# .env.example, so any default deployment could inject alerts unauthenticated
+# (GHSA-x8gc-f8p4-frc2). Mirrors verify_grafana_header (GHSA-xh98-w6qh-cr44).
 async def verify_velociraptor_header(velociraptor: str = Header(None)):
     """Verify that the request has the correct Velociraptor header."""
-    # Get the header value from environment variable or use "ab73de7a-6f61-4dde-87cd-3af5175a7281" as default
-    expected_header = os.getenv("VELOCIRAPTOR_API_HEADER_VALUE", "ab73de7a-6f61-4dde-87cd-3af5175a7281")
-
+    expected_header = os.getenv("VELOCIRAPTOR_API_HEADER_VALUE")
+    if not expected_header:
+        logger.error("VELOCIRAPTOR_API_HEADER_VALUE is not configured; denying Velociraptor webhook request")
+        raise HTTPException(status_code=403, detail="Velociraptor header authentication is not configured")
     if velociraptor != expected_header:
         logger.error("Invalid or missing Velociraptor header")
         raise HTTPException(status_code=403, detail="Invalid or missing Velociraptor header")


### PR DESCRIPTION
## Summary

Fixes **GHSA-x8gc-f8p4-frc2** — Hardcoded default header secret enabling unauthenticated active-response invocation and alert injection (critical).

Two webhook header validators read their secret from an env var that **fell back to a constant hardcoded in source and shipped in `.env.example`**. Any deployment that didn't manually change both values authenticated against a publicly-known secret, exposing three otherwise-privileged routes to anonymous callers:

- `POST /api/graylog/invoke` — active-response invocation on any agent ID
- `POST /api/incidents/alerts/create/threshold` — alert injection for any `customer_code`
- `POST /api/incidents/alerts/create/velo-sigma` — alert injection

## Changes

1. **`verify_graylog_header` and `verify_velociraptor_header` now fail closed** — read the env var with no default and deny the request when unset, mirroring the existing `verify_grafana_header` (GHSA-xh98-w6qh-cr44; same bug class as the `JWT_SECRET` default in GHSA-4gxj-hw3c-3x2x).
2. **`.env.example` scrubbed** — both hardcoded secrets removed (now blank, like `GRAFANA_API_HEADER_VALUE`), with a consolidated comment documenting that all three header secrets fail closed and must be uniquely generated per deployment.
3. **Light `COMMAND` validation** on the Graylog webhook field — a `field_validator` enforcing `^[A-Za-z0-9_-]{1,64}$`, blocking shell metacharacters and path traversal while still allowing any operator-defined active-response script name.

## Deviation from the advisory's fix #3

The advisory suggests validating `COMMAND` against the `ActiveResponsesSupported` enum. That enum only contains `WINDOWS_FIREWALL`, so enforcing it would **break shipped scripts** (`domain_sinkhole`, `windows_firewall_multiple_failures`) and any custom active-response script an operator deploys — the webhook is designed to forward operator-chosen command names. The token-format check above achieves the defense-in-depth intent without that breakage. The fail-closed header is the actual remediation: only callers holding the operator's secret can reach the route.

## ⚠️ Breaking change for existing deployments

Any deployment that relied on the old hardcoded default (never set `GRAYLOG_API_HEADER_VALUE` / `VELOCIRAPTOR_API_HEADER_VALUE`) will get **403s** on these webhooks after upgrade until operators set the env vars and update the matching `Graylog` / `Velociraptor` request headers in their Graylog/Velociraptor configs. Should be called out in release notes / advisory remediation steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)