### PR TITLE
fix(customer-portal): replace leftover Pinx theme footer nav (#948)

### DIFF
--- a/customer-portal/src/app-layouts/HorizontalNav/SidebarFooter.vue
+++ b/customer-portal/src/app-layouts/HorizontalNav/SidebarFooter.vue
@@ -14,7 +14,6 @@ const { collapsed = false } = defineProps<{
 	collapsed?: boolean
 }>()
 
-const BuyIcon = "carbon:shopping-cart"
 const DocsIcon = "ion:book-outline"
 const menuOptions = ref([
 	{
@@ -22,28 +21,14 @@ const menuOptions = ref([
 			h(
 				"a",
 				{
-					href: "https://pinx-docs.vercel.app/",
+					href: "https://docs.socfortress.co",
 					target: "_blank",
-					rel: "noopenner noreferrer"
+					rel: "noopener noreferrer"
 				},
 				"Documentation"
 			),
 		key: "documentation",
 		icon: renderIcon(DocsIcon)
-	},
-	{
-		label: () =>
-			h(
-				"a",
-				{
-					href: "https://themeforest.net/item/pinx-vuejs-admin-template/47799543",
-					target: "_blank",
-					rel: "noopenner noreferrer"
-				},
-				"Buy now"
-			),
-		key: "buy-now",
-		icon: renderIcon(BuyIcon)
 	}
 ])
 


### PR DESCRIPTION
## Summary

Fixes #948 — the customer portal's sidebar footer still showed the **Pinx admin-template defaults**: a "Documentation" link to `pinx-docs.vercel.app` and a "Buy now" link to the ThemeForest listing. Both are visible in the mobile navigation and unrelated to SOCFortress.

## Change

`customer-portal/src/app-layouts/HorizontalNav/SidebarFooter.vue`:
- **Remove** the "Buy now" item (and its unused icon).
- **Repoint** "Documentation" to `https://docs.socfortress.co`.
- **Fix** the `rel="noopenner"` typo → `noopener`, so the tab-nabbing protection on the external link actually applies.

## Notes

- Portal-only — the main `frontend/` has no equivalent leftover (verified).
- customer-portal eslint clean.

## Verify

Open the customer portal on mobile / collapsed sidebar → the footer shows **only "Documentation"** (→ SOCFortress docs); "Buy now" is gone.