### PR TITLE
feat(audit): admin audit log read API (issue #943, Phase 2)

### DIFF
--- a/backend/app/audit/routes/audit.py
+++ b/backend/app/audit/routes/audit.py
@@ -1,0 +1,86 @@
+"""Admin-only read API for the SOC analyst audit log (issue #943, Phase 2).
+
+Read-only: there is no create/update/delete here. Audit rows are written only by
+``record_audit_event`` at the instrumented actions, and the table is append-only by
+intent (no purge/edit endpoint — retention is a policy decision, not an API).
+"""
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Query
+from fastapi import Security
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.models.audit import AuditAction
+from app.audit.models.audit import AuditResult
+from app.audit.schema.audit import AuditLogEntry
+from app.audit.schema.audit import AuditLogResponse
+from app.audit.services.query import list_audit_logs
+from app.auth.utils import AuthHandler
+from app.db.db_session import get_db
+
+audit_router = APIRouter()
+
+# Cap page size so a caller cannot pull the whole table in one request.
+MAX_LIMIT = 1000
+
+
+@audit_router.get(
+    "/actions",
+    description="List the audit action and result vocabularies (for filter UIs)",
+    dependencies=[Security(AuthHandler().get_current_user, scopes=["admin"])],
+)
+async def get_audit_vocabularies():
+    """Return the known action + result values so a UI can populate its filter dropdowns."""
+    return {
+        "actions": [a.value for a in AuditAction],
+        "results": [r.value for r in AuditResult],
+        "success": True,
+        "message": "Audit vocabularies retrieved successfully",
+    }
+
+
+@audit_router.get(
+    "",
+    response_model=AuditLogResponse,
+    description="List audit log entries (admin only) with filtering and pagination",
+    dependencies=[Security(AuthHandler().get_current_user, scopes=["admin"])],
+)
+async def get_audit_logs(
+    skip: int = Query(0, ge=0, description="Rows to skip (pagination offset)"),
+    limit: int = Query(100, ge=1, le=MAX_LIMIT, description="Max rows to return"),
+    actor_user_id: Optional[int] = Query(None, description="Filter by acting user id"),
+    actor_username: Optional[str] = Query(None, description="Filter by acting username (exact)"),
+    action: Optional[str] = Query(None, description="Filter by action, e.g. 'agent.delete'"),
+    entity_type: Optional[str] = Query(None, description="Filter by entity type, e.g. 'agent'"),
+    entity_id: Optional[str] = Query(None, description="Filter by entity id (exact)"),
+    customer_code: Optional[str] = Query(None, description="Filter by customer code"),
+    result: Optional[str] = Query(None, description="Filter by result: success | failure"),
+    start_time: Optional[datetime] = Query(None, description="Only entries at/after this UTC time"),
+    end_time: Optional[datetime] = Query(None, description="Only entries at/before this UTC time"),
+    search: Optional[str] = Query(None, description="Substring search over details, username and entity id"),
+    session: AsyncSession = Depends(get_db),
+) -> AuditLogResponse:
+    rows, total = await list_audit_logs(
+        session,
+        skip=skip,
+        limit=limit,
+        actor_user_id=actor_user_id,
+        actor_username=actor_username,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        customer_code=customer_code,
+        result=result,
+        start_time=start_time,
+        end_time=end_time,
+        search=search,
+    )
+    return AuditLogResponse(
+        audit_logs=[AuditLogEntry.model_validate(row) for row in rows],
+        pagination={"total": total, "skip": skip, "limit": limit},
+        success=True,
+        message=f"Retrieved {len(rows)} of {total} audit log entries",
+    )

--- a/backend/app/audit/services/query.py
+++ b/backend/app/audit/services/query.py
@@ -1,0 +1,82 @@
+"""Read/query side of the audit log (issue #943, Phase 2).
+
+Admin-only listing with filtering + pagination. The write side lives in
+``app/audit/services/audit.py``; this module never mutates.
+"""
+from datetime import datetime
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from sqlalchemy import desc
+from sqlalchemy import func
+from sqlalchemy import or_
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.models.audit import AuditLog
+
+
+async def list_audit_logs(
+    session: AsyncSession,
+    *,
+    skip: int = 0,
+    limit: int = 100,
+    actor_user_id: Optional[int] = None,
+    actor_username: Optional[str] = None,
+    action: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    entity_id: Optional[str] = None,
+    customer_code: Optional[str] = None,
+    result: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
+    search: Optional[str] = None,
+) -> Tuple[List[AuditLog], int]:
+    """Return (rows, total_count) for the given filters, newest first.
+
+    ``total`` is the count for the filter set (ignoring skip/limit) so the caller can
+    paginate. ``search`` is a case-insensitive substring match across details, actor
+    username and entity id.
+    """
+    filters = []
+    if actor_user_id is not None:
+        filters.append(AuditLog.actor_user_id == actor_user_id)
+    if actor_username:
+        filters.append(AuditLog.actor_username == actor_username)
+    if action:
+        filters.append(AuditLog.action == action)
+    if entity_type:
+        filters.append(AuditLog.entity_type == entity_type)
+    if entity_id:
+        filters.append(AuditLog.entity_id == entity_id)
+    if customer_code:
+        filters.append(AuditLog.customer_code == customer_code)
+    if result:
+        filters.append(AuditLog.result == result)
+    if start_time is not None:
+        filters.append(AuditLog.timestamp >= start_time)
+    if end_time is not None:
+        filters.append(AuditLog.timestamp <= end_time)
+    if search:
+        like = f"%{search}%"
+        filters.append(
+            or_(
+                AuditLog.details.ilike(like),
+                AuditLog.actor_username.ilike(like),
+                AuditLog.entity_id.ilike(like),
+            ),
+        )
+
+    count_stmt = select(func.count()).select_from(AuditLog)
+    for f in filters:
+        count_stmt = count_stmt.where(f)
+    total = (await session.execute(count_stmt)).scalar_one()
+
+    stmt = select(AuditLog)
+    for f in filters:
+        stmt = stmt.where(f)
+    stmt = stmt.order_by(desc(AuditLog.timestamp), desc(AuditLog.id)).offset(skip).limit(limit)
+    rows = (await session.execute(stmt)).scalars().all()
+
+    return list(rows), total

--- a/backend/app/routers/audit.py
+++ b/backend/app/routers/audit.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+from app.audit.routes.audit import audit_router
+
+# Instantiate the APIRouter
+router = APIRouter()
+
+# Include the audit log read routes
+router.include_router(audit_router, prefix="/audit", tags=["audit"])

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -45,6 +45,7 @@ from app.routers import active_response
 from app.routers import agents
 from app.routers import ai_analyst
 from app.routers import alert_creation_settings
+from app.routers import audit
 from app.routers import auth
 from app.routers import bitdefender
 from app.routers import carbonblack
@@ -189,6 +190,7 @@ api_router.include_router(microsoft_patch_tuesday.router)
 api_router.include_router(customers.router)
 api_router.include_router(healthcheck.router)
 api_router.include_router(logs.router)
+api_router.include_router(audit.router)
 api_router.include_router(influxdb.router)
 api_router.include_router(version.router)
 api_router.include_router(grafana.router)

--- a/frontend/src/api/endpoints/audit.ts
+++ b/frontend/src/api/endpoints/audit.ts
@@ -1,0 +1,16 @@
+import type { FlaskBaseResponse } from "@/types/flask.d"
+import type { AuditLogEntry, AuditLogFilters, AuditLogPagination, AuditVocabularies } from "@/types/audit.d"
+import { HttpClient } from "../httpClient"
+
+export default {
+	/** List audit log entries (admin only) with filtering + pagination. */
+	getAuditLogs(filters?: AuditLogFilters) {
+		return HttpClient.get<FlaskBaseResponse & { audit_logs: AuditLogEntry[]; pagination: AuditLogPagination }>("/audit", {
+			params: filters
+		})
+	},
+	/** Action + result vocabularies, for populating filter dropdowns. */
+	getAuditVocabularies() {
+		return HttpClient.get<FlaskBaseResponse & AuditVocabularies>("/audit/actions")
+	}
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -4,6 +4,7 @@ import aiAnalyst from "./endpoints/aiAnalyst"
 import alerts from "./endpoints/alerts"
 import artifacts from "./endpoints/artifacts"
 import askSocfortress from "./endpoints/askSocfortress"
+import audit from "./endpoints/audit"
 import auth from "./endpoints/auth"
 import cloudSecurityAssessment from "./endpoints/cloudSecurityAssessment"
 import connectors from "./endpoints/connectors"
@@ -56,6 +57,7 @@ export default {
 	alerts,
 	artifacts,
 	auth,
+	audit,
 	connectors,
 	copilotAction,
 	graylog,

--- a/frontend/src/types/audit.d.ts
+++ b/frontend/src/types/audit.d.ts
@@ -1,0 +1,46 @@
+import type { SafeAny } from "@/types/common.d"
+
+export interface AuditLogEntry {
+	id: number
+	timestamp: string
+	actor_user_id: number | null
+	actor_username: string | null
+	customer_code: string | null
+	action: string
+	entity_type: string | null
+	entity_id: string | null
+	result: string
+	old_value: Record<string, SafeAny> | null
+	new_value: Record<string, SafeAny> | null
+	source_ip: string | null
+	details: string | null
+}
+
+export interface AuditLogPagination {
+	total: number
+	skip: number
+	limit: number
+}
+
+export interface AuditLogFilters {
+	skip?: number
+	limit?: number
+	actor_user_id?: number
+	actor_username?: string
+	action?: string
+	entity_type?: string
+	entity_id?: string
+	customer_code?: string
+	result?: string
+	/** ISO datetime; only entries at/after this UTC time */
+	start_time?: string
+	/** ISO datetime; only entries at/before this UTC time */
+	end_time?: string
+	/** Substring search over details, username and entity id */
+	search?: string
+}
+
+export interface AuditVocabularies {
+	actions: string[]
+	results: string[]
+}


### PR DESCRIPTION
## Summary

**Phase 2** of the SOC analyst audit log (#943) — the read + filter side that makes the Phase 1 data viewable and searchable (the "filtering and search capabilities… by user, action type, affected asset, date range, or result" the request asks for).

This PR is the **backend read API + frontend API layer**. The analyst-facing UI view is a deliberate follow-up PR.

## Backend — admin-only read API (`app/audit/`)

- **`services/query.py` → `list_audit_logs(...)`** — filter by actor (id / username), action, entity_type / entity_id, customer_code, result, and a date range (`start_time` / `end_time`), plus a case-insensitive `search` substring over details / username / entity_id. Returns `(rows, total)` newest-first for pagination.
- **`routes/audit.py`**:
  - `GET /audit` — paginated, filtered list (`response_model=AuditLogResponse`).
  - `GET /audit/actions` — action + result vocabularies for filter dropdowns.
  - **Read-only** — no create/update/delete. The table stays **append-only** by intent (retention is a policy decision, not an API). Page size capped at 1000.
- Both routes are **admin-only** (`Security(get_current_user, scopes=["admin"])`), matching the existing logs router.
- Registered via `app/routers/audit.py` + `copilot.py` (prefix `/audit`).

## Frontend — API layer only (UI view = next PR)

- `api/endpoints/audit.ts` (`getAuditLogs`, `getAuditVocabularies`)
- `types/audit.d.ts`
- registered in `api/index.ts`

## Verification

- End-to-end test against an in-memory DB: every filter, the substring search, the date range, pagination, and JSON-column (`old_value` / `new_value`) serialization all pass.
- No schema change → **no migration**.
- pre-commit + smoke test clean.

## Next

The natural follow-up is the **frontend Audit view** — `src/views/Audit.vue` + filter components (forking the `Logs.vue` / DetectionCatalog patterns), router entry, and nav item — which turns this API into the analyst-facing audit screen. Remaining Phase 2 items (SSO/portal/platform config-change coverage, retention policy, bulk-delete, logout) stay tracked in the module README.