### PR TITLE
fix(security): sanitize filename in ScoutSuite save_file_to_directory (GHSA-q3g8-3cf7-744f)

### DIFF
--- a/backend/app/integrations/scoutsuite/services/scoutsuite.py
+++ b/backend/app/integrations/scoutsuite/services/scoutsuite.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 import aiofiles
 from fastapi import HTTPException
 from loguru import logger
+from werkzeug.utils import secure_filename
 
 from app.integrations.scoutsuite.schema.scoutsuite import AWSScoutSuiteReportRequest
 from app.integrations.scoutsuite.schema.scoutsuite import AzureScoutSuiteReportRequest
@@ -134,12 +135,33 @@ def validate_json_data(data: dict):
 
 
 async def save_file_to_directory(contents: bytes, directory: str, filename: str) -> str:
-    """Save the uploaded file to the specified directory."""
+    """Save the uploaded file to the specified directory.
+
+    The filename is sanitized and the resolved path is confirmed to stay inside
+    ``directory`` before writing. An unsanitized filename here was an arbitrary
+    file-write-as-root primitive: ``os.path.join(directory, "../../x")`` escapes the
+    intended directory (GHSA-q3g8-3cf7-744f). Mirrors the secure_filename pattern used by
+    the connector-upload route.
+    """
     try:
+        # Strip any directory components, then run secure_filename to drop "..", separators,
+        # and other unsafe characters. Reject anything that doesn't reduce to a safe name.
+        safe_filename = secure_filename(os.path.basename(filename or ""))
+        if not safe_filename:
+            raise HTTPException(status_code=400, detail="Invalid file name")
+
         os.makedirs(directory, exist_ok=True)
-        file_path = os.path.join(directory, filename)
+        base_dir = os.path.realpath(directory)
+        file_path = os.path.realpath(os.path.join(base_dir, safe_filename))
+
+        # Defense in depth: confirm the resolved path is still inside the intended directory.
+        if os.path.commonpath([base_dir, file_path]) != base_dir:
+            raise HTTPException(status_code=400, detail="Invalid file name")
+
         async with aiofiles.open(file_path, "wb") as out_file:
             await out_file.write(contents)
         return file_path
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
## Summary

Hardens against **GHSA-q3g8-3cf7-744f** — Arbitrary host file write as root via path traversal in the ScoutSuite GCP report upload.

`save_file_to_directory` built its destination with `os.path.join(directory, filename)` using an unsanitized, caller-supplied `file.filename`. A `../`-laden multipart filename escaped the intended directory, giving an **arbitrary file-write-as-root primitive** (drop a cron job, overwrite a Python module → RCE).

## ⚠️ Live exploit already closed in #940

The exploitable path through `POST /api/scoutsuite/generate-gcp-report` was **already fixed** in GHSA-pm2w-mmc3-h8hc (#940, shipped in 0.1.76): the route now writes the upload to a private temp dir under a **server-generated constant filename**, so the attacker-controlled `file.filename` no longer reaches the writer. The advisory's PoC does not work against current `main`.

## What this PR adds

Defense-in-depth at the helper level (the exact file the advisory names, `save_file_to_directory:131`), so the primitive cannot be reintroduced by any future caller:

- Reduce the filename to its basename and run `werkzeug.utils.secure_filename` — the same pattern the connector-upload route already uses — rejecting names that don't reduce to a safe value.
- Resolve the path with `os.path.realpath` and confirm via `os.path.commonpath` that it stays inside the target directory before writing.

## Verification

Tested the helper against every PoC payload from the advisory:

| Input filename | Result |
|---|---|
| `gcp-service-account.json` (legit) | written inside `scoutsuite-report/` |
| `../../../../../../tmp/0nlymohammed-PoC.txt` | contained → `scoutsuite-report/0nlymohammed-PoC.txt` |
| `../0nlymohammed-PoC.txt` | contained → `scoutsuite-report/0nlymohammed-PoC.txt` |
| `../../../../../../etc/cron.d/x` | contained → `scoutsuite-report/x` |
| `/etc/passwd` | contained → `scoutsuite-report/passwd` |
| `""` (empty) | rejected (400) |

Every traversal payload now lands inside the intended directory instead of escaping.

## Not in scope

The advisory's recommendation #3 ("do not run the backend as root") is a separate Docker/deployment-hardening item, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)