### PR TITLE
feat(notifications): direct webhook delivery channel for AI Notifications

### DIFF
--- a/backend/alembic/versions/a7b8c9d0e1f2_add_webhook_channel_to_notification_route.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_webhook_channel_to_notification_route.py
@@ -1,0 +1,49 @@
+"""Add direct-webhook channel columns to customer_notification_route.
+
+Adds three nullable columns so an AI-notification route can deliver
+straight to a customer-chosen URL (n8n, Discord, Slack incoming webhook,
+custom automation endpoint, …) instead of going through Shuffle's MCP:
+
+  - webhook_url          : target URL (http/https), populated when channel='webhook'
+  - webhook_method       : 'POST' (default) or 'PUT'
+  - webhook_headers      : JSON-encoded custom request headers (auth tokens, …)
+  - include_full_report  : when true, the dispatcher inlines the alert's full
+                           AI analyst report (markdown + recommended actions +
+                           IOCs) in the webhook JSON payload
+
+All nullable / no server default — existing Shuffle routes are untouched
+and read back NULL. The `channel` column is already a free-form varchar
+(documented as kept that way precisely so direct channels could be added
+without a migration), so only these new columns are needed.
+
+Revision ID: a7b8c9d0e1f2
+Revises: 649e1a544188
+Create Date: 2026-06-27 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a7b8c9d0e1f2"
+down_revision = "649e1a544188"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("customer_notification_route", sa.Column("webhook_url", sa.Text(), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("webhook_method", sa.String(length=8), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("webhook_headers", sa.Text(), nullable=True))
+    op.add_column(
+        "customer_notification_route",
+        sa.Column("include_full_report", sa.Boolean(), nullable=True, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("customer_notification_route", "include_full_report")
+    op.drop_column("customer_notification_route", "webhook_headers")
+    op.drop_column("customer_notification_route", "webhook_method")
+    op.drop_column("customer_notification_route", "webhook_url")

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -798,6 +798,21 @@ class CustomerNotificationRoute(SQLModel, table=True):
     shuffle_app_id: Optional[str] = Field(default=None, max_length=64)
     shuffle_app_name: Optional[str] = Field(default=None, max_length=128)
 
+    # ----- Direct webhook channel routing -----
+    # Populated when channel='webhook'. NULL for shuffle routes. The
+    # dispatch service POSTs/PUTs to `webhook_url` with either a
+    # structured JSON payload (default) or the rendered format_template
+    # (when set). `webhook_headers` is a JSON-encoded string of custom
+    # request headers (auth tokens etc.) — stored as text for portability
+    # across the MySQL/SQLite backends rather than a native JSON column.
+    webhook_url: Optional[str] = Field(sa_column=Column(Text), default=None)
+    webhook_method: Optional[str] = Field(default=None, max_length=8)
+    webhook_headers: Optional[str] = Field(sa_column=Column(Text), default=None)
+    # Webhook-only: inline the full AI analyst report (markdown + recommended
+    # actions + IOCs) in the dispatched JSON payload. Default False; NULL on
+    # legacy/shuffle rows reads back as falsy.
+    include_full_report: Optional[bool] = Field(default=False)
+
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     updated_at: Optional[datetime] = Field(default=None)
 

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -52,9 +53,20 @@ class NotificationChannel(str, Enum):
     columns. Email, chat, ticketing, and the rest of the catalog all
     flow through this single channel — there's no separate direct SMTP
     path because Shuffle's email apps cover that surface.
+
+    `webhook` is a direct HTTP POST to any URL the customer chooses
+    (automation platforms, chat incoming webhooks, a custom automation
+    endpoint, …) — no Shuffle org in the path. Routes referencing
+    `webhook` MUST populate `webhook_url`. By default the dispatcher
+    sends a structured JSON object; if the route sets a `format_template`
+    that template's rendered output is sent as the raw body instead, so
+    provider-specific shapes (Discord's `{"content": …}`, Slack's
+    `{"text": …}`) work without a code change. Optional `webhook_headers`
+    carry auth (Authorization / X-API-Key / …).
     """
 
     SHUFFLE = "shuffle"
+    WEBHOOK = "webhook"
 
 
 class NotificationSeverity(str, Enum):
@@ -117,14 +129,15 @@ class NotificationRouteBase(BaseModel):
             return NotificationTrigger.INVESTIGATION_COMPLETE.value
         return v
 
-    # For SMTP: comma-separated recipient emails. For Shuffle: free-form
-    # destination hint (e.g. '#soc-alerts', 'ir@corp.com') that gets
-    # injected into Shuffle's natural-language input — Shuffle's app
-    # agent figures out how to route it within the authenticated app.
-    destination: str = Field(
-        ...,
-        min_length=1,
-        description="Destination hint for the Shuffle app (channel name, email address, handle).",
+    # For Shuffle: free-form destination hint (e.g. '#soc-alerts',
+    # 'ir@corp.com') that gets injected into Shuffle's natural-language
+    # input — Shuffle's app agent figures out how to route it within the
+    # authenticated app. For webhook: optional, unused by the dispatcher
+    # (the URL is the real target); kept as a human label only. Required
+    # for Shuffle, optional for webhook — enforced in the model validator.
+    destination: Optional[str] = Field(
+        default=None,
+        description="Destination hint for the Shuffle app (channel name, email address, handle). Optional for webhook routes.",
     )
     min_severity: NotificationSeverity = NotificationSeverity.MEDIUM
     format_template: Optional[str] = Field(
@@ -147,18 +160,73 @@ class NotificationRouteBase(BaseModel):
         description="Human-readable Shuffle app name cached for the UI list (e.g. 'Slack').",
     )
 
+    # Webhook routing target. Required when channel='webhook'. The
+    # dispatcher POSTs (or PUTs) to `webhook_url` with the structured
+    # payload, or the rendered `format_template` if one is set. Custom
+    # headers carry auth (Authorization / X-API-Key / …).
+    webhook_url: Optional[str] = Field(
+        default=None,
+        description="Target URL for direct webhook delivery (required when channel='webhook'). Must be http(s).",
+    )
+    # Optional (not just defaulted) so reading back a non-webhook route —
+    # whose column is NULL — doesn't fail validation. New webhook routes
+    # that omit it fall back to POST at dispatch time.
+    webhook_method: Optional[str] = Field(
+        default="POST",
+        pattern="^(POST|PUT)$",
+        description="HTTP method for webhook delivery. POST (default) or PUT.",
+    )
+    webhook_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Optional custom request headers for webhook delivery (e.g. {'Authorization': 'Bearer …'}).",
+    )
+    # When True (webhook channel only), the dispatcher looks up the alert's
+    # latest AI analyst report + IOCs and merges the extra fields
+    # (recommended_actions, report_markdown, iocs, …) flat into the JSON
+    # payload — for downstream automation that wants the full analysis and
+    # IOC list rather than just the one-line summary. Default off so
+    # chat-target routes and the base payload stay lean.
+    include_full_report: bool = Field(
+        default=False,
+        description="Webhook only — inline the full AI report (markdown, recommended actions, IOCs) in the payload.",
+    )
+
     @field_validator("destination")
     @classmethod
-    def _strip_destination(cls, v: str) -> str:
-        return v.strip()
+    def _strip_destination(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip() if v is not None else v
+
+    @field_validator("webhook_url")
+    @classmethod
+    def _strip_webhook_url(cls, v: Optional[str]) -> Optional[str]:
+        return v.strip() if v is not None else v
+
+    @field_validator("include_full_report", mode="before")
+    @classmethod
+    def _coerce_null_full_report(cls, v):
+        """Treat a NULL column value as False on read.
+
+        The column is nullable; the migration backfills `false`, but a
+        hand-edited or pre-backfill row could be NULL. Pydantic 2 would
+        reject NULL against the `bool` field and 500 the list endpoint,
+        so coerce it here rather than surface a strictness error.
+        """
+        return False if v is None else v
 
     @model_validator(mode="after")
-    def _shuffle_fields_required(self):
+    def _channel_fields_required(self):
         if self.channel == NotificationChannel.SHUFFLE:
             if not self.shuffle_integration_id:
                 raise ValueError("shuffle_integration_id is required when channel='shuffle'")
             if not self.shuffle_app_id:
                 raise ValueError("shuffle_app_id is required when channel='shuffle'")
+            if not self.destination:
+                raise ValueError("destination is required when channel='shuffle'")
+        elif self.channel == NotificationChannel.WEBHOOK:
+            if not self.webhook_url:
+                raise ValueError("webhook_url is required when channel='webhook'")
+            if not self.webhook_url.lower().startswith(("http://", "https://")):
+                raise ValueError("webhook_url must start with http:// or https://")
         return self
 
 
@@ -182,6 +250,12 @@ class NotificationRouteUpdate(BaseModel):
     shuffle_integration_id: Optional[int] = None
     shuffle_app_id: Optional[str] = None
     shuffle_app_name: Optional[str] = None
+    # Webhook target — included on PATCH so admins can re-point a route
+    # at a different URL / method / headers without recreating it.
+    webhook_url: Optional[str] = None
+    webhook_method: Optional[str] = Field(default=None, pattern="^(POST|PUT)$")
+    webhook_headers: Optional[Dict[str, str]] = None
+    include_full_report: Optional[bool] = None
 
 
 class NotificationRouteRead(NotificationRouteBase):
@@ -193,6 +267,32 @@ class NotificationRouteRead(NotificationRouteBase):
     created_at: datetime
     updated_at: Optional[datetime] = None
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("webhook_headers", mode="before")
+    @classmethod
+    def _parse_webhook_headers(cls, v):
+        """Deserialize the DB's JSON-string column into a dict.
+
+        The `webhook_headers` ORM column stores a JSON string; this Read
+        schema exposes it as a dict. Pydantic 2 won't coerce a JSON
+        string to a dict on its own, so we parse it here. Tolerates the
+        already-dict case (when the schema is built from a payload
+        rather than an ORM row) and bad/empty values (→ None).
+        """
+        if v is None or isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            v = v.strip()
+            if not v:
+                return None
+            try:
+                import json
+
+                parsed = json.loads(v)
+                return parsed if isinstance(parsed, dict) else None
+            except ValueError:
+                return None
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -15,10 +15,17 @@ Channels:
               downstream provider's terminal state. Email, Slack,
               Teams, etc. all flow through this single channel via
               Shuffle's catalog of authenticated apps.
+  - webhook : Direct HTTP POST/PUT to any URL the customer configures
+              on the route (automation platforms, chat incoming
+              webhooks, a custom endpoint, …). No Shuffle in the path.
+              By default sends a structured JSON object; if the route
+              supplies a rendered template, that string is sent as the
+              raw body instead so provider-specific shapes work.
 """
 
 from __future__ import annotations
 
+import json
 import time
 from typing import Any
 from typing import Dict
@@ -39,6 +46,102 @@ ShuffleDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
 # 30s leaves enough headroom for those without letting a stuck request
 # stall the dispatch loop indefinitely.
 _SHUFFLE_TIMEOUT_S = 30.0
+
+# Webhook delivery is fire-and-record like Shuffle. 15s is plenty for a
+# healthy automation endpoint (most respond in well under a
+# second); a slow target shouldn't stall the whole dispatch loop.
+_WEBHOOK_TIMEOUT_S = 15.0
+
+# The webhook dispatcher returns the same 4-tuple shape as Shuffle for a
+# uniform call site, but the 4th slot (a provider execution id) is always
+# None for webhooks — there's no async run to correlate to.
+WebhookDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
+
+
+# ---------------------------------------------------------------------------
+# Webhook dispatcher (direct HTTP)
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_webhook(
+    *,
+    url: str,
+    method: str = "POST",
+    headers: Optional[Dict[str, str]] = None,
+    structured_payload: Dict[str, Any],
+    rendered_template: Optional[str] = None,
+) -> WebhookDispatchResult:
+    """Deliver a notification by direct HTTP request to `url`.
+
+    Body selection:
+      - When `rendered_template` is set, that string is the body. If it
+        parses as JSON we send it with `Content-Type: application/json`
+        (so Discord's `{"content": …}` / Slack's `{"text": …}` work);
+        otherwise it goes out as `text/plain`. This lets a route target
+        a provider with a strict body shape without a code change.
+      - Otherwise we POST `structured_payload` as JSON — the default
+        shape for automation platforms that consume discrete fields.
+
+    User-supplied `headers` are merged last so they can override the
+    default Content-Type when a target needs something specific.
+
+    Returns (status, error_message, latency_ms, None) — the 4th slot is
+    always None (no provider execution id for a direct webhook); it
+    exists only to match the Shuffle dispatcher's tuple shape so the
+    dispatch loop has one call-site contract.
+    """
+    method = (method or "POST").upper()
+    if method not in ("POST", "PUT"):
+        return ("failed", f"Unsupported webhook method: {method}", 0, None)
+
+    # Build the body + default content-type.
+    request_headers: Dict[str, str] = {"Accept": "application/json"}
+    content: Optional[str] = None
+    json_body: Optional[Dict[str, Any]] = None
+
+    if rendered_template is not None:
+        # Custom template path — send verbatim, JSON if it parses.
+        try:
+            parsed = json.loads(rendered_template)
+            json_body = parsed if isinstance(parsed, (dict, list)) else None
+        except ValueError:
+            json_body = None
+        if json_body is None:
+            content = rendered_template
+            request_headers["Content-Type"] = "text/plain; charset=utf-8"
+        else:
+            request_headers["Content-Type"] = "application/json"
+    else:
+        json_body = structured_payload
+        request_headers["Content-Type"] = "application/json"
+
+    # Caller headers win (auth tokens, content-type overrides, …).
+    if headers:
+        request_headers.update({str(k): str(v) for k, v in headers.items()})
+
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=_WEBHOOK_TIMEOUT_S) as client:
+            if json_body is not None:
+                response = await client.request(method, url, headers=request_headers, json=json_body)
+            else:
+                response = await client.request(method, url, headers=request_headers, content=content)
+        latency_ms = int((time.monotonic() - started) * 1000)
+
+        if response.status_code >= 400:
+            return (
+                "failed",
+                f"Webhook returned {response.status_code}: {response.text[:200]}",
+                latency_ms,
+                None,
+            )
+        # Any 2xx/3xx is treated as accepted — fire-and-record, we don't
+        # interpret the target's response body.
+        return ("sent", None, latency_ms, None)
+    except Exception as e:  # noqa: BLE001
+        latency_ms = int((time.monotonic() - started) * 1000)
+        logger.warning(f"Webhook dispatch failed: {e!r}")
+        return ("failed", f"{type(e).__name__}: {e}", latency_ms, None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -13,7 +13,10 @@ log row is what gives us idempotency — re-dispatching the same
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -25,6 +28,8 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.ai_analyst.services.ai_analyst import list_iocs_by_alert
+from app.ai_analyst.services.ai_analyst import list_reports_by_alert
 from app.connectors.utils import get_connector_info_from_db
 from app.db.universal_models import CustomerNotificationRoute
 from app.db.universal_models import CustomerShuffleIntegration
@@ -43,6 +48,7 @@ from app.notifications.schema.notifications import ShuffleIntegrationCreate
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
 from app.notifications.schema.notifications import ShuffleOrg
 from app.notifications.services.dispatchers import dispatch_shuffle
+from app.notifications.services.dispatchers import dispatch_webhook
 from app.notifications.services.dispatchers import (
     list_shuffle_apps as shuffle_apps_client,
 )
@@ -132,7 +138,9 @@ async def create_route(
         name=payload.name,
         trigger=payload.trigger.value,
         channel=payload.channel.value,
-        destination=payload.destination,
+        # `destination` is non-null in the DB; webhook routes may omit it,
+        # so coalesce to empty string rather than NULL.
+        destination=payload.destination or "",
         min_severity=payload.min_severity.value,
         format_template=payload.format_template,
         enabled=payload.enabled,
@@ -140,6 +148,16 @@ async def create_route(
         shuffle_integration_id=payload.shuffle_integration_id,
         shuffle_app_id=payload.shuffle_app_id,
         shuffle_app_name=payload.shuffle_app_name,
+        # Only persist webhook columns for webhook routes — leave them
+        # NULL on shuffle routes so a read-back doesn't surface a
+        # spurious method/url on a route that doesn't use them.
+        webhook_url=payload.webhook_url if payload.channel == NotificationChannel.WEBHOOK else None,
+        webhook_method=(payload.webhook_method or "POST") if payload.channel == NotificationChannel.WEBHOOK else None,
+        # Headers are stored as a JSON string in a Text column.
+        webhook_headers=(
+            json.dumps(payload.webhook_headers) if payload.channel == NotificationChannel.WEBHOOK and payload.webhook_headers else None
+        ),
+        include_full_report=(payload.include_full_report if payload.channel == NotificationChannel.WEBHOOK else False),
     )
     session.add(route)
     await session.commit()
@@ -176,6 +194,14 @@ async def update_route(
         # Enums: write the underlying string into the DB column.
         if hasattr(value, "value"):
             value = value.value
+        # webhook_headers is a dict in the schema but a JSON-string
+        # column in the DB — encode on the way in.
+        if field == "webhook_headers":
+            value = json.dumps(value) if value else None
+        # destination is NOT NULL in the DB; a webhook PATCH legitimately
+        # sends it as null (webhooks don't use it) — coalesce to "".
+        if field == "destination" and value is None:
+            value = ""
         setattr(route, field, value)
     route.updated_at = datetime.utcnow()
 
@@ -484,6 +510,66 @@ def _format_default_body(req: DispatchRequest) -> str:
     return "\n".join(parts)
 
 
+def _decode_webhook_headers(raw: Optional[str]) -> Optional[Dict[str, str]]:
+    """Deserialize the route's JSON-string `webhook_headers` column.
+
+    Returns a flat str→str dict, or None when unset/blank/malformed.
+    Failing closed (None) rather than raising keeps a bad row from
+    aborting the whole dispatch — the request just goes out with the
+    dispatcher's default headers.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        logger.warning(f"Malformed webhook_headers JSON, ignoring: {raw[:120]!r}")
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
+async def _build_full_report(alert_id: int, session: AsyncSession) -> Optional[Dict[str, Any]]:
+    """Fetch the alert's latest AI report's *extra* fields as a flat dict.
+
+    Returns only the fields NOT already present at the top level of the
+    webhook payload — i.e. it deliberately omits `summary` and the
+    severity (those are already sent as `summary`/`severity`) to avoid
+    duplicating them. The dispatcher merges this flat into the payload.
+
+    Reuses the ai_analyst service layer (the canonical read path) so the
+    shape stays in sync with the AI Analyst API. Returns None when no
+    report exists yet — the dispatcher then sends the base payload
+    unchanged, so a webhook never fails just because the report
+    write-back hasn't landed.
+
+    `list_reports_by_alert` returns newest-first, so element 0 is the
+    report this dispatch is about. IOCs are scoped to the same alert.
+    """
+    reports = await list_reports_by_alert(alert_id, session)
+    if not reports:
+        return None
+    report = reports[0]
+    iocs = await list_iocs_by_alert(alert_id, session)
+    return {
+        "report_id": report.id,
+        "recommended_actions": report.recommended_actions,
+        "report_markdown": report.report_markdown,
+        "report_created_at": report.created_at.isoformat() if report.created_at else None,
+        "iocs": [
+            {
+                "ioc_value": i.ioc_value,
+                "ioc_type": i.ioc_type,
+                "vt_verdict": i.vt_verdict,
+                "vt_score": i.vt_score,
+                "details": i.details,
+            }
+            for i in iocs
+        ],
+    }
+
+
 def _render_body(route: CustomerNotificationRoute, req: DispatchRequest) -> str:
     """Apply the route's `format_template` if set, else fall back.
 
@@ -645,6 +731,11 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         route_destination = route.destination
         route_shuffle_app_id = route.shuffle_app_id
         route_shuffle_integration_id = route.shuffle_integration_id
+        route_has_template = bool(route.format_template)
+        route_webhook_url = route.webhook_url
+        route_webhook_method = route.webhook_method
+        route_webhook_headers = route.webhook_headers
+        route_include_full_report = bool(route.include_full_report)
 
         body = _render_body(route, req)
         body_preview = body[:500]
@@ -711,6 +802,61 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
                             app_id=route_shuffle_app_id,
                             input_text=input_text,
                         )
+            elif route_channel == NotificationChannel.WEBHOOK.value:
+                # Direct HTTP webhook. Fire-and-record — POST/PUT to the
+                # route's URL with either a structured JSON payload
+                # (default) or the rendered template (when the route sets
+                # one), and treat any 2xx/3xx as `sent`.
+                if not route_webhook_url:
+                    result_status = "failed"
+                    error_message = "Route has no webhook_url (data integrity issue)"
+                    latency_ms = 0
+                else:
+                    # Structured default payload — automation platforms
+                    # consume these fields directly.
+                    structured_payload: Dict[str, Any] = {
+                        "customer_code": req.customer_code,
+                        "alert_id": req.alert_id,
+                        "alert_name": req.alert_name,
+                        "severity": req.severity_assessment.value,
+                        "summary": req.summary,
+                        "report_url": req.report_url,
+                        "text": body,
+                    }
+                    # Two mutually-exclusive body modes (enforced in the UI,
+                    # guarded here):
+                    #   1. include_full_report → merge the report's extra
+                    #      fields (recommended actions, full markdown, IOCs)
+                    #      flat into the structured payload. Template ignored.
+                    #   2. custom template → that rendered string is the body.
+                    #      If it contains the `{{report}}` token, inject the
+                    #      same report fields as a JSON object at that spot.
+                    rendered_template: Optional[str] = None
+                    if route_include_full_report:
+                        report_fields = await _build_full_report(req.alert_id, session)
+                        if report_fields is not None:
+                            structured_payload.update(report_fields)
+                    elif route_has_template:
+                        rendered_template = body
+                        if "{{report}}" in rendered_template:
+                            report_fields = await _build_full_report(req.alert_id, session)
+                            rendered_template = rendered_template.replace(
+                                "{{report}}",
+                                json.dumps(report_fields) if report_fields is not None else "null",
+                            )
+                    headers = _decode_webhook_headers(route_webhook_headers)
+                    (
+                        result_status,
+                        error_message,
+                        latency_ms,
+                        _,
+                    ) = await dispatch_webhook(
+                        url=route_webhook_url,
+                        method=route_webhook_method or "POST",
+                        headers=headers,
+                        structured_payload=structured_payload,
+                        rendered_template=rendered_template,
+                    )
             else:
                 # Unknown channel — preserved as a failure rather than
                 # silently dropped so a misconfigured row surfaces in

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -15,73 +15,160 @@
 		</div>
 
 		<!--
-			Channel is now Shuffle-only — the SMTP path was removed when we
-			consolidated email delivery into Shuffle's catalog (Outlook,
-			Gmail, SendGrid, SMTP-via-Shuffle, etc. all live there). Field
-			stays in the form for clarity but is fixed to a single value.
+			Channel picks the delivery path. Shuffle proxies to a customer's
+			authenticated Shuffle org (Slack / Teams / Outlook / 3,000+ apps);
+			Webhook POSTs directly to any URL (automation platforms, chat
+			webhooks, custom endpoints) with no Shuffle in the path.
 		-->
-		<n-form-item label="Channel">
-			<n-select v-model:value="form.channel" :options="channelOptions" disabled />
-			<template v-if="!fieldErrors.channel" #feedback>
-				Email is direct SMTP via CoPilot's deployment config. Shuffle proxies to 3,000+ integrations through a
-				customer's authenticated Shuffle org.
+		<n-form-item label="Channel" path="channel">
+			<n-select v-model:value="form.channel" :options="channelOptions" @update:value="onChannelChange" />
+			<template #feedback>
+				<span v-if="isWebhook">
+					Direct HTTP POST/PUT to a URL you control — automation platforms, chat incoming webhooks, custom
+					endpoints, etc. No Shuffle org required.
+				</span>
+				<span v-else>Shuffle proxies to 3,000+ integrations through a customer's authenticated Shuffle org.</span>
 			</template>
 		</n-form-item>
 
-		<n-form-item label="Shuffle integration" path="shuffle_integration_id">
-			<n-select
-				v-model:value="form.shuffle_integration_id"
-				:options="integrationOptions"
-				placeholder="Pick a Shuffle org for this customer"
-				:loading="loadingIntegrations"
-				@update:value="onIntegrationChange"
-			/>
-			<template
-				v-if="!fieldErrors.shuffle_integration_id && !integrationOptions.length && !loadingIntegrations"
-				#feedback
-			>
-				No Shuffle integrations configured for this customer yet — go to the
-				<strong>Shuffle integrations</strong>
-				tab to add one first.
-			</template>
-		</n-form-item>
+		<!-- ===== Shuffle channel fields ===== -->
+		<template v-if="isShuffle">
+			<n-form-item label="Shuffle integration" path="shuffle_integration_id">
+				<n-select
+					v-model:value="form.shuffle_integration_id"
+					:options="integrationOptions"
+					placeholder="Pick a Shuffle org for this customer"
+					:loading="loadingIntegrations"
+					@update:value="onIntegrationChange"
+				/>
+				<template
+					v-if="!fieldErrors.shuffle_integration_id && !integrationOptions.length && !loadingIntegrations"
+					#feedback
+				>
+					No Shuffle integrations configured for this customer yet — go to the
+					<strong>Shuffle integrations</strong>
+					tab to add one first.
+				</template>
+			</n-form-item>
 
-		<n-form-item label="Shuffle app" path="shuffle_app_id">
-			<n-select
-				v-model:value="form.shuffle_app_id"
-				:options="appOptions"
-				placeholder="Pick an authenticated app"
-				:loading="loadingApps"
-				:disabled="!form.shuffle_integration_id || loadingApps"
-				filterable
-				@update:value="onAppChange"
-			/>
-			<template v-if="showShuffleAppsFetchError" #feedback>
-				<div class="text-error">Couldn't fetch apps from Shuffle: {{ appsError }}</div>
-			</template>
-		</n-form-item>
+			<n-form-item label="Shuffle app" path="shuffle_app_id">
+				<n-select
+					v-model:value="form.shuffle_app_id"
+					:options="appOptions"
+					placeholder="Pick an authenticated app"
+					:loading="loadingApps"
+					:disabled="!form.shuffle_integration_id || loadingApps"
+					filterable
+					@update:value="onAppChange"
+				/>
+				<template v-if="showShuffleAppsFetchError" #feedback>
+					<div class="text-error">Couldn't fetch apps from Shuffle: {{ appsError }}</div>
+				</template>
+			</n-form-item>
 
-		<n-form-item label="Destination hint" path="destination">
-			<n-input
-				v-model:value="form.destination"
-				placeholder="e.g. #soc-alerts, soc@example.com, @user-id"
-				type="text"
-			/>
-			<template v-if="!fieldErrors.destination" #feedback>
-				Free-form — gets prepended to the outgoing message as a
-				<code>Send to &lt;destination&gt;: …</code>
-				hint so the Shuffle app agent knows where to deliver. Channel name for Slack, email for Outlook / Gmail,
-				handle for chat apps, etc.
-			</template>
-		</n-form-item>
+			<n-form-item label="Destination hint" path="destination">
+				<n-input
+					v-model:value="form.destination"
+					placeholder="e.g. #soc-alerts, soc@example.com, @user-id"
+					type="text"
+				/>
+				<template v-if="!fieldErrors.destination" #feedback>
+					Free-form — gets prepended to the outgoing message as a
+					<code>Send to &lt;destination&gt;: …</code>
+					hint so the Shuffle app agent knows where to deliver. Channel name for Slack, email for Outlook /
+					Gmail, handle for chat apps, etc.
+				</template>
+			</n-form-item>
+		</template>
+
+		<!-- ===== Webhook channel fields ===== -->
+		<template v-else-if="isWebhook">
+			<div class="grid grid-cols-1 gap-4 md:grid-cols-[1fr_140px]">
+				<n-form-item label="Webhook URL" path="webhook_url">
+					<n-input
+						v-model:value="form.webhook_url"
+						placeholder="https://example.com/webhook/abc-123"
+						type="text"
+					/>
+				</n-form-item>
+
+				<n-form-item label="Method" path="webhook_method">
+					<n-select v-model:value="form.webhook_method" :options="methodOptions" />
+				</n-form-item>
+			</div>
+
+			<n-form-item label="Custom headers (optional)" :show-feedback="false">
+				<n-dynamic-input
+					v-model:value="headerPairs"
+					:on-create="() => ({ key: '', value: '' })"
+					class="w-full"
+				>
+					<template #default="{ value }">
+						<div class="flex w-full items-center gap-2">
+							<n-input v-model:value="value.key" placeholder="Header name (e.g. Authorization)" />
+							<n-input v-model:value="value.value" placeholder="Header value (e.g. Bearer …)" />
+						</div>
+					</template>
+				</n-dynamic-input>
+			</n-form-item>
+			<div class="text-secondary mb-2 text-xs">
+				Sent on every request. Use for auth tokens (e.g.
+				<code>Authorization: Bearer …</code>
+				or
+				<code>X-API-Key</code>
+				). Leave empty if the URL itself carries the secret (Discord / Slack).
+			</div>
+
+			<n-form-item :show-feedback="false">
+				<n-checkbox v-model:checked="form.include_full_report" :disabled="fullReportDisabled">
+					Include full AI report
+				</n-checkbox>
+			</n-form-item>
+			<div class="text-secondary mb-2 text-xs">
+				Adds the full AI report to the payload — the recommended actions, the full markdown write-up, and the IOC
+				list — for automation agents that need more than the summary. Leave off for chat targets to keep the
+				payload small.
+				<template v-if="fullReportDisabled">
+					<br />
+					<em>Unavailable while a custom template is set — use the
+						<code>{{ reportToken }}</code>
+						token in the template instead.</em>
+				</template>
+			</div>
+		</template>
+
 		<n-form-item label="Custom message template (optional)" path="format_template" :show-feedback="false">
 			<n-input
 				v-model:value="form.format_template"
 				type="textarea"
 				:autosize="{ minRows: 4, maxRows: 12 }"
-				placeholder="Leave empty to use the default. Substitutions: {{customer_code}} {{alert_id}} {{alert_name}} {{severity}} {{summary}} {{report_url}}"
+				:placeholder="templatePlaceholder"
+				:disabled="templateDisabled"
 			/>
 		</n-form-item>
+		<div class="text-secondary mb-2 text-xs">
+			<template v-if="templateDisabled">
+				<em>Unavailable while
+					<strong>Include full AI report</strong>
+					is ticked — the full structured payload is sent. Untick it to write a custom body.</em>
+			</template>
+			<template v-else-if="isWebhook">
+				Leave empty to send a structured JSON payload (<code>customer_code</code>, <code>alert_id</code>,
+				<code>severity</code>, <code>summary</code>, <code>report_url</code>, <code>text</code>). Set a template to
+				send a custom body instead — if it's valid JSON it's sent as JSON (e.g.
+				<code>{"content": "…"}</code>), otherwise as plain text. Available tokens:
+				<code>{{ substitutionTokens }}</code>
+				. To include the full AI report, place
+				<code>{{ reportToken }}</code>
+				unquoted as a JSON value (e.g.
+				<code>"report": {{ reportToken }}</code>
+				).
+			</template>
+			<template v-else>
+				Leave empty to use the default. Substitutions:
+				<code>{{ substitutionTokens }}</code>
+			</template>
+		</div>
 
 		<n-form-item>
 			<n-checkbox v-model:checked="form.enabled">Enabled</n-checkbox>
@@ -99,6 +186,7 @@
 <script setup lang="ts">
 import type { FormInst, FormRules } from "naive-ui"
 import type {
+	NotificationChannel,
 	NotificationRoute,
 	NotificationRoutePayload,
 	NotificationSeverity,
@@ -106,7 +194,16 @@ import type {
 	ShuffleApp,
 	ShuffleIntegration
 } from "@/types/notifications"
-import { NButton, NCheckbox, NForm, NFormItem, NInput, NSelect, useMessage } from "naive-ui"
+import {
+	NButton,
+	NCheckbox,
+	NDynamicInput,
+	NForm,
+	NFormItem,
+	NInput,
+	NSelect,
+	useMessage
+} from "naive-ui"
 import { computed, onBeforeMount, reactive, ref } from "vue"
 import Api from "@/api"
 import { getApiErrorMessage } from "@/utils"
@@ -126,12 +223,8 @@ const formRef = ref<FormInst | null>(null)
 const submitting = ref(false)
 
 const editing = computed(() => props.editingRoute !== null)
-type FeedbackField = "channel" | "destination" | "min_severity" | "shuffle_app_id" | "shuffle_integration_id"
+type FeedbackField = "channel" | "destination" | "min_severity" | "shuffle_app_id" | "shuffle_integration_id" | "webhook_url"
 
-// Channel is hard-coded to "shuffle" — the SMTP path was removed.
-// Existing routes loaded via the editing path may have legacy values
-// in the DB; we still use the route's channel as-is on edit (fall
-// back to "shuffle" for new routes).
 const fieldErrors = reactive<Partial<Record<FeedbackField, string>>>({})
 
 const form = reactive<NotificationRoutePayload>({
@@ -144,23 +237,51 @@ const form = reactive<NotificationRoutePayload>({
 	enabled: props.editingRoute?.enabled ?? true,
 	shuffle_integration_id: props.editingRoute?.shuffle_integration_id ?? null,
 	shuffle_app_id: props.editingRoute?.shuffle_app_id ?? null,
-	shuffle_app_name: props.editingRoute?.shuffle_app_name ?? null
+	shuffle_app_name: props.editingRoute?.shuffle_app_name ?? null,
+	webhook_url: props.editingRoute?.webhook_url ?? null,
+	webhook_method: props.editingRoute?.webhook_method ?? "POST",
+	include_full_report: props.editingRoute?.include_full_report ?? false
 })
 
+const isShuffle = computed(() => form.channel === "shuffle")
+const isWebhook = computed(() => form.channel === "webhook")
+
+// Mutual exclusivity (webhook only): "include full report" and a custom
+// template are two alternative body modes. Ticking the box disables the
+// template; writing a template disables the box. Each lane can still get
+// the report — the box for the structured payload, the {{report}} token
+// for the template.
+const templateDisabled = computed(() => isWebhook.value && form.include_full_report)
+const fullReportDisabled = computed(() => isWebhook.value && Boolean(form.format_template?.trim()))
+// Shown literally in the help text. Kept as a constant so the template
+// doesn't nest {{ }} inside an interpolation (Vue can't parse that).
+const reportToken = "{{report}}"
+
+// Custom headers are edited as an ordered key/value list and converted to
+// a Record on submit. Seed from the editing route's stored headers.
+const headerPairs = ref<{ key: string; value: string }[]>(
+	props.editingRoute?.webhook_headers
+		? Object.entries(props.editingRoute.webhook_headers).map(([key, value]) => ({ key, value }))
+		: []
+)
+
 // Trigger is a single fixed value today (`investigation_complete`).
-// Hidden from the UI — set programmatically on the form. Will become
-// a select again when we add more dispatch event types (analyst-review
-// hooks, IOC-enrichment alerts, scheduled-sweep findings).
+// Will become a richer select again when we add more dispatch event
+// types (analyst-review hooks, IOC-enrichment alerts, scheduled sweeps).
 const triggerOptions = [
 	{ label: "Every investigation completes", value: "investigation_complete" },
 	{ label: "Critical / High severity only", value: "severity_critical_or_high" }
 ]
 
-// Single-option list — keeps the n-select rendering consistent with
-// the rest of the form even though there's nothing to pick. If we
-// ever add a second channel back (e.g. raw webhook), this is the line
-// to extend.
-const channelOptions = [{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" }]
+const channelOptions = [
+	{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" },
+	{ label: "Webhook (direct HTTP to any URL)", value: "webhook" }
+]
+
+const methodOptions = [
+	{ label: "POST", value: "POST" },
+	{ label: "PUT", value: "PUT" }
+]
 
 const severityOptions = [
 	{ label: "Critical (only)", value: "Critical" },
@@ -170,9 +291,19 @@ const severityOptions = [
 	{ label: "Informational and above (everything)", value: "Informational" }
 ]
 
+const templatePlaceholder = computed(() =>
+	isWebhook.value
+		? 'Leave empty for structured JSON. Example custom body: {"content": "[{{severity}}] {{alert_name}} — {{summary}}"}'
+		: "Leave empty to use the default. Substitutions: {{customer_code}} {{alert_id}} {{alert_name}} {{severity}} {{summary}} {{report_url}}"
+)
+
+// Displayed as literal text in the help line. Kept as a script constant so
+// the template doesn't nest `{{ }}` inside an interpolation — Vue's compiler
+// closes the interpolation at the first inner `}}` and fails to parse.
+const substitutionTokens = "{{customer_code}} {{alert_id}} {{alert_name}} {{severity}} {{summary}} {{report_url}}"
+
 // Shuffle integrations + apps state. Integrations are fetched on form
-// open; apps are fetched lazily when an integration is picked. Both
-// short-circuit on edit so we don't blank a route's existing values.
+// open; apps are fetched lazily when an integration is picked.
 const integrations = ref<ShuffleIntegration[]>([])
 const loadingIntegrations = ref(false)
 const apps = ref<ShuffleApp[]>([])
@@ -211,6 +342,17 @@ function clearFieldError(field: FeedbackField) {
 function createFieldError(field: FeedbackField, message: string) {
 	fieldErrors[field] = message
 	return new Error(message)
+}
+
+function onChannelChange(channel: NotificationChannel) {
+	// Clear any stale per-channel validation feedback when switching.
+	clearFieldError("shuffle_integration_id")
+	clearFieldError("shuffle_app_id")
+	clearFieldError("destination")
+	clearFieldError("webhook_url")
+	if (channel === "webhook" && !form.webhook_method) {
+		form.webhook_method = "POST"
+	}
 }
 
 async function loadIntegrations() {
@@ -257,8 +399,7 @@ async function onIntegrationChange(integrationId: number | null) {
 
 function onAppChange(appId: string | null) {
 	// Cache the app's display name alongside the UUID so the UI list can
-	// render "Slack" instead of a UUID without re-fetching the catalog
-	// every render.
+	// render "Slack" instead of a UUID without re-fetching the catalog.
 	const app = apps.value.find(a => a.id === appId)
 	form.shuffle_app_name = app?.name ?? null
 }
@@ -275,10 +416,10 @@ const rules: FormRules = {
 		trigger: ["change", "blur"]
 	},
 	destination: {
-		required: true,
+		// Required for Shuffle only — webhook routes don't use it.
 		validator: (_rule, value: string) => {
-			if (!value || !value.trim()) {
-				createFieldError("destination", "Destination hint is required")
+			if (isShuffle.value && (!value || !value.trim())) {
+				return createFieldError("destination", "Destination hint is required")
 			}
 			clearFieldError("destination")
 			return true
@@ -286,9 +427,8 @@ const rules: FormRules = {
 		trigger: ["input", "blur"]
 	},
 	shuffle_integration_id: {
-		required: true,
 		validator: (_rule, value: number | null) => {
-			if (form.channel === "shuffle" && !value) {
+			if (isShuffle.value && !value) {
 				return createFieldError("shuffle_integration_id", "Pick a Shuffle integration")
 			}
 			clearFieldError("shuffle_integration_id")
@@ -297,14 +437,37 @@ const rules: FormRules = {
 		trigger: ["change", "blur"]
 	},
 	shuffle_app_id: {
-		required: true,
 		validator: (_rule, value: string | null) => {
-			if (!value) return createFieldError("shuffle_app_id", "Pick a Shuffle app")
+			if (isShuffle.value && !value) return createFieldError("shuffle_app_id", "Pick a Shuffle app")
 			clearFieldError("shuffle_app_id")
 			return true
 		},
 		trigger: ["change", "blur"]
+	},
+	webhook_url: {
+		validator: (_rule, value: string | null) => {
+			if (!isWebhook.value) {
+				clearFieldError("webhook_url")
+				return true
+			}
+			if (!value || !value.trim()) {
+				return createFieldError("webhook_url", "Webhook URL is required")
+			}
+			if (!/^https?:\/\//i.test(value.trim())) {
+				return createFieldError("webhook_url", "URL must start with http:// or https://")
+			}
+			clearFieldError("webhook_url")
+			return true
+		},
+		trigger: ["input", "blur"]
 	}
+}
+
+function buildHeaders(): Record<string, string> | null {
+	const entries = headerPairs.value
+		.map(p => [p.key.trim(), p.value])
+		.filter(([k]) => k.length > 0) as [string, string][]
+	return entries.length ? Object.fromEntries(entries) : null
 }
 
 async function submit() {
@@ -316,10 +479,46 @@ async function submit() {
 
 	submitting.value = true
 	try {
-		const payload: NotificationRoutePayload = {
-			...form,
-			format_template: form.format_template?.trim() || null
+		// Build a channel-clean payload: only send the fields relevant to
+		// the selected channel so we don't persist stale values from the
+		// other branch (e.g. a Shuffle app id left over after switching).
+		// Full report and a custom template are mutually exclusive — if the
+		// box is ticked, never persist a template (the structured payload is
+		// sent). Keeps stored data consistent with the UI's grey-out.
+		const sendTemplate = isWebhook.value && form.include_full_report ? null : form.format_template?.trim() || null
+
+		const base = {
+			name: form.name,
+			trigger: form.trigger,
+			channel: form.channel,
+			min_severity: form.min_severity,
+			format_template: sendTemplate,
+			enabled: form.enabled
 		}
+
+		const payload: NotificationRoutePayload = isWebhook.value
+			? {
+					...base,
+					destination: null,
+					webhook_url: form.webhook_url?.trim() || null,
+					webhook_method: form.webhook_method || "POST",
+					webhook_headers: buildHeaders(),
+					include_full_report: form.include_full_report,
+					shuffle_integration_id: null,
+					shuffle_app_id: null,
+					shuffle_app_name: null
+				}
+			: {
+					...base,
+					destination: form.destination,
+					shuffle_integration_id: form.shuffle_integration_id,
+					shuffle_app_id: form.shuffle_app_id,
+					shuffle_app_name: form.shuffle_app_name,
+					webhook_url: null,
+					webhook_method: null,
+					webhook_headers: null,
+					include_full_report: false
+				}
 
 		const res = props.editingRoute
 			? await Api.notifications.updateRoute(props.customerCode, props.editingRoute.id, payload)

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
@@ -25,11 +25,23 @@
 		<template #default>
 			<div class="flex flex-col gap-3 text-sm">
 				<div class="flex flex-col gap-0.5 text-sm">
-					<div class="flex flex-wrap gap-1">
+					<div v-if="isWebhook" class="flex flex-wrap gap-1">
+						<span class="font-medium">{{ route.webhook_method || "POST" }} to:</span>
+						<code class="break-all">{{ route.webhook_url }}</code>
+					</div>
+					<div v-else class="flex flex-wrap gap-1">
 						<span class="font-medium">Destination:</span>
 						<span class="flex flex-wrap gap-1">
 							<code v-for="destination in destinationList" :key="destination">{{ destination }}</code>
 						</span>
+					</div>
+					<div v-if="isWebhook && hasCustomHeaders" class="flex flex-wrap gap-1">
+						<span class="font-medium">Custom headers:</span>
+						<span class="italic">configured</span>
+					</div>
+					<div v-if="isWebhook && route.include_full_report" class="flex flex-wrap gap-1">
+						<span class="font-medium">Full AI report:</span>
+						<span class="italic">included</span>
 					</div>
 					<div v-if="route.format_template" class="flex flex-wrap gap-1">
 						<span class="font-medium">Custom template:</span>
@@ -130,13 +142,25 @@ const loadingDelete = ref(false)
 const message = useMessage()
 const dFormats = useSettingsStore().dateFormat
 
-// All current routes are Shuffle-routed; the underlying Shuffle app
-// name is cached on the route row at form-submit time so we don't
-// need to roundtrip to Shuffle on every list render.
-const channelIcon = computed(() => "carbon:integration")
-const channelLabel = computed(() =>
-	props.route.shuffle_app_name ? `Shuffle · ${props.route.shuffle_app_name}` : "Shuffle"
+const isWebhook = computed(() => props.route.channel === "webhook")
+const hasCustomHeaders = computed(
+	() => props.route.webhook_headers !== null && Object.keys(props.route.webhook_headers ?? {}).length > 0
 )
+
+// Shuffle routes cache the app name on the row at form-submit time so we
+// can render "Shuffle · Slack" without a roundtrip; webhook routes show
+// the URL host so the list is scannable at a glance.
+const channelIcon = computed(() => (isWebhook.value ? "carbon:webhook" : "carbon:integration"))
+const channelLabel = computed(() => {
+	if (isWebhook.value) {
+		try {
+			return `Webhook · ${new URL(props.route.webhook_url ?? "").host}`
+		} catch {
+			return "Webhook"
+		}
+	}
+	return props.route.shuffle_app_name ? `Shuffle · ${props.route.shuffle_app_name}` : "Shuffle"
+})
 
 const severityColor = computed<"danger" | "warning" | "success">(() => {
 	if (props.route.min_severity === "Critical" || props.route.min_severity === "High") return "danger"

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRoutes.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRoutes.vue
@@ -36,7 +36,7 @@
 						<template v-else>
 							<n-empty
 								v-if="!loading"
-								description="No routes configured. Add one to send Talon's investigation summaries to Slack or email."
+								description="No routes configured. Add one to send Talon's investigation summaries to Shuffle apps or a direct webhook (automation platforms, chat, custom endpoints)."
 								class="h-48 justify-center"
 							/>
 						</template>

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -8,7 +8,7 @@
 // analyst-review / IOC-enrichment / scheduled sweeps.
 export type NotificationTrigger = "investigation_complete"
 
-export type NotificationChannel = "shuffle"
+export type NotificationChannel = "shuffle" | "webhook"
 
 export type NotificationSeverity = "Critical" | "High" | "Medium" | "Low" | "Informational"
 
@@ -33,19 +33,30 @@ export interface NotificationRoute {
 	shuffle_integration_id: number | null
 	shuffle_app_id: string | null
 	shuffle_app_name: string | null
+	// Populated only when channel === "webhook"
+	webhook_url: string | null
+	webhook_method: string | null
+	webhook_headers: Record<string, string> | null
+	// Webhook only — inline the full AI report (markdown + recommended actions + IOCs) in the payload.
+	include_full_report: boolean
 }
 
 export interface NotificationRoutePayload {
 	name: string
 	trigger: NotificationTrigger
 	channel: NotificationChannel
-	destination: string
+	// Optional for webhook routes (the URL is the real target); required for shuffle.
+	destination?: string | null
 	min_severity: NotificationSeverity
 	format_template?: string | null
 	enabled: boolean
 	shuffle_integration_id?: number | null
 	shuffle_app_id?: string | null
 	shuffle_app_name?: string | null
+	webhook_url?: string | null
+	webhook_method?: string | null
+	webhook_headers?: Record<string, string> | null
+	include_full_report?: boolean
 }
 
 export type NotificationRouteUpdatePayload = Partial<NotificationRoutePayload>


### PR DESCRIPTION
## Summary

Adds a **`webhook`** delivery channel to AI-notification routes, alongside the existing
Shuffle/MCP channel, plus an **opt-in "full AI report"** payload mode for it. When an AI
investigation completes, a route can now POST/PUT straight to any URL the customer chooses
(automation platforms, chat incoming webhooks, custom endpoints) — no Shuffle org in the
path — and optionally carry the complete investigation (recommended actions, full markdown
write-up, and IOCs), not just the one-line summary. Shuffle routing is untouched; this is
purely additive.

## Motivation

**Direct webhook.** Today every AI-notification route has to go through Shuffle. For teams whose automation lives elsewhere (a self-hosted automation platform, a chat
incoming webhook, a bespoke endpoint), routing through Shuffle adds a hop, an extra
credential, and a point of failure. A direct webhook lets those notifications go straight to
the destination.

**Why carry the full report.** The current notification payload is intentionally minimal — a
one-paragraph `summary`. That's fine for a human glancing at a chat message, but it's not
enough for an *automation* downstream: to triage or act (e.g. enrich, open a ticket,
or drive a response workflow), the agent needs the AI's **recommended actions** and the
**extracted IOCs**, not a prose summary it has to re-parse.

Without inlining the report, the only way for a downstream workflow to get that data is to
**call back into CoPilot's API** to fetch the report by alert ID. For deployments where
CoPilot sits on a private network that's a real cost: it forces inbound API access to the
platform, another credential to manage, and TLS/allowlist plumbing — all to retrieve data
CoPilot already had at dispatch time. Inlining the report keeps the flow **outbound-only**:
CoPilot pushes everything the agent needs in the same webhook, and the automation side never
has to reach back in. That's simpler and a better security posture for private deployments.

## What's included

**Webhook channel**
- New `webhook` value on the notification channel. A route stores a target `webhook_url`,
  an HTTP method (`POST`/`PUT`), and optional custom headers (for auth tokens).
- Same trigger/severity filtering and idempotent dispatch logging as the Shuffle path.
- `webhook_url` is validated as `http(s)`; routes remain admin/analyst-scoped.
- Default body is a structured JSON object: `customer_code`, `alert_id`, `alert_name`,
  `severity`, `summary`, `report_url`, `text`.

**Full AI report (opt-in)** — two mutually-exclusive body modes, enforced in the UI and
guarded in the dispatcher:

1. **"Include full AI report"** tickbox → merges the report's extra fields
   (`recommended_actions`, `report_markdown`, `iocs[]`, `report_id`, `report_created_at`)
   **flat** into the structured payload, with **no duplicated** `summary`/`severity`. Best
   for automation agents that want clean, typed fields.
2. **Custom template** → author the exact body; drop the **`{{report}}`** token (placed as
   an unquoted JSON value, e.g. `"report": {{report}}`) to inject the same report fields as
   a nested object. Best when a downstream endpoint needs a specific body shape.

The two modes are mutually exclusive: ticking the box greys out the template, and writing a
template greys out the box — each lane has its own way to include the report, so there's no
ambiguity about which body is sent.

## Full AI report — behaviour & design

**Where the data comes from.** Report data is read through the existing `ai_analyst` service
layer (`list_reports_by_alert` / `list_iocs_by_alert`) — the same canonical read path the AI
Analyst API uses — so the shape stays in sync. The newest report per alert is used, with its
IOCs scoped to the same alert.

**Graceful degradation.** If no report row exists yet at dispatch time (e.g. the write-back
hasn't landed), the report fields are simply omitted and the base payload (incl. `summary`)
is still sent. A webhook never fails just because the report isn't ready.

**No duplication.** The report's `summary` and `severity_assessment` are deliberately dropped
from the inlined fields because they're already present at the top level as `summary` /
`severity`. Only genuinely-new fields are added.

**JSON-injection safety.** The `{{report}}` token is replaced with `json.dumps(...)` of the
report fields, so a report containing quotes or newlines (the markdown almost always does)
produces valid JSON rather than breaking the body. When no report exists, the token resolves
to `null`. This is why the token is documented as an *unquoted JSON value*, not a string
substitution.

**Default is lean.** The tickbox defaults off, so existing routes and chat-target routes
(where a large report blob is unwanted) are unchanged.

Example payload with the tickbox enabled:

{
  "customer_code": "acme",
  "alert_id": 1423,
  "alert_name": "Reg.exe used to dump SAM hive",
  "severity": "Medium",
  "summary": "reg.exe dumped HKLM\\SAM hive ...",
  "report_url": null,
  "text": "*AI investigation complete* ...",
  "report_id": 42,
  "recommended_actions": "1. Verify SAM/SYSTEM/SECURITY hive dumps are cleaned up ...",
  "report_markdown": "## AI Investigation\n\n...full write-up...",
  "report_created_at": "2026-06-28T14:03:11",
  "iocs": [
    {
      "ioc_value": "EF37663B...C3EB5F0",
      "ioc_type": "hash",
      "vt_verdict": "clean",
      "vt_score": null,
      "details": "Signed Windows OS binary; SHA256 matches Windows 11 24H2 build."
    }
  ]
}

## Schema & migration

- `NotificationChannel` gains `WEBHOOK`; routes gain `webhook_url` / `webhook_method` /
  `webhook_headers` / `include_full_report`, with channel-aware validation. The Read schema
  coerces a NULL `include_full_report` to `false` so a nullable column can never trip
  Pydantic-v2 strictness on the list endpoint.
- One migration (`a7b8c9d0e1f2`) adds four nullable columns to
  `customer_notification_route`. Additive, no data mutation, reversible. Existing Shuffle
  routes read back unchanged.

## Frontend

Scoped to the AI Notifications route components: channel selector + conditional webhook
fields (URL, method, headers editor), the full-report tickbox, and the template field with
a mutual-exclusivity grey-out and a `{{report}}` token hint. The route card surfaces the
target URL/method and whether the full report is included.

## Testing

- Backend: black / isort / flake8 clean; unit-level validation of the schema (incl. the NULL
  coercion) and both webhook body modes; end-to-end dispatch verified against a live receiver
  with a **real** investigation — recommended actions + full markdown + IOCs delivered as
  valid JSON, including a report containing embedded quotes (to confirm `{{report}}`
  injection stays valid).
- Missing-report path verified (fields omitted, summary still sent).
- Migration applied cleanly on a running instance; frontend builds.

## Notes for reviewers

- **Migration parent:** `down_revision = 649e1a544188` (current `main` head at time of
  writing). If `main` gains a migration before merge, this will need a quick re-parent.
- **Webhook URLs are admin/analyst-scoped and `http(s)`-validated**, consistent with the
  existing admin-configured Shuffle/connector endpoints.