### PR TITLE
feat(audit): scheduled retention pruning for audit_log (issue #943)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,12 @@ LOG_LEVEL=INFO
 # JWT token expiry in minutes (default: 1440 = 24h)
 ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
+# Audit log retention, in days (issue #943). A daily scheduled job deletes audit_log rows
+# older than this so the append-only audit trail can't grow without bound. Default 90.
+# Raise it if your compliance framework mandates a longer minimum retention; set 0 to disable
+# pruning entirely (keep all audit entries forever).
+AUDIT_LOG_RETENTION_DAYS=90
+
 # MCP Server Process Management
 MCP_SERVER_ENABLED=true
 

--- a/backend/app/audit/services/retention.py
+++ b/backend/app/audit/services/retention.py
@@ -1,0 +1,52 @@
+"""Audit-log retention — the scheduled prune job (issue #943, Phase 2).
+
+The audit_log table is append-only at the application layer (no purge endpoint). To keep it
+from growing without bound, a daily APScheduler job deletes rows older than a configurable
+retention window.
+
+Retention is controlled by the AUDIT_LOG_RETENTION_DAYS env var (default 90). Because this is
+a compliance audit trail, deployments whose framework mandates a longer minimum should raise
+this value; a value <= 0 disables pruning entirely (keep everything forever).
+"""
+import os
+from datetime import datetime
+from datetime import timedelta
+
+from loguru import logger
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.audit.models.audit import AuditLog
+from app.db.db_session import async_engine
+
+DEFAULT_AUDIT_LOG_RETENTION_DAYS = 90
+
+
+def get_retention_days() -> int:
+    """Resolve the retention window from AUDIT_LOG_RETENTION_DAYS (default 90).
+
+    Returns 0 (pruning disabled / keep forever) when the value is <= 0. Falls back to the
+    default on an unparseable value.
+    """
+    raw = os.getenv("AUDIT_LOG_RETENTION_DAYS", str(DEFAULT_AUDIT_LOG_RETENTION_DAYS))
+    try:
+        days = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid AUDIT_LOG_RETENTION_DAYS={raw!r}; using default {DEFAULT_AUDIT_LOG_RETENTION_DAYS}")
+        return DEFAULT_AUDIT_LOG_RETENTION_DAYS
+    return days if days > 0 else 0
+
+
+async def prune_audit_log() -> None:
+    """Scheduled job: delete audit_log rows older than the configured retention window."""
+    days = get_retention_days()
+    if days <= 0:
+        logger.info("Audit-log pruning disabled (AUDIT_LOG_RETENTION_DAYS <= 0); keeping all rows")
+        return
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    async with AsyncSession(async_engine) as session:
+        result = await session.execute(delete(AuditLog).where(AuditLog.timestamp < cutoff))
+        await session.commit()
+        deleted = result.rowcount if result.rowcount is not None else 0
+        logger.info(f"Audit-log prune: deleted {deleted} row(s) older than {days} days (before {cutoff.isoformat()}Z)")

--- a/backend/app/schedulers/scheduler.py
+++ b/backend/app/schedulers/scheduler.py
@@ -9,6 +9,7 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
+from app.audit.services.retention import prune_audit_log
 from app.db.db_session import async_engine
 from app.db.db_session import sync_engine
 from app.schedulers.models.scheduler import CreateSchedulerRequest
@@ -175,6 +176,14 @@ async def initialize_job_metadata():
                 "function": invoke_palace_lesson_sweeper,
                 "description": "Forgets expired one-off AI analyst palace lessons via NanoClaw /palace/forget.",
             },
+            {
+                "job_id": "prune_audit_log",
+                # Daily. Deletes audit_log rows older than AUDIT_LOG_RETENTION_DAYS (default 90)
+                # so the append-only audit trail can't grow without bound. See issue #943.
+                "time_interval": 1440,
+                "function": prune_audit_log,
+                "description": "Prunes audit_log entries older than the configured retention window (AUDIT_LOG_RETENTION_DAYS).",
+            },
             # ! Mirgrated SIGMA to VELO ! #
             # {
             #     "job_id": "invoke_sigma_queries_collect",
@@ -282,6 +291,7 @@ def get_function_by_name(function_name: str):
     """
     function_map = {
         "agent_sync": agent_sync,
+        "prune_audit_log": prune_audit_log,
         # "wazuh_index_fields_resize": resize_wazuh_index_fields,
         "resize_wazuh_index_fields": resize_wazuh_index_fields,
         "invoke_alert_creation_collect": invoke_alert_creation_collect,


### PR DESCRIPTION
## Summary

Adds **retention** to the audit log so it can't grow without bound. The `audit_log` table is append-only with no purge path, so without this it would accumulate forever and consume disk.

A **daily APScheduler job** deletes `audit_log` rows older than a configurable window.

## Change

- **`app/audit/services/retention.py` → `prune_audit_log()`** — deletes rows older than `AUDIT_LOG_RETENTION_DAYS` (default **90**). A value `<= 0` **disables pruning** (keep forever) for frameworks that mandate indefinite retention; an unparseable value falls back to the default.
- Registered as a **daily job** (1440 min) in the scheduler's `known_jobs` + `get_function_by_name` map, so it's **enabled by default** and its interval/enabled state are adjustable from the scheduler UI like any other job.
- Documented `AUDIT_LOG_RETENTION_DAYS` in `.env.example`.

## Compliance note

Default is 90 days per maintainer choice. Several common frameworks expect a **1-year minimum** for audit trails — deployments with that requirement should set `AUDIT_LOG_RETENTION_DAYS=365` (no code change). The knob exists so each deployment matches its own obligation; `0` keeps everything.

## Verification

- No schema change → **no migration**.
- Tested against an in-memory DB: default prunes rows >90d old, `0` disables pruning, an invalid value falls back to 90.
- pre-commit clean.

## Next

With retention in place, the remaining Phase 2 piece is the **frontend Audit view** (`Audit.vue` + filters + router + nav) consuming the read API from #946.