### PR TITLE
feat(audit): analyst-facing Audit Log view (issue #943, Phase 2)

### DIFF
--- a/frontend/src/api/endpoints/audit.ts
+++ b/frontend/src/api/endpoints/audit.ts
@@ -1,5 +1,5 @@
-import type { FlaskBaseResponse } from "@/types/flask.d"
 import type { AuditLogEntry, AuditLogFilters, AuditLogPagination, AuditVocabularies } from "@/types/audit.d"
+import type { FlaskBaseResponse } from "@/types/flask.d"
 import { HttpClient } from "../httpClient"
 
 export default {

--- a/frontend/src/app-layouts/common/Toolbar/Avatar.vue
+++ b/frontend/src/app-layouts/common/Toolbar/Avatar.vue
@@ -15,6 +15,7 @@ const UserIcon = "ion:person-outline"
 const LicenseIcon = "carbon:license"
 const LogoutIcon = "ion:log-out-outline"
 const LogsIcon = "carbon:cloud-logging"
+const AuditIcon = "carbon:document-security"
 const ContactIcon = "ic:outline-alternate-email"
 const DocsIcon = "carbon:document"
 const UsersIcon = "carbon:group-security"
@@ -72,6 +73,15 @@ const options = ref([
 		key: "route-Logs",
 		icon: renderIcon(LogsIcon)
 	},
+	...(authStore.isAdmin
+		? [
+				{
+					label: "Audit Log",
+					key: "route-Audit",
+					icon: renderIcon(AuditIcon)
+				}
+			]
+		: []),
 	{
 		type: "divider",
 		key: "divider-2"

--- a/frontend/src/components/audit/AuditFilters.vue
+++ b/frontend/src/components/audit/AuditFilters.vue
@@ -1,0 +1,101 @@
+<template>
+	<div class="flex w-80! flex-col gap-3 py-1">
+		<div class="px-3">
+			<small class="text-secondary">Filter audit log by:</small>
+		</div>
+
+		<div class="flex flex-col gap-2 px-3">
+			<n-select
+				v-model:value="local.action"
+				:options="actionOptions"
+				placeholder="Action"
+				size="small"
+				clearable
+				filterable
+			/>
+			<n-select
+				v-model:value="local.result"
+				:options="resultOptions"
+				placeholder="Result"
+				size="small"
+				clearable
+			/>
+			<n-input v-model:value="local.actor_username" placeholder="Actor username" size="small" clearable />
+			<n-input v-model:value="local.entity_type" placeholder="Entity type (e.g. agent, user)" size="small" clearable />
+			<n-input v-model:value="local.customer_code" placeholder="Customer code" size="small" clearable />
+			<n-input v-model:value="local.search" placeholder="Search (details / username / entity)" size="small" clearable />
+			<n-date-picker
+				v-model:value="local.dateRange"
+				type="datetimerange"
+				size="small"
+				clearable
+				placeholder="Date range"
+			/>
+		</div>
+
+		<div class="flex justify-between gap-2 px-3">
+			<n-button size="small" quaternary @click="reset()">Reset</n-button>
+			<div class="flex gap-2">
+				<n-button size="small" secondary @click="close()">Close</n-button>
+				<n-button size="small" type="primary" secondary @click="submit()">Apply</n-button>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { AuditUiFilters } from "@/types/audit.d"
+import _cloneDeep from "lodash/cloneDeep"
+import { NButton, NDatePicker, NInput, NSelect } from "naive-ui"
+import { onBeforeMount, ref } from "vue"
+
+const props = defineProps<{ actions: string[]; results: string[] }>()
+
+const emit = defineEmits<{
+	(e: "close"): void
+	(e: "submit"): void
+}>()
+
+const filters = defineModel<AuditUiFilters>("filters", { required: true })
+
+function emptyFilters(): AuditUiFilters {
+	return {
+		action: null,
+		result: null,
+		entity_type: null,
+		actor_username: null,
+		customer_code: null,
+		search: null,
+		dateRange: null
+	}
+}
+
+const local = ref<AuditUiFilters>(emptyFilters())
+
+const actionOptions = props.actions.map(a => ({ label: a, value: a }))
+const resultOptions = props.results.map(r => ({ label: r, value: r }))
+
+function close() {
+	emit("close")
+}
+
+function reset() {
+	local.value = emptyFilters()
+	filters.value = _cloneDeep(local.value)
+	emit("submit")
+}
+
+function submit() {
+	// Normalise empty strings to null so they don't become no-op query params.
+	const normalised: AuditUiFilters = { ...local.value }
+	for (const key of ["action", "result", "entity_type", "actor_username", "customer_code", "search"] as const) {
+		if (!normalised[key]) normalised[key] = null
+	}
+	filters.value = _cloneDeep(normalised)
+	emit("submit")
+}
+
+onBeforeMount(() => {
+	local.value = _cloneDeep(filters.value) ?? emptyFilters()
+})
+</script>

--- a/frontend/src/components/audit/AuditItem.vue
+++ b/frontend/src/components/audit/AuditItem.vue
@@ -1,0 +1,100 @@
+<template>
+	<CardEntity>
+		<template #headerExtra>{{ formatDate(entry.timestamp) }}</template>
+		<template #default>
+			<div class="flex flex-col gap-2">
+				<div class="flex flex-wrap items-center gap-3 font-mono">
+					<code class="action">{{ entry.action }}</code>
+					<div v-if="entry.entity_type" class="text-sm">
+						{{ entry.entity_type }}
+						<strong v-if="entry.entity_id">: {{ entry.entity_id }}</strong>
+					</div>
+				</div>
+
+				<div v-if="entry.details" class="px-1 text-sm">
+					{{ entry.details }}
+				</div>
+
+				<div v-if="entry.old_value || entry.new_value" class="flex flex-col gap-1 px-1 text-xs">
+					<div v-if="entry.old_value" class="flex flex-wrap gap-2">
+						<span class="text-secondary">Before:</span>
+						<code class="wrap-break-word">{{ stringify(entry.old_value) }}</code>
+					</div>
+					<div v-if="entry.new_value" class="flex flex-wrap gap-2">
+						<span class="text-secondary">After:</span>
+						<code class="wrap-break-word">{{ stringify(entry.new_value) }}</code>
+					</div>
+				</div>
+			</div>
+		</template>
+
+		<template #mainExtra>
+			<div class="flex flex-wrap items-center gap-3">
+				<Badge type="splitted" :color="isFailure ? 'danger' : 'success'">
+					<template #iconLeft>
+						<Icon :name="isFailure ? FailIcon : OkIcon" :size="14" />
+					</template>
+					<template #label>Result</template>
+					<template #value>{{ entry.result }}</template>
+				</Badge>
+				<Badge v-if="actorLabel" type="splitted" color="primary">
+					<template #iconLeft>
+						<Icon :name="UserIcon" :size="14" />
+					</template>
+					<template #label>Actor</template>
+					<template #value>{{ actorLabel }}</template>
+				</Badge>
+				<Badge v-if="entry.customer_code" type="muted">
+					<template #label>Customer</template>
+					<template #value>{{ entry.customer_code }}</template>
+				</Badge>
+				<Badge v-if="entry.source_ip" type="muted">
+					<template #label>IP</template>
+					<template #value>{{ entry.source_ip }}</template>
+				</Badge>
+			</div>
+		</template>
+	</CardEntity>
+</template>
+
+<script setup lang="ts">
+import type { AuditLogEntry } from "@/types/audit.d"
+import { computed } from "vue"
+import Badge from "@/components/common/Badge.vue"
+import CardEntity from "@/components/common/cards/CardEntity.vue"
+import Icon from "@/components/common/Icon.vue"
+import { useSettingsStore } from "@/stores/settings"
+import dayjs from "@/utils/dayjs"
+
+const { entry } = defineProps<{ entry: AuditLogEntry }>()
+
+const UserIcon = "carbon:user"
+const OkIcon = "carbon:checkmark-outline"
+const FailIcon = "majesticons:exclamation-line"
+
+const dFormats = useSettingsStore().dateFormat
+
+const isFailure = computed(() => entry.result?.toLowerCase() === "failure")
+const actorLabel = computed(() => entry.actor_username || (entry.actor_user_id ? `#${entry.actor_user_id}` : ""))
+
+function stringify(value: Record<string, unknown> | null): string {
+	if (!value) return ""
+	try {
+		return JSON.stringify(value)
+	} catch {
+		return String(value)
+	}
+}
+
+function formatDate(timestamp: string | number | Date): string {
+	// Backend stores UTC without a 'Z' suffix; parse as UTC then convert to local.
+	return dayjs.utc(timestamp).local().format(dFormats.datetime)
+}
+</script>
+
+<style lang="scss" scoped>
+.action {
+	color: var(--primary-color);
+	font-weight: bold;
+}
+</style>

--- a/frontend/src/components/audit/AuditList.vue
+++ b/frontend/src/components/audit/AuditList.vue
@@ -33,7 +33,7 @@
 				@update:page-size="onPageSizeChange()"
 			/>
 
-			<n-popover :show="showFilters" trigger="manual" overlap placement="left-start" class="px-0!">
+			<n-popover :show="showFilters" trigger="manual" placement="bottom-end" class="px-0!" to="body">
 				<template #trigger>
 					<div class="bg-default rounded-lg">
 						<n-badge :show="filtered" dot type="success" :offset="[-4, 0]">

--- a/frontend/src/components/audit/AuditList.vue
+++ b/frontend/src/components/audit/AuditList.vue
@@ -1,0 +1,217 @@
+<template>
+	<div class="audit-list">
+		<div ref="header" class="header flex items-center justify-end gap-2">
+			<div class="info flex grow gap-2">
+				<n-popover overlap placement="bottom-start">
+					<template #trigger>
+						<div class="bg-default rounded-lg">
+							<n-button size="small" class="cursor-help!">
+								<template #icon>
+									<Icon :name="InfoIcon" />
+								</template>
+							</n-button>
+						</div>
+					</template>
+					<div class="flex flex-col gap-2">
+						<div class="box">
+							Total matching :
+							<code>{{ total }}</code>
+						</div>
+					</div>
+				</n-popover>
+			</div>
+
+			<n-pagination
+				v-model:page="currentPage"
+				v-model:page-size="pageSize"
+				:page-slot
+				:show-size-picker
+				:page-sizes
+				:item-count="total"
+				:simple="simpleMode"
+				@update:page="getData()"
+				@update:page-size="onPageSizeChange()"
+			/>
+
+			<n-popover :show="showFilters" trigger="manual" overlap placement="left-start" class="px-0!">
+				<template #trigger>
+					<div class="bg-default rounded-lg">
+						<n-badge :show="filtered" dot type="success" :offset="[-4, 0]">
+							<n-button size="small" @click="showFilters = true">
+								<template #icon>
+									<Icon :name="FilterIcon" />
+								</template>
+							</n-button>
+						</n-badge>
+					</div>
+				</template>
+				<AuditFilters
+					v-model:filters="filters"
+					:actions
+					:results
+					@submit="applyFilters()"
+					@close="showFilters = false"
+				/>
+			</n-popover>
+		</div>
+
+		<n-spin :show="loading">
+			<div class="my-3 flex min-h-52 flex-col gap-2">
+				<template v-if="list.length">
+					<AuditItem
+						v-for="entry of list"
+						:key="entry.id"
+						:entry
+						class="item-appear item-appear-bottom item-appear-005"
+					/>
+				</template>
+				<template v-else>
+					<n-empty v-if="!loading" description="No audit entries found" class="h-48 justify-center" />
+				</template>
+			</div>
+		</n-spin>
+
+		<div class="footer flex justify-end">
+			<n-pagination
+				v-if="list.length > 3"
+				v-model:page="currentPage"
+				:page-size
+				:item-count="total"
+				:page-slot="6"
+				@update:page="getData()"
+			/>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { AuditLogEntry, AuditLogFilters, AuditUiFilters } from "@/types/audit.d"
+import type { ApiError } from "@/types/common"
+import { useResizeObserver } from "@vueuse/core"
+import { NBadge, NButton, NEmpty, NPagination, NPopover, NSpin, useMessage } from "naive-ui"
+import { computed, onBeforeMount, ref } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+import AuditFilters from "./AuditFilters.vue"
+import AuditItem from "./AuditItem.vue"
+
+const message = useMessage()
+
+const loading = ref(false)
+const list = ref<AuditLogEntry[]>([])
+const total = ref(0)
+const showFilters = ref(false)
+
+const actions = ref<string[]>([])
+const results = ref<string[]>([])
+
+const pageSize = ref(25)
+const currentPage = ref(1)
+const simpleMode = ref(false)
+const showSizePicker = ref(true)
+const pageSizes = [10, 25, 50, 100]
+const header = ref()
+const pageSlot = ref(8)
+
+const FilterIcon = "carbon:filter-edit"
+const InfoIcon = "carbon:information"
+
+const filters = ref<AuditUiFilters>({
+	action: null,
+	result: null,
+	entity_type: null,
+	actor_username: null,
+	customer_code: null,
+	search: null,
+	dateRange: null
+})
+
+const filtered = computed(() => {
+	const f = filters.value
+	return Boolean(
+		f.action || f.result || f.entity_type || f.actor_username || f.customer_code || f.search || f.dateRange
+	)
+})
+
+function buildApiFilters(): AuditLogFilters {
+	const f = filters.value
+	const api: AuditLogFilters = {
+		skip: (currentPage.value - 1) * pageSize.value,
+		limit: pageSize.value
+	}
+	if (f.action) api.action = f.action
+	if (f.result) api.result = f.result
+	if (f.entity_type) api.entity_type = f.entity_type
+	if (f.actor_username) api.actor_username = f.actor_username
+	if (f.customer_code) api.customer_code = f.customer_code
+	if (f.search) api.search = f.search
+	if (f.dateRange) {
+		api.start_time = new Date(f.dateRange[0]).toISOString()
+		api.end_time = new Date(f.dateRange[1]).toISOString()
+	}
+	return api
+}
+
+function getData() {
+	loading.value = true
+
+	Api.audit
+		.getAuditLogs(buildApiFilters())
+		.then(res => {
+			if (res.data.success) {
+				list.value = res.data.audit_logs || []
+				total.value = res.data.pagination?.total ?? 0
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch(err => {
+			list.value = []
+			message.error(getApiErrorMessage(err as ApiError) || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			loading.value = false
+		})
+}
+
+function applyFilters() {
+	showFilters.value = false
+	currentPage.value = 1
+	getData()
+}
+
+function onPageSizeChange() {
+	currentPage.value = 1
+	getData()
+}
+
+function getVocabularies() {
+	Api.audit
+		.getAuditVocabularies()
+		.then(res => {
+			if (res.data.success) {
+				actions.value = res.data.actions || []
+				results.value = res.data.results || []
+			}
+		})
+		.catch(() => {
+			// Non-fatal: filter dropdowns simply stay empty.
+		})
+}
+
+useResizeObserver(header, entries => {
+	const entry = entries[0]
+	if (!entry) return
+
+	const { width } = entry.contentRect
+
+	pageSlot.value = width < 700 ? 5 : 8
+	simpleMode.value = width < 550
+})
+
+onBeforeMount(() => {
+	getVocabularies()
+	getData()
+})
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -332,6 +332,12 @@ const router = createRouter({
 			meta: { title: "Logs", auth: true, roles: RouteRole.All }
 		},
 		{
+			path: "/audit",
+			name: "Audit",
+			component: () => import("@/views/Audit.vue"),
+			meta: { title: "Audit Log", auth: true, roles: RouteRole.All }
+		},
+		{
 			path: "/users",
 			name: "Users",
 			component: () => import("@/views/Users.vue"),

--- a/frontend/src/types/audit.d.ts
+++ b/frontend/src/types/audit.d.ts
@@ -44,3 +44,15 @@ export interface AuditVocabularies {
 	actions: string[]
 	results: string[]
 }
+
+/** UI-side filter state (the view converts dateRange -> start_time/end_time ISO strings). */
+export interface AuditUiFilters {
+	action: string | null
+	result: string | null
+	entity_type: string | null
+	actor_username: string | null
+	customer_code: string | null
+	search: string | null
+	/** [startMs, endMs] from the date-range picker, or null */
+	dateRange: [number, number] | null
+}

--- a/frontend/src/views/Audit.vue
+++ b/frontend/src/views/Audit.vue
@@ -1,0 +1,9 @@
+<template>
+	<div class="page">
+		<AuditList />
+	</div>
+</template>
+
+<script setup lang="ts">
+import AuditList from "@/components/audit/AuditList.vue"
+</script>


### PR DESCRIPTION
## Summary

The analyst-facing **Audit Log screen** for #943 — the UI that consumes the read API (#946) and makes the captured audit data searchable in the app. Frontend only.

## What's included

- **Route + nav**: `/audit` route (name `Audit`) next to `/logs`, and an **admin-gated "Audit Log"** entry in the Avatar (top-right user) dropdown right next to "Logs" — mirroring where the Logs page lives.
- **`views/Audit.vue`** + **`components/audit/{AuditList,AuditItem,AuditFilters}.vue`**.
- **`AuditList`** — server-side pagination (skip/limit/total) and a filter popover supporting **action, result, actor username, entity type, customer code, free-text search, and a datetime range** — all applied server-side via `Api.audit.getAuditLogs`. Action/result dropdowns populate from `Api.audit.getAuditVocabularies`.
- **`AuditItem`** — renders each entry as a card: action, entity, actor, a success/failure result badge, source IP, customer, and the before/after JSON when present.
- **`AuditUiFilters`** type added; filter popover uses `placement="bottom-end"` so it stays within the viewport.

## Scope / safety

- **Admin-only**: the API enforces it, and the nav entry is gated to `isAdmin`.
- **Frontend only** — no backend change, **no migration**.
- `vue-tsc` and `eslint` both clean locally.

## Where this leaves #943

With this merged, the feature is substantially complete:
- ✅ Phase 1 (#945) — capture
- ✅ Phase 2 read API (#946) — query/filter/paginate
- ✅ Retention (#949) — daily prune, configurable window
- ✅ Audit view (this PR) — the analyst-facing screen

Remaining tracked follow-ups (module README): config-change coverage (SSO/portal/platform), bulk-agent-delete auditing, and a logout event.