### PR TITLE
fix(security): keep uploaded GCP credential out of web-served dir (GHSA-pm2w-mmc3-h8hc, part 1)

### DIFF
--- a/backend/app/integrations/scoutsuite/routes/scoutsuite.py
+++ b/backend/app/integrations/scoutsuite/routes/scoutsuite.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from fastapi import APIRouter
 from fastapi import BackgroundTasks
@@ -161,11 +162,15 @@ async def generate_gcp_report(
     data = await read_json_file(contents)
     validate_json_data(data)
 
-    # Save the file to the scoutsuite-report directory
-    directory = os.path.join(os.getcwd(), "scoutsuite-report")
-    file_path = await save_file_to_directory(contents, directory, file.filename)
+    # Write the uploaded service-account key to a private temp directory, NOT the
+    # web-served `scoutsuite-report` directory. Writing the credential into the static
+    # mount made it readable unauthenticated for the duration of the scan
+    # (GHSA-pm2w-mmc3-h8hc). Use a generated filename to avoid path traversal from the
+    # caller-supplied file.filename.
+    directory = tempfile.mkdtemp(prefix="scoutsuite-gcp-cred-")
+    file_path = await save_file_to_directory(contents, directory, "gcp-service-account.json")
 
-    logger.info(f"File saved to: {file_path}")
+    logger.info("GCP credentials written to private temp path for scan")
     request = GCPScoutSuiteReportRequest(report_name=report_name, file_path=file_path)
     logger.info(f"Request: {request}")
     background_tasks.add_task(generate_gcp_report_background, request)

--- a/backend/app/integrations/scoutsuite/services/scoutsuite.py
+++ b/backend/app/integrations/scoutsuite/services/scoutsuite.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
@@ -67,14 +68,18 @@ async def generate_gcp_report_background(request: GCPScoutSuiteReportRequest):
     logger.info("Generating GCP ScoutSuite report in the background")
 
     command = construct_gcp_command(request)
-    await run_command_in_background(command)
-
-    # Delete the file after the report is generated
     try:
-        os.remove(request.file_path)
-        logger.info(f"Deleted GCP credentials file: {request.file_path}")
-    except Exception as e:
-        logger.error(f"Error deleting GCP credentials file: {e}")
+        await run_command_in_background(command)
+    finally:
+        # Always remove the uploaded credential, even if the scan fails or raises, so the
+        # service-account key never lingers on disk (GHSA-pm2w-mmc3-h8hc). The key lives in
+        # its own private temp directory; remove the whole directory.
+        cred_dir = os.path.dirname(request.file_path)
+        try:
+            shutil.rmtree(cred_dir, ignore_errors=True)
+            logger.info("Deleted GCP credentials temp directory")
+        except Exception as e:
+            logger.error(f"Error deleting GCP credentials temp directory: {e}")
 
 
 def construct_gcp_command(request: GCPScoutSuiteReportRequest):


### PR DESCRIPTION
## Summary

Partial fix for **GHSA-pm2w-mmc3-h8hc** — Unauthenticated exposure of ScoutSuite reports and the uploaded GCP service-account key via the static mount (critical).

This PR closes the **highest-impact part**: unauthenticated theft of a live GCP credential. It does **not** yet close the report-file exposure — see "Remaining work" below.

## The problem (this PR)

The GCP ScoutSuite flow wrote the uploaded service-account JSON key into the `scoutsuite-report` directory, which is published via an unauthenticated `StaticFiles` mount (`copilot.py:241`). The live private key was therefore readable by any anonymous client at a predictable URL (`/scoutsuite-report/<uploaded-filename>`) for the duration of the scan.

## Change

- Write the uploaded key to a private `tempfile.mkdtemp()` directory **outside the web-served tree**, under a generated filename (`gcp-service-account.json`) — which also removes the path-traversal vector from the caller-supplied `file.filename`.
- Delete the credential (its whole temp directory, via `shutil.rmtree`) in a **`finally`**, so the key never lingers on disk even if the scan fails or raises (previously it was only removed on the success path).

No frontend impact — ScoutSuite reads the key from `--service-account <path>`; the path doesn't need to be web-served.

## ⚠️ Remaining work (NOT in this PR — advisory should stay open)

The ScoutSuite **report files themselves** (the `.html` shell + `scoutsuite-results/*.js` holding IAM principals, resource inventory, and findings) are **still served unauthenticated** via the `StaticFiles` mount. Closing that cleanly requires a serving redesign because reports are multi-file and the frontend opens them with `window.open(...)` (a direct browser navigation that carries no bearer token), so a plain JWT-header check would break viewing.

Planned as a separate follow-up PR. Leading candidate: a short-lived **signed path-token** serving route that preserves in-browser viewing (relative sibling assets resolve under the same token prefix). Do not close the advisory on this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)