### PR TITLE
feat(customer-portal): 2FA (TOTP) support for customers (#947)

### DIFF
--- a/backend/app/auth/routes/auth.py
+++ b/backend/app/auth/routes/auth.py
@@ -123,7 +123,7 @@ async def login_for_access_token(
     return {"access_token": access_token, "token_type": "bearer"}
 
 
-@auth_router.post("/token/customer-portal", response_model=Token)
+@auth_router.post("/token/customer-portal")
 async def login_for_customer_portal(
     request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -162,6 +162,20 @@ async def login_for_customer_portal(
             detail="This account does not have access to the Customer Portal.",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    # Check if user has 2FA enabled — login is not yet complete; it finishes at /2fa/validate,
+    # which is where the auth.login event + last_login are recorded for 2FA users (and where the
+    # customer_codes claim is attached to the issued session token for customer_user accounts).
+    if await is_2fa_enabled(user.id):
+        from app.auth.routes.totp import _create_temp_token
+
+        temp_token = _create_temp_token(user.username)
+        logger.info(f"Customer user {user.username} requires 2FA verification")
+        return {
+            "access_token": temp_token,
+            "token_type": "bearer",
+            "requires_2fa": True,
+        }
 
     # Fetch assigned customer codes
     from sqlalchemy import select

--- a/backend/app/auth/routes/totp.py
+++ b/backend/app/auth/routes/totp.py
@@ -21,6 +21,7 @@ from app.auth.models.totp import TOTPSetupResponse
 from app.auth.models.totp import TOTPStatusResponse
 from app.auth.models.totp import TOTPValidateRequest
 from app.auth.models.totp import TOTPVerifyRequest
+from app.auth.models.users import RoleEnum
 from app.auth.services.totp import disable_totp
 from app.auth.services.totp import is_2fa_enabled
 from app.auth.services.totp import regenerate_backup_codes
@@ -75,7 +76,7 @@ def _decode_temp_token(token: str) -> str:
 @totp_router.get(
     "/2fa/status",
     response_model=TOTPStatusResponse,
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
 )
 async def get_2fa_status(
     token: str = Depends(AuthHandler().security),
@@ -96,7 +97,7 @@ async def get_2fa_status(
 @totp_router.post(
     "/2fa/setup",
     response_model=TOTPSetupResponse,
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
 )
 async def start_2fa_setup(
     token: str = Depends(AuthHandler().security),
@@ -120,7 +121,7 @@ async def start_2fa_setup(
 
 @totp_router.post(
     "/2fa/verify-setup",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
 )
 async def verify_2fa_setup(
     body: TOTPVerifyRequest,
@@ -145,7 +146,7 @@ async def verify_2fa_setup(
 
 @totp_router.delete(
     "/2fa/disable",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
 )
 async def disable_2fa(
     body: TOTPDisableRequest,
@@ -206,17 +207,38 @@ async def validate_2fa_login(body: TOTPValidateRequest, request: Request):
         raise HTTPException(status_code=401, detail=str(e))
 
     # Issue full access token — this is where login completes for 2FA-enabled users.
+    # Customer-portal users (role customer_user) authenticate against /token/customer-portal,
+    # whose non-2FA path attaches a customer_codes claim used for tenant scoping. When 2FA is
+    # enabled the session token is minted here instead, so we must replicate that claim — without
+    # it the customer portal would have no accessible customers after a 2FA login.
+    extra_claims = None
+    customer_code = None
+    login_detail = "Main portal login (2FA)"
+    if user.role_id == RoleEnum.customer_user.value:
+        from sqlalchemy import select
+
+        from app.auth.models.users import UserCustomerAccess
+        from app.db.db_session import get_session
+
+        async with get_session() as session:
+            result = await session.execute(select(UserCustomerAccess.customer_code).where(UserCustomerAccess.user_id == user.id))
+            customer_codes = result.scalars().all()
+        extra_claims = {"customer_codes": customer_codes}
+        customer_code = customer_codes[0] if customer_codes else None
+        login_detail = "Customer portal login (2FA)"
+
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = await auth_handler.encode_token(user.username, access_token_expires)
+    access_token = await auth_handler.encode_token(user.username, access_token_expires, extra_claims=extra_claims)
     logger.info(f"2FA login completed for {user.username}")
     await update_last_login(user.id)
     await record_audit_event(
         action=AuditAction.AUTH_LOGIN,
         actor_user_id=user.id,
         actor_username=user.username,
+        customer_code=customer_code,
         entity_type="user",
         entity_id=user.username,
-        details="Main portal login (2FA)",
+        details=login_detail,
         request=request,
     )
 
@@ -229,7 +251,7 @@ async def validate_2fa_login(body: TOTPValidateRequest, request: Request):
 @totp_router.post(
     "/2fa/backup-codes/regenerate",
     response_model=TOTPBackupCodesResponse,
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
 )
 async def regenerate_2fa_backup_codes(
     body: TOTPVerifyRequest,

--- a/customer-portal/src/api/endpoints/totp.ts
+++ b/customer-portal/src/api/endpoints/totp.ts
@@ -1,0 +1,67 @@
+import type { CommonResponse } from "@/types/common"
+import { HttpClient } from "../httpClient"
+
+export interface TOTPSetupResponse {
+	secret: string
+	otpauth_url: string
+	qr_data_uri: string
+	backup_codes: string[]
+}
+
+export interface TOTPStatusResponse {
+	enabled: boolean
+}
+
+export interface TOTPBackupCodesResponse {
+	backup_codes: string[]
+}
+
+export interface TOTPValidateResponse {
+	access_token: string
+	token_type: string
+}
+
+export interface TOTPValidateRequest {
+	temp_token: string
+	code?: string
+	backup_code?: string
+}
+
+export interface TOTPDeleteRequest {
+	code?: string
+	backup_code?: string
+}
+
+export default {
+	/** Get 2FA status for current user */
+	getStatus() {
+		return HttpClient.get<CommonResponse<TOTPStatusResponse>>("/auth/2fa/status")
+	},
+
+	/** Start 2FA setup — get QR code and backup codes */
+	setup() {
+		return HttpClient.post<CommonResponse<TOTPSetupResponse>>("/auth/2fa/setup")
+	},
+
+	/** Verify setup with a TOTP code to activate 2FA */
+	verifySetup(code: string) {
+		return HttpClient.post<CommonResponse>("/auth/2fa/verify-setup", { code })
+	},
+
+	/** Disable 2FA (requires TOTP code or backup code) */
+	disable(payload: TOTPDeleteRequest) {
+		return HttpClient.delete<CommonResponse>("/auth/2fa/disable", { data: payload })
+	},
+
+	/** Validate 2FA code during login (uses temp_token, no auth header) */
+	validate(payload: TOTPValidateRequest) {
+		return HttpClient.post<CommonResponse<TOTPValidateResponse>>("/auth/2fa/validate", payload)
+	},
+
+	/** Regenerate backup codes (requires TOTP code) */
+	regenerateBackupCodes(code: string) {
+		return HttpClient.post<CommonResponse<TOTPBackupCodesResponse>>("/auth/2fa/backup-codes/regenerate", {
+			code
+		})
+	}
+}

--- a/customer-portal/src/api/index.ts
+++ b/customer-portal/src/api/index.ts
@@ -5,6 +5,7 @@ import cases from "./endpoints/cases"
 import caseTemplates from "./endpoints/caseTemplates"
 import portal from "./endpoints/portal"
 import siem from "./endpoints/siem"
+import totp from "./endpoints/totp"
 
 export default {
 	auth,
@@ -13,5 +14,6 @@ export default {
 	cases,
 	caseTemplates,
 	siem,
-	portal
+	portal,
+	totp
 }

--- a/customer-portal/src/components/auth/BackupCodesPanel.vue
+++ b/customer-portal/src/components/auth/BackupCodesPanel.vue
@@ -1,0 +1,59 @@
+<template>
+	<div class="flex flex-col gap-2">
+		<n-alert type="info">Backup codes generated. Save them — they are shown only once.</n-alert>
+
+		<div class="grid max-w-140 grid-cols-2 gap-2">
+			<n-code v-for="code in codes" :key="code" class="p-2 text-center">
+				{{ code }}
+			</n-code>
+		</div>
+
+		<div class="flex gap-2">
+			<n-button v-if="isCopySupported" size="small" secondary @click="copyBackupCodes(codes)">
+				<template #icon>
+					<Icon name="carbon:copy" />
+				</template>
+				Copy all
+			</n-button>
+			<n-button size="small" secondary @click="downloadBackupCodes(codes)">
+				<template #icon>
+					<Icon name="carbon:download" />
+				</template>
+				Download .txt
+			</n-button>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { useClipboard } from "@vueuse/core"
+import { saveAs } from "file-saver"
+import { NAlert, NButton, NCode, useMessage } from "naive-ui"
+import { watch } from "vue"
+import Icon from "@/components/common/Icon.vue"
+
+defineProps<{
+	codes: string[]
+}>()
+
+const message = useMessage()
+const { copy, copied, isSupported: isCopySupported } = useClipboard()
+
+function copyBackupCodes(codes: string[]) {
+	copy(codes.join("\n"))
+}
+
+function downloadBackupCodes(codes: string[]) {
+	const text = `CoPilot — 2FA Backup Codes\n${"=".repeat(30)}\n\n${codes.join(
+		"\n"
+	)}\n\nKeep these codes safe. Each code can only be used once.\n`
+
+	saveAs(new Blob([text], { type: "text/plain" }), "copilot-2fa-backup-codes.txt")
+}
+
+watch(copied, newVal => {
+	if (newVal) {
+		message.success("Backup codes copied to clipboard")
+	}
+})
+</script>

--- a/customer-portal/src/components/auth/SignIn.vue
+++ b/customer-portal/src/components/auth/SignIn.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<n-form ref="formRef" :model :rules :disabled="loading">
+		<n-form v-if="!show2faForm" ref="formRef" :model :rules :disabled="loading">
 			<n-form-item path="username" label="Username">
 				<n-input
 					v-model:value="model.username"
@@ -29,6 +29,8 @@
 				</div>
 			</div>
 		</n-form>
+
+		<TotpForm v-else v-model:two-fa-temp-token="twoFaTempToken" @cancel="show2faForm = false" />
 	</div>
 </template>
 
@@ -38,6 +40,7 @@ import type { LoginPayload } from "@/api/endpoints/auth"
 import { NButton, NForm, NFormItem, NInput, useMessage } from "naive-ui"
 import { computed, ref, watch } from "vue"
 import { useRouter } from "vue-router"
+import TotpForm from "@/components/auth/TotpForm.vue"
 import { useAuthStore } from "@/stores/auth"
 
 interface ModelType {
@@ -54,6 +57,11 @@ const model = ref<ModelType>({
 	password: null
 })
 const authStore = useAuthStore()
+
+// 2FA challenge state — when login returns `requires_2fa`, we swap the credentials
+// form for the TOTP challenge and hand it the short-lived temp token.
+const show2faForm = ref(false)
+const twoFaTempToken = ref("")
 
 const rules: FormRules = {
 	username: [
@@ -89,7 +97,14 @@ function signIn(e: Event) {
 
 			authStore
 				.login(payload)
-				.then(() => {
+				.then(res => {
+					if (res?.requires_2fa) {
+						// Credentials accepted but a second factor is required. Carry the temp
+						// token into the TOTP challenge; login completes in TotpForm.
+						twoFaTempToken.value = res.access_token
+						show2faForm.value = true
+						return
+					}
 					router.push({ path: "/", replace: true })
 				})
 				.catch(err => {

--- a/customer-portal/src/components/auth/TotpForm.vue
+++ b/customer-portal/src/components/auth/TotpForm.vue
@@ -1,0 +1,118 @@
+<template>
+	<div class="flex flex-col">
+		<div class="min-h-17">
+			<div class="mb-2 text-sm">Two-Factor Authentication</div>
+
+			<n-collapse-transition :show="!showBackupInput">
+				<n-input-otp
+					ref="twoFaCodeRef"
+					v-model:value="twoFaCode"
+					block
+					size="large"
+					:input-props="{ autocomplete: 'one-time-code', inputmode: 'numeric' }"
+					@finish="verify2fa()"
+					@keydown.enter="verify2fa()"
+				/>
+			</n-collapse-transition>
+			<n-collapse-transition :show="showBackupInput">
+				<n-input
+					v-model:value="backupCode"
+					placeholder="Backup code (e.g. ABCD1234EF)"
+					size="large"
+					@keydown.enter="verify2fa({ useBackupCode: true })"
+				/>
+			</n-collapse-transition>
+		</div>
+
+		<div class="h-6 w-full"></div>
+
+		<n-button
+			type="primary"
+			class="w-full!"
+			size="large"
+			:loading="twoFaLoading"
+			:disabled="!isValid"
+			@click="verify2fa({ useBackupCode: showBackupInput })"
+		>
+			{{ showBackupInput ? "Use backup code" : "Verify" }}
+		</n-button>
+
+		<div class="mt-4 flex items-center justify-between gap-2">
+			<n-button text size="small" @click="cancel2fa()">← Back to login</n-button>
+			<n-button text size="small" @click="showBackupInput = !showBackupInput">
+				{{ showBackupInput ? "Use authenticator code" : "Use a backup code instead" }}
+			</n-button>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import type { InputOtpInst } from "naive-ui"
+import type { TOTPValidateRequest } from "@/api/endpoints/totp"
+import { NButton, NCollapseTransition, NInput, NInputOtp, useMessage } from "naive-ui"
+import { computed, onMounted, ref, watch } from "vue"
+import { useRouter } from "vue-router"
+import { useAuthStore } from "@/stores/auth"
+
+const emit = defineEmits<{
+	(e: "cancel"): void
+}>()
+
+const twoFaTempToken = defineModel<string>("twoFaTempToken", { default: "" })
+
+const router = useRouter()
+const message = useMessage()
+const twoFaCodeRef = ref<InputOtpInst | null>(null)
+const authStore = useAuthStore()
+
+const twoFaCode = ref<string[]>([])
+const backupCode = ref("")
+const twoFaLoading = ref(false)
+const showBackupInput = ref(false)
+
+watch(showBackupInput, () => {
+	twoFaCode.value = []
+	backupCode.value = ""
+})
+
+const isValid = computed(() => {
+	if (showBackupInput.value) {
+		return !!backupCode.value
+	}
+	return twoFaCode.value.join("").length === 6
+})
+
+function cancel2fa() {
+	twoFaTempToken.value = ""
+	twoFaCode.value = []
+	backupCode.value = ""
+	showBackupInput.value = false
+	emit("cancel")
+}
+
+async function verify2fa(params?: { useBackupCode?: boolean }) {
+	twoFaLoading.value = true
+
+	const payload: TOTPValidateRequest = {
+		temp_token: twoFaTempToken.value,
+		code: params?.useBackupCode ? undefined : twoFaCode.value.join(""),
+		backup_code: params?.useBackupCode ? backupCode.value : undefined
+	}
+
+	authStore
+		.verify2fa(payload)
+		.then(() => {
+			router.push({ path: "/", replace: true })
+		})
+		.catch(err => {
+			message.error(err?.message || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			twoFaLoading.value = false
+		})
+}
+
+onMounted(() => {
+	twoFaCodeRef.value?.focusOnChar(0)
+})
+</script>

--- a/customer-portal/src/components/auth/TotpToggle.vue
+++ b/customer-portal/src/components/auth/TotpToggle.vue
@@ -1,0 +1,315 @@
+<template>
+	<div>
+		<!-- 2FA Section -->
+		<n-card title="Two-Factor Authentication (TOTP)">
+			<template #header-extra>
+				<n-tag :type="twoFaEnabled ? 'success' : 'default'" size="small">
+					{{ twoFaEnabled ? "Enabled" : "Disabled" }}
+				</n-tag>
+			</template>
+
+			<n-spin :show="twoFaLoading">
+				<!-- ── 2FA disabled — show enable button ── -->
+				<div v-if="!twoFaEnabled && !setupData">
+					<p class="text-secondary mb-4">
+						Add an extra layer of security to your account. You will need an authenticator app like Google
+						Authenticator, Authy, or Microsoft Authenticator.
+					</p>
+					<n-button type="primary" @click="startSetup">
+						<template #icon>
+							<Icon name="carbon:locked" />
+						</template>
+						Enable Two-Factor Authentication
+					</n-button>
+				</div>
+
+				<!-- ── Setup flow: QR + verify ── -->
+				<div v-if="setupData && (!twoFaEnabled || setupStep === 3)" class="flex flex-col gap-6">
+					<n-steps :current="setupStep" size="small">
+						<n-step title="Scan QR code" />
+						<n-step title="Verify code" />
+						<n-step title="Save backup codes" />
+					</n-steps>
+
+					<!-- Step 1: QR -->
+					<div v-if="setupStep === 1" class="flex flex-col gap-4">
+						<p>Scan this QR code with your authenticator app:</p>
+
+						<img :src="setupData.qr_data_uri" alt="TOTP QR Code" class="rounded border" width="200" />
+
+						<div>
+							<strong>Manual entry key:</strong>
+							<n-code class="ml-2">{{ setupData.secret }}</n-code>
+						</div>
+
+						<n-alert type="warning">
+							<template #icon>
+								<Icon name="carbon:time" />
+							</template>
+							<strong>Important:</strong>
+							Make sure your device clock is accurate. TOTP codes are time-sensitive and allow only a
+							&plusmn;30 second tolerance window.
+						</n-alert>
+
+						<div class="flex justify-between">
+							<n-button @click="finishSetup()">Cancel</n-button>
+							<n-button type="primary" @click="setupStep = 2">Next</n-button>
+						</div>
+					</div>
+
+					<!-- Step 2: Verify -->
+					<div v-if="setupStep === 2" class="flex flex-col gap-4">
+						<p>Enter the 6-digit code from your authenticator app to confirm:</p>
+
+						<n-input-otp
+							v-model:value="verifyCode"
+							block
+							size="large"
+							:input-props="{ autocomplete: 'one-time-code', inputmode: 'numeric' }"
+							class="max-w-100"
+							@finish="confirmSetup()"
+							@keydown.enter="confirmSetup()"
+						/>
+
+						<div class="flex justify-between gap-2">
+							<n-button @click="setupStep = 1">Back</n-button>
+							<n-button
+								type="primary"
+								:loading="verifying"
+								:disabled="verifyCode.length < 6"
+								@click="confirmSetup"
+							>
+								Verify &amp; Enable
+							</n-button>
+						</div>
+					</div>
+
+					<!-- Step 3: Backup codes -->
+					<div v-if="setupStep === 3" class="flex flex-col gap-4">
+						<n-alert type="success">
+							<template #icon>
+								<Icon name="carbon:checkmark-filled" />
+							</template>
+							Two-factor authentication is now enabled!
+						</n-alert>
+
+						<BackupCodesPanel :codes="setupData?.backup_codes || []" />
+
+						<n-button type="primary" class="ml-auto!" @click="finishSetup">Done</n-button>
+					</div>
+				</div>
+
+				<!-- ── 2FA enabled — show disable + regenerate ── -->
+				<div v-if="twoFaEnabled && !setupStep" class="flex flex-col gap-4">
+					<p class="text-secondary">
+						Two-factor authentication is active. You will be asked for a code from your authenticator app
+						every time you log in.
+					</p>
+					<div class="flex flex-wrap gap-3">
+						<n-popconfirm @positive-click="showDisableModal = true">
+							<template #trigger>
+								<n-button type="error">
+									<template #icon>
+										<Icon name="carbon:unlocked" />
+									</template>
+									Disable 2FA
+								</n-button>
+							</template>
+							Are you sure you want to disable two-factor authentication?
+						</n-popconfirm>
+						<n-button @click="showRegenModal = true">
+							<template #icon>
+								<Icon name="carbon:renew" />
+							</template>
+							Regenerate backup codes
+						</n-button>
+					</div>
+				</div>
+			</n-spin>
+		</n-card>
+
+		<!-- Disable 2FA Modal -->
+		<n-modal v-model:show="showDisableModal" preset="card" title="Disable 2FA" :style="{ maxWidth: '400px' }">
+			<p class="mb-4">Enter your TOTP code or a backup code to disable 2FA:</p>
+			<n-input
+				v-model:value="disableCode"
+				placeholder="6-digit code or backup code"
+				class="mb-4"
+				@keydown.enter="disableTwoFa"
+			/>
+			<div class="flex justify-end gap-2">
+				<n-button @click="showDisableModal = false">Cancel</n-button>
+				<n-button type="error" :loading="disabling" :disabled="!disableCode" @click="disableTwoFa">
+					Disable
+				</n-button>
+			</div>
+		</n-modal>
+
+		<!-- Regenerate Backup Codes Modal -->
+		<n-modal
+			v-model:show="showRegenModal"
+			preset="card"
+			title="Regenerate Backup Codes"
+			:style="{ maxWidth: '500px' }"
+		>
+			<div v-if="!regenCodes" class="flex flex-col gap-4">
+				<p>Enter your TOTP code to generate new backup codes. Old codes will be invalidated.</p>
+				<n-input-otp
+					v-model:value="regenCode"
+					block
+					size="large"
+					:input-props="{ autocomplete: 'one-time-code', inputmode: 'numeric' }"
+					@finish="regenBackupCodes()"
+					@keydown.enter="regenBackupCodes()"
+				/>
+				<div class="flex justify-end gap-2">
+					<n-button @click="showRegenModal = false">Cancel</n-button>
+					<n-button
+						type="primary"
+						:loading="regenerating"
+						:disabled="regenCode.length < 6"
+						@click="regenBackupCodes"
+					>
+						Regenerate
+					</n-button>
+				</div>
+			</div>
+			<div v-else class="flex flex-col gap-4">
+				<BackupCodesPanel :codes="regenCodes || []" />
+				<n-button type="primary" class="ml-auto!" @click="closeRegenModal">Done</n-button>
+			</div>
+		</n-modal>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import type { TOTPSetupResponse } from "@/api/endpoints/totp"
+import type { ApiError } from "@/types/common"
+import {
+	NAlert,
+	NButton,
+	NCard,
+	NCode,
+	NInput,
+	NInputOtp,
+	NModal,
+	NPopconfirm,
+	NSpin,
+	NStep,
+	NSteps,
+	NTag,
+	useMessage
+} from "naive-ui"
+import { onBeforeMount, ref } from "vue"
+import Api from "@/api"
+import BackupCodesPanel from "@/components/auth/BackupCodesPanel.vue"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+
+const message = useMessage()
+
+// ── 2FA state ────────────────────────────────────────────────────────────────
+const twoFaLoading = ref(false)
+const twoFaEnabled = ref(false)
+const setupData = ref<TOTPSetupResponse | null>(null)
+const setupStep = ref(0)
+const verifyCode = ref<string[]>([])
+const verifying = ref(false)
+
+const showDisableModal = ref(false)
+const disableCode = ref("")
+const disabling = ref(false)
+
+const showRegenModal = ref(false)
+const regenCode = ref<string[]>([])
+const regenCodes = ref<string[] | null>(null)
+const regenerating = ref(false)
+
+async function load2faStatus() {
+	twoFaLoading.value = true
+
+	try {
+		const res = await Api.totp.getStatus()
+		twoFaEnabled.value = res.data.enabled
+	} finally {
+		twoFaLoading.value = false
+	}
+}
+
+async function startSetup() {
+	twoFaLoading.value = true
+
+	try {
+		const res = await Api.totp.setup()
+		setupData.value = res.data
+		setupStep.value = 1
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Failed to start 2FA setup")
+	} finally {
+		twoFaLoading.value = false
+	}
+}
+
+async function confirmSetup() {
+	verifying.value = true
+
+	try {
+		await Api.totp.verifySetup(verifyCode.value.join(""))
+		twoFaEnabled.value = true
+		setupStep.value = 3
+		message.success("Two-factor authentication enabled!")
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Invalid code. Try again.")
+	} finally {
+		verifying.value = false
+	}
+}
+
+function finishSetup() {
+	setupData.value = null
+	setupStep.value = 0
+	verifyCode.value = []
+}
+
+async function disableTwoFa() {
+	disabling.value = true
+	const isBackup = disableCode.value.length > 6
+
+	try {
+		await Api.totp.disable(isBackup ? { backup_code: disableCode.value } : { code: disableCode.value })
+		twoFaEnabled.value = false
+		showDisableModal.value = false
+		disableCode.value = ""
+		message.success("Two-factor authentication disabled")
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Failed to disable 2FA")
+	} finally {
+		disabling.value = false
+	}
+}
+
+async function regenBackupCodes() {
+	regenerating.value = true
+
+	try {
+		const res = await Api.totp.regenerateBackupCodes(regenCode.value.join(""))
+		regenCodes.value = res.data.backup_codes
+		regenCode.value = []
+		message.success("Backup codes regenerated")
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Failed to regenerate codes")
+	} finally {
+		regenerating.value = false
+	}
+}
+
+function closeRegenModal() {
+	showRegenModal.value = false
+	regenCodes.value = null
+	regenCode.value = []
+}
+
+onBeforeMount(() => {
+	load2faStatus()
+})
+</script>

--- a/customer-portal/src/stores/auth.ts
+++ b/customer-portal/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import type { LoginPayload } from "@/api/endpoints/auth"
+import type { TOTPValidateRequest } from "@/api/endpoints/totp"
 import type { AuthResponse, AuthUser, AuthUserRole, JWTPayload, RouteMetaAuthRole } from "@/types/auth"
 import type { ApiError } from "@/types/common"
 import * as jose from "jose"
@@ -47,8 +48,27 @@ export const useAuthStore = defineStore("auth", {
 			try {
 				const response = await Api.auth.login(payload)
 
-				if (response.data) {
+				// When 2FA is enabled the response carries a short-lived temp token and
+				// `requires_2fa: true`. Do NOT treat it as a session — the caller hands the
+				// temp token to the 2FA challenge and completes login via verify2fa().
+				if (response.data && !response.data.requires_2fa) {
 					this.setLogged(response.data)
+				}
+
+				return response.data
+			} catch (err) {
+				const error = err as ApiError
+				throw error.response?.data
+			}
+		},
+		async verify2fa(payload: TOTPValidateRequest) {
+			try {
+				const response = await Api.totp.validate(payload)
+
+				// The validate endpoint returns the same {access_token, token_type} shape as the
+				// customer-portal login Token (no refresh_token), so cast through unknown.
+				if (response.data) {
+					this.setLogged(response.data as unknown as AuthResponse)
 				}
 
 				return response.data

--- a/customer-portal/src/types/auth.ts
+++ b/customer-portal/src/types/auth.ts
@@ -33,6 +33,11 @@ export interface AuthResponse {
 	access_token: string
 	refresh_token: string
 	token_type: string
+	/**
+	 * Set by the login endpoint when the account has 2FA enabled. When true, `access_token`
+	 * is a short-lived temp token to be exchanged at /auth/2fa/validate rather than a session.
+	 */
+	requires_2fa?: boolean
 }
 
 export interface JWTPayload extends jose.JWTPayload {

--- a/customer-portal/src/views/Profile.vue
+++ b/customer-portal/src/views/Profile.vue
@@ -70,6 +70,7 @@
 				<n-tab-pane name="security">
 					<div class="flex flex-col gap-4">
 						<ChangePasswordCard />
+						<TotpToggle />
 					</div>
 				</n-tab-pane>
 			</n-tabs>
@@ -82,6 +83,7 @@ import type { ImageCropperResult } from "@/components/common/ImageCropper.vue"
 import { NAvatar, NButton, NCard, NTab, NTabPane, NTabs, NTooltip } from "naive-ui"
 import { ref } from "vue"
 import ChangePasswordCard from "@/components/auth/ChangePasswordCard.vue"
+import TotpToggle from "@/components/auth/TotpToggle.vue"
 import Icon from "@/components/common/Icon.vue"
 import ImageCropper from "@/components/common/ImageCropper.vue"
 import ProfileSettings from "@/components/profile/ProfileSettings.vue"


### PR DESCRIPTION
Closes #947

## Summary

Adds native Two-Factor Authentication (TOTP) to the **customer portal**, reusing CoPilot's existing role-agnostic TOTP engine. Customers can self-enroll, disable, and regenerate backup codes from their account settings, and are challenged for a code at login.

**No new tables, columns, or Alembic migrations** — the `user_totp` table and TOTP service already exist for the main portal and are role-agnostic.

## Backend (`app/auth/routes/`)

- **`auth.py`** — `/token/customer-portal` now checks `is_2fa_enabled` after the role gate and returns a short-lived temp token with `requires_2fa: true` instead of a session (dropped `response_model=Token` so the flag isn't stripped, matching how `/token` already behaves).
- **`totp.py`** — `/2fa/validate` is now **role-aware**: when the user is `customer_user` it fetches their `customer_codes` and attaches them as a JWT claim — the tenant-scoping claim the portal relies on. Without it a customer would have zero accessible customers after a 2FA login. Audit detail reflects the portal accurately.
- **`totp.py`** — added `customer_user` to the allowed scopes on the 5 management routes (`status`, `setup`, `verify-setup`, `disable`, `backup-codes/regenerate`).

A single `/2fa/validate` endpoint is kept and branched on role rather than adding a portal-specific one — safe because customer users can only obtain a temp token from `/token/customer-portal` (the main `/token` rejects role 4 before the 2FA check).

## Customer portal (Vue)

- `api/endpoints/totp.ts` (new) + registered in `api/index.ts`
- `stores/auth.ts` — `verify2fa()` action; `login()` no longer treats a `requires_2fa` response as a session; `requires_2fa?` added to `AuthResponse`
- `components/auth/SignIn.vue` — swaps the credentials form for the TOTP challenge when login returns `requires_2fa`
- `components/auth/TotpForm.vue`, `TotpToggle.vue`, `BackupCodesPanel.vue` (new) — login challenge + self-service enrollment/disable/regenerate, mounted in the Profile **Security** tab

## Verification

- Backend: both files `py_compile` clean.
- Portal: `vue-tsc` reports no errors in any changed file; eslint clean. (Pre-existing `vue-echarts` type errors come from a stale local `node_modules`, unrelated to this change.)

## Test plan

1. Rebuild/restart backend.
2. In the customer portal, **Profile → Security → Enable Two-Factor Authentication**, scan the QR, verify a code, save backup codes.
3. Log out and back in — confirm the TOTP challenge appears and that the post-login view is still customer-scoped (verifies the `customer_codes` claim survives a 2FA login).
4. Confirm backup-code login, disable, and regenerate all work.