### PR TITLE
fix(security): validate identifiers before building Velociraptor VQL (GHSA-5542-j2fc-gqjm, part 1)

### DIFF
--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -54,6 +54,7 @@ from app.auth.models.users import User
 
 # App specific imports
 from app.auth.routes.auth import AuthHandler
+from app.connectors.velociraptor.utils.validation import validate_client_id
 from app.connectors.wazuh_manager.utils.universal import send_get_request
 from app.db.db_session import get_db
 
@@ -1242,6 +1243,10 @@ async def update_agent(
         AgentModifyResponse: The response indicating the success or failure of the update.
     """
     logger.info(f"Updating agent {agent_id} with Velociraptor ID: {velociraptor_id}")
+    # Validate the velociraptor_id format BEFORE persisting. This value is later read back
+    # into VQL client_id positions and executed on the Velociraptor server, so a crafted
+    # value (containing a quote) was a stored VQL-injection -> RCE sink (GHSA-5542-j2fc-gqjm).
+    validate_client_id(velociraptor_id)
     try:
         # Check customer access - first find the agent
         base_query = select(Agents).filter(Agents.agent_id == agent_id)

--- a/backend/app/agents/velociraptor/services/agents.py
+++ b/backend/app/agents/velociraptor/services/agents.py
@@ -6,6 +6,8 @@ from loguru import logger
 from app.agents.schema.agents import AgentModifyResponse
 from app.agents.velociraptor.schema.agents import VelociraptorAgent
 from app.connectors.velociraptor.utils.universal import UniversalService
+from app.connectors.velociraptor.utils.validation import validate_client_id
+from app.connectors.velociraptor.utils.validation import validate_org_id
 
 
 def create_query(query: str) -> str:
@@ -28,6 +30,10 @@ async def collect_velociraptor_clients(org_id: str) -> list:
     Returns:
         list: A list of all clients.
     """
+    # org_id is interpolated into VQL here but execute_query runs with the default org, so
+    # validate it explicitly (the central create_vql_request check would only see "root").
+    # GHSA-5542-j2fc-gqjm.
+    validate_org_id(org_id)
     velociraptor_service = await UniversalService.create("Velociraptor")
     # query = create_query(
     #     "SELECT * FROM clients()",
@@ -262,6 +268,7 @@ async def delete_client(client_id: str) -> dict:
     Returns:
         dict: A dictionary containing the result of the deletion operation.
     """
+    validate_client_id(client_id)
     universal_service = await UniversalService.create("Velociraptor")
     try:
         query = create_query(

--- a/backend/app/connectors/velociraptor/services/artifacts.py
+++ b/backend/app/connectors/velociraptor/services/artifacts.py
@@ -24,6 +24,10 @@ from app.connectors.velociraptor.schema.artifacts import QuarantineResponse
 from app.connectors.velociraptor.schema.artifacts import RunCommandBody
 from app.connectors.velociraptor.schema.artifacts import RunCommandResponse
 from app.connectors.velociraptor.utils.universal import UniversalService
+from app.connectors.velociraptor.utils.validation import validate_artifact_name
+from app.connectors.velociraptor.utils.validation import validate_client_id
+from app.connectors.velociraptor.utils.validation import validate_flow_id
+from app.connectors.velociraptor.utils.validation import validate_org_id
 
 
 def create_query(query: str) -> str:
@@ -127,6 +131,7 @@ async def get_artifact_by_name(artifact_name: str) -> ArtifactsResponse:
         ArtifactsResponse: A response containing the specific artifact.
     """
     logger.info(f"Fetching artifact '{artifact_name}' from Velociraptor")
+    validate_artifact_name(artifact_name)
     velociraptor_service = await UniversalService.create("Velociraptor")
 
     # Query for a specific artifact by name
@@ -455,6 +460,13 @@ async def run_artifact_collection(
     from app.db.universal_models import AgentDataStore
     from app.db.universal_models import Agents
 
+    # Validate the identifier fields that get interpolated into VQL (GHSA-5542-j2fc-gqjm).
+    # Note: artifact `parameters`/`env` values are free-form and are NOT validated here;
+    # those are secured by parameterized VQL (follow-up), not format rejection.
+    validate_org_id(collect_artifact_body.velociraptor_org)
+    validate_client_id(collect_artifact_body.velociraptor_id)
+    validate_artifact_name(collect_artifact_body.artifact_name)
+
     velociraptor_service = await UniversalService.create("Velociraptor")
     try:
         # Get agent details from database
@@ -648,6 +660,13 @@ async def run_file_collection(
     from app.db.universal_models import AgentDataStore
     from app.db.universal_models import Agents
 
+    # Validate the identifier fields interpolated into VQL (GHSA-5542-j2fc-gqjm). The `file`
+    # and `root_disk` values are free-form and are NOT validated here; those are secured by
+    # parameterized VQL (follow-up).
+    validate_org_id(collect_artifact_body.velociraptor_org)
+    validate_client_id(collect_artifact_body.velociraptor_id)
+    validate_artifact_name(collect_artifact_body.artifact_name)
+
     velociraptor_service = await UniversalService.create("Velociraptor")
 
     try:
@@ -786,6 +805,11 @@ async def fetch_file_from_filestore(
     import os
 
     from app.data_store.data_store_operations import upload_agent_artifact_file
+
+    # Validate identifier fields interpolated into VQL (GHSA-5542-j2fc-gqjm). org_id is
+    # validated centrally in create_vql_request.
+    validate_client_id(client_id)
+    validate_flow_id(flow_id)
 
     velociraptor_service = await UniversalService.create("Velociraptor")
 
@@ -948,6 +972,11 @@ async def run_remote_command(run_command_body: RunCommandBody) -> RunCommandResp
     velociraptor_service = await UniversalService.create("Velociraptor")
     try:
         run_command_body.artifact_name = run_command_body.artifact_name.value
+        # Validate the identifier fields interpolated into VQL (GHSA-5542-j2fc-gqjm). The
+        # `command` value is free-form by design and is NOT validated here; it is secured by
+        # parameterized VQL (follow-up). artifact_name is already an enum.
+        validate_org_id(run_command_body.velociraptor_org)
+        validate_client_id(run_command_body.velociraptor_id)
         logger.info(f"Running remote command on {run_command_body}")
         query = create_query(
             (
@@ -1036,6 +1065,10 @@ async def quarantine_host(quarantine_body: QuarantineBody) -> QuarantineResponse
         # route already resolved it). See issue #913.
         quarantine_body.artifact_name = resolve_quarantine_artifact(quarantine_body.artifact_name)
         quarantine_body.action = quarantine_body.action.value
+        # Validate the identifier fields interpolated into VQL (GHSA-5542-j2fc-gqjm).
+        validate_org_id(quarantine_body.velociraptor_org)
+        validate_client_id(quarantine_body.velociraptor_id)
+        validate_artifact_name(quarantine_body.artifact_name)
         if quarantine_body.action == "quarantine":
             query = create_query(
                 (

--- a/backend/app/connectors/velociraptor/services/flows.py
+++ b/backend/app/connectors/velociraptor/services/flows.py
@@ -6,6 +6,8 @@ from app.connectors.velociraptor.schema.flows import FlowClientSession
 from app.connectors.velociraptor.schema.flows import FlowResponse
 from app.connectors.velociraptor.schema.flows import RetrieveFlowRequest
 from app.connectors.velociraptor.utils.universal import UniversalService
+from app.connectors.velociraptor.utils.validation import validate_client_id
+from app.connectors.velociraptor.utils.validation import validate_flow_id
 
 
 def create_query(query: str) -> str:
@@ -29,6 +31,7 @@ async def get_flows(velociraptor_id: str, velociraptor_org: str = "root") -> Flo
         ArtifactsResponse: A dictionary containing the artifacts.
     """
     logger.info("Fetching artifacts from Velociraptor")
+    validate_client_id(velociraptor_id)
     velociraptor_service = await UniversalService.create("Velociraptor")
     query = create_query(
         f"SELECT * FROM flows(client_id='{velociraptor_id}')",
@@ -65,6 +68,8 @@ async def get_flow(retrieve_flow_request: RetrieveFlowRequest, velociraptor_org:
         ArtifactsResponse: A dictionary containing the artifacts.
     """
     logger.info("Fetching artifacts from Velociraptor")
+    validate_client_id(retrieve_flow_request.client_id)
+    validate_flow_id(retrieve_flow_request.session_id)
     velociraptor_service = await UniversalService.create("Velociraptor")
     query = create_query(
         f"SELECT * FROM flow_results(client_id='{retrieve_flow_request.client_id}', flow_id='{retrieve_flow_request.session_id}')",

--- a/backend/app/connectors/velociraptor/utils/universal.py
+++ b/backend/app/connectors/velociraptor/utils/universal.py
@@ -11,6 +11,11 @@ from pyvelociraptor import api_pb2
 from pyvelociraptor import api_pb2_grpc
 
 from app.connectors.utils import get_connector_info_from_db
+from app.connectors.velociraptor.utils.validation import validate_artifact_name
+from app.connectors.velociraptor.utils.validation import validate_client_id
+from app.connectors.velociraptor.utils.validation import validate_flow_id
+from app.connectors.velociraptor.utils.validation import validate_hostname
+from app.connectors.velociraptor.utils.validation import validate_org_id
 from app.db.db_session import AsyncSessionLocal
 from app.db.db_session import get_db_session
 
@@ -151,6 +156,12 @@ class UniversalService:
         Returns:
             VQLCollectorArgs: The VQLCollectorArgs object with given VQL query.
         """
+        # Central choke point for every executed VQL: org_id reaches the API verbatim and is
+        # also interpolated into VQL by callers, so reject any non-identifier value here
+        # (GHSA-5542-j2fc-gqjm). Coalesce a falsy org to the default "root" first so callers
+        # that pass None/"" keep working (and protobuf never receives None).
+        org_id = org_id or "root"
+        validate_org_id(org_id)
         return api_pb2.VQLCollectorArgs(
             max_wait=1,
             org_id=org_id,
@@ -216,6 +227,7 @@ class UniversalService:
         Returns:
             dict: A dictionary with the success status and a message.
         """
+        validate_flow_id(flow_id)
         vql = f"SELECT * FROM watch_monitoring(artifact='System.Flow.Completion') WHERE FlowId='{flow_id}' LIMIT 1"
         logger.info(f"Watching flow {flow_id} for completion")
         return self.execute_query(vql, org_id)
@@ -238,6 +250,9 @@ class UniversalService:
         Returns:
             dict: A dictionary with the success status, a message, and potentially the results.
         """
+        validate_client_id(client_id)
+        validate_flow_id(flow_id)
+        validate_artifact_name(artifact)
         vql = f"SELECT * FROM source(client_id='{client_id}', flow_id='{flow_id}', artifact='{artifact}')"
         return self.execute_query(vql, org_id)
 
@@ -253,6 +268,7 @@ class UniversalService:
         """
         # Formulate queries
         try:
+            validate_hostname(client_name)
             vql_client_id = f"select client_id,os_info from clients(search='host:{client_name}')"
             vql_last_seen_at = f"select last_seen_at from clients(search='host:{client_name}')"
 

--- a/backend/app/connectors/velociraptor/utils/validation.py
+++ b/backend/app/connectors/velociraptor/utils/validation.py
@@ -1,0 +1,81 @@
+"""Input validation for values interpolated into Velociraptor VQL.
+
+CoPilot builds VQL by f-string interpolation and executes it server-side over the
+Velociraptor gRPC API. A single quote (or brace/backtick/newline) in an interpolated
+value breaks out of the VQL string literal and lets the caller append arbitrary VQL —
+including an ``execve()`` subquery that runs OS commands on the Velociraptor server
+(GHSA-5542-j2fc-gqjm).
+
+These validators constrain the *identifier* fields (client/agent id, org id, artifact
+name, flow id) to their known, machine-generated formats, so an injection payload can
+never reach the query. They are intentionally strict: every legitimate value matches,
+and anything containing a quote, backtick, brace, backslash, whitespace, or newline is
+rejected. Free-form fields (a run_command ``command``, a collect ``file`` glob, artifact
+``parameters``) are NOT identifiers and must NOT be validated here — those are secured by
+parameterized/bound VQL, not by format rejection.
+"""
+import re
+
+from fastapi import HTTPException
+
+# Velociraptor client IDs are "C." followed by hex (e.g. C.475df76785008b04). The literal
+# "server" addresses the Velociraptor server itself and is used by built-in server
+# artifacts (e.g. Server.Utils.DeleteClient).
+_CLIENT_ID_PATTERN = re.compile(r"^(server|C\.[0-9A-Fa-f]+)$")
+
+# Org IDs are "root" (the default org) or generated ids like "O1234ABCD".
+_ORG_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Artifact names are dotted alphanumeric segments, e.g. Windows.AttackSimulation.AtomicRedTeam
+# or Custom.Linux.Remediation.Quarantine. Source notation (Artifact/Source, e.g.
+# Generic.Client.Info/BasicInformation) uses a slash. None of the allowed characters can
+# break out of a VQL string literal.
+_ARTIFACT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+# Flow / session IDs are "F." followed by alphanumerics, e.g. F.CMVK8U....
+_FLOW_ID_PATTERN = re.compile(r"^F\.[A-Za-z0-9]+$")
+
+# Characters that can break out of a (single- or double-quoted) VQL string literal. Used for
+# values like a hostname that are too variable to pin to a strict format but must never carry
+# a string-literal escape.
+_VQL_BREAKOUT_CHARS = ("'", '"', "`", "\\", "\n", "\r")
+
+
+def validate_client_id(value: str) -> str:
+    """Validate a Velociraptor client/agent id ("C.<hex>" or "server")."""
+    if not isinstance(value, str) or not _CLIENT_ID_PATTERN.fullmatch(value):
+        raise HTTPException(status_code=400, detail="Invalid Velociraptor client id")
+    return value
+
+
+def validate_org_id(value: str) -> str:
+    """Validate a Velociraptor org id ("root" or a generated org id)."""
+    if not isinstance(value, str) or not _ORG_ID_PATTERN.fullmatch(value):
+        raise HTTPException(status_code=400, detail="Invalid Velociraptor org id")
+    return value
+
+
+def validate_artifact_name(value: str) -> str:
+    """Validate a Velociraptor artifact name (dotted alphanumeric segments)."""
+    if not isinstance(value, str) or not _ARTIFACT_NAME_PATTERN.fullmatch(value):
+        raise HTTPException(status_code=400, detail="Invalid Velociraptor artifact name")
+    return value
+
+
+def validate_flow_id(value: str) -> str:
+    """Validate a Velociraptor flow/session id ("F.<alnum>")."""
+    if not isinstance(value, str) or not _FLOW_ID_PATTERN.fullmatch(value):
+        raise HTTPException(status_code=400, detail="Invalid Velociraptor flow id")
+    return value
+
+
+def validate_hostname(value: str) -> str:
+    """Reject a hostname/asset name that could break out of a VQL string literal.
+
+    Hostnames are too variable to pin to a strict format, but a legitimate one never
+    contains a quote, backtick, backslash, or newline, so rejecting those is enough to
+    prevent VQL injection via the client search (GHSA-5542-j2fc-gqjm).
+    """
+    if not isinstance(value, str) or any(ch in value for ch in _VQL_BREAKOUT_CHARS):
+        raise HTTPException(status_code=400, detail="Invalid Velociraptor hostname")
+    return value


### PR DESCRIPTION
## Summary

Part 1 of the fix for **GHSA-5542-j2fc-gqjm** — VQL injection in Velociraptor artifact collection leading to RCE (critical).

CoPilot builds Velociraptor VQL with f-strings that interpolate request values, then executes the result server-side over the gRPC API (the `create_query` helper that looks like a sanitizer is a no-op). A single quote in an interpolated value breaks out of the VQL string literal and lets the caller append arbitrary VQL — including an `execve()` subquery that runs OS commands **as root on the Velociraptor server**, targets **any** `client_id`, and **bypasses the per-host artifact allow-list**. The primary sink is `velociraptor_id`, stored verbatim by the agent-update endpoint and replayed into the `client_id` position on the next collection (a stored injection reachable by the analyst role).

## Change — strict validation of the identifier fields

New `connectors/velociraptor/utils/validation.py` with validators for the fields that are interpolated into VQL. These are machine-generated / enum-constrained, so **every legitimate value matches and only injection payloads are rejected**:

- `validate_client_id` — `C.<hex>` or the literal `server`
- `validate_org_id` — `root` / generated org ids
- `validate_artifact_name` — dotted segments, allows `/` source notation (e.g. `Generic.Client.Info/BasicInformation`)
- `validate_flow_id` — `F.<alnum>`
- `validate_hostname` — rejects only VQL-breakout characters (quote/backtick/backslash/newline), since hostnames are more variable

Wired in at every interpolated-identifier sink:
- **`update_agent`** validates `velociraptor_id` **before persisting** — closes the stored sink at the source.
- **`create_vql_request`** validates `org_id` centrally for every executed query (coalescing a falsy org to `"root"` first so optional-org callers keep working and protobuf never receives `None`).
- **artifacts.py / flows.py / universal.py / agents service** — collect, file-collect, run-command, quarantine, flows, delete-client, get-client-id, fetch-file builders validate the `client_id` / `artifact_name` / `flow_id` they interpolate.

## ⚠️ Not fully remediated — part 2 still required

Deliberately **not** validated here: the genuinely free-form fields — run_command `command`, file-collect `file` / `root_disk`, and artifact `parameters` / `env` values. Identifier-regexing those **would break legitimate collections** (a command has spaces/quotes; the default `file` glob contains newlines and backslashes). Those must be secured by **parameterized / bound VQL**, which is **part 2**.

So this PR closes the documented identifier-based RCE path (including the `velociraptor_id` stored sink that the PoC uses) and is confirmed non-breaking for legitimate artifact runs, but **the advisory should stay open** until part 2 lands.

## Verification

Validators tested against the advisory's PoC payloads and real values: all legitimate identifiers (`C.475df76785008b04`, `server`, `root`, `Windows.System.PowerShell`, `Generic.Client.Info/BasicInformation`, `F.CMVK8U3R`, `WIN-HFOU106TD7K`) are accepted; every injection payload (e.g. `C.x'), { SELECT Stdout FROM execve(...) } ... --`) is rejected with a 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)