### PR TITLE
fix(security): require admin/analyst on Velociraptor Sigma exclusion routes (GHSA-c6jc-rh4j-wg88)

### DIFF
--- a/backend/app/incidents/routes/incident_alert.py
+++ b/backend/app/incidents/routes/incident_alert.py
@@ -470,7 +470,12 @@ async def process_sigma_alert(alert: VelociraptorSigmaAlert, session: AsyncSessi
 )
 async def create_exclusion(
     exclusion: VeloSigmaExclusionCreate,
-    current_user: str = Depends(AuthHandler().return_username_for_logging),
+    # SECURITY: require a VALID admin/analyst token. The previous dependency
+    # (return_username_for_logging) decoded the token but never validated it, so any request
+    # carrying an arbitrary/forged Bearer header could create detection-suppression rules
+    # unauthenticated (GHSA-c6jc-rh4j-wg88). require_any_scope validates the token and returns
+    # the authenticated username, which we use for created_by.
+    current_user: str = Security(AuthHandler().require_any_scope("admin", "analyst")),
     db: AsyncSession = Depends(get_db),
 ):
     """Create a new exclusion rule for Velociraptor Sigma alerts."""
@@ -498,11 +503,11 @@ async def create_exclusion(
     "/create/velo-sigma/exclusion/{exclusion_id}",
     response_model=VeloSigmaExlcusionRouteResponse,
     summary="Get an exclusion rule by ID",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def get_exclusion(
     exclusion_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(AuthHandler().get_current_user),
 ):
     """Retrieve details of a specific exclusion rule."""
     service = VeloSigmaExclusionService(db)
@@ -522,13 +527,13 @@ async def get_exclusion(
     "/create/velo-sigma/exclusion",
     response_model=VeloSigmaExclusionListResponse,
     summary="List all exclusion rules",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def list_exclusions(
     skip: int = Query(0, description="Number of items to skip for pagination"),
     limit: int = Query(100, description="Maximum number of items to return"),
     enabled_only: bool = Query(False, description="Only return enabled exclusions"),
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(AuthHandler().get_current_user),
 ):
     """List all exclusion rules with pagination."""
     service = VeloSigmaExclusionService(db)
@@ -548,12 +553,12 @@ async def list_exclusions(
     "/create/velo-sigma/exclusion/{exclusion_id}",
     response_model=VeloSigmaExlcusionRouteResponse,
     summary="Update an exclusion rule",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def update_exclusion(
     exclusion_id: int,
     exclusion: VeloSigmaExclusionUpdate,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(AuthHandler().get_current_user),
 ):
     """Update an existing exclusion rule."""
     service = VeloSigmaExclusionService(db)
@@ -570,11 +575,14 @@ async def update_exclusion(
     )
 
 
-@incidents_alerts_router.delete("/create/velo-sigma/exclusion/{exclusion_id}", summary="Delete an exclusion rule")
+@incidents_alerts_router.delete(
+    "/create/velo-sigma/exclusion/{exclusion_id}",
+    summary="Delete an exclusion rule",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
 async def delete_exclusion(
     exclusion_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(AuthHandler().get_current_user),
 ):
     """Delete an exclusion rule."""
     service = VeloSigmaExclusionService(db)
@@ -590,11 +598,11 @@ async def delete_exclusion(
     "/velo-sigma/exclusion/{exclusion_id}/toggle",
     response_model=VeloSigmaExlcusionRouteResponse,
     summary="Toggle an exclusion rule's enabled status",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
 async def toggle_exclusion(
     exclusion_id: int,
     db: AsyncSession = Depends(get_db),
-    current_user: str = Depends(AuthHandler().get_current_user),
 ):
     """Enable or disable an exclusion rule."""
     service = VeloSigmaExclusionService(db)


### PR DESCRIPTION
## Summary

Fixes **GHSA-c6jc-rh4j-wg88** — Authentication bypass and missing authorization on Velociraptor Sigma exclusion rules (detection suppression).

Velociraptor Sigma exclusion rules are **detection-suppression** rules: a matching enabled exclusion drops an incoming alert before it becomes an incident (a null `customer_code` rule suppresses platform-wide). The CRUD routes were missing the authorization their sibling routes have, and the create route never validated the caller's token.

## The problem

- **create** used `return_username_for_logging`, which *decodes* the token but never validates it (`decode_token` returns a sentinel string like `"Invalid token"` instead of raising, and the dependency hands it back without checking). With `OAuth2PasswordBearer(auto_error=True)` only requiring that *some* `Authorization: Bearer` header be present, **any arbitrary/forged token created a suppression rule with no valid credentials** (stored `created_by="Invalid token"`).
- **get / list / update / delete / toggle** depended on `get_current_user` with no scopes, so **any authenticated user — including the lowest-privilege `customer_user`** — could enumerate, modify, disable, and delete every exclusion rule.

## Change

All six routes now require a **valid admin/analyst token**, matching the sibling routes in the same file:

- **create** → `current_user: str = Security(AuthHandler().require_any_scope("admin", "analyst"))` — validates the token and yields the authenticated username used for `created_by`.
- **get / list / update / delete / toggle** → `dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))]`, with the now-unused `current_user` params removed.

`require_any_scope` checks the decode sentinels, confirms the user still exists, and enforces the scope — so this closes both the unauthenticated-create bypass and the `customer_user` management gap.

## Deferred (intentionally not in this PR)

- **Advisory fix #3 — make `decode_token` fail closed (raise).** This is the root-cause hardening, but `decode_token` has **15 call sites** (`get_current_user`, `require_any_scope`, `totp.py` ×5, `passkey.py` ×5, `app/utils.py`) that all rely on its sentinel-string return. The actual vulnerability is fully closed here because no exclusion route uses the unvalidated path anymore; the fail-closed refactor is better done as a focused, well-tested follow-up. Recommended as a separate PR.
- **Advisory fix #4 — tenant-scope exclusions / reject null `customer_code` from non-admins.** Largely moot now that these routes are admin/analyst-only; analysts are all-tenant by design in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)