### PR TITLE
feat(monitoring-alert): route predefined alerts to selected Graylog instance (#967)

### DIFF
--- a/backend/app/integrations/monitoring_alert/routes/provision.py
+++ b/backend/app/integrations/monitoring_alert/routes/provision.py
@@ -12,9 +12,13 @@ from app.auth.routes.auth import AuthHandler
 from app.connectors.graylog.routes.events import get_all_event_definitions
 from app.connectors.graylog.schema.events import GraylogEventDefinitionsResponse
 from app.connectors.graylog.services.streams import get_streams
+from app.connectors.graylog.utils.routing import GraylogContext
+from app.connectors.graylog.utils.routing import clear_graylog_context
+from app.connectors.graylog.utils.routing import set_graylog_context
 from app.db.db_session import get_db
 from app.db.universal_models import CustomersMeta
 from app.integrations.monitoring_alert.schema.provision import AvailableMonitoringAlerts
+from app.integrations.monitoring_alert.schema.provision import GraylogInstance
 from app.integrations.monitoring_alert.schema.provision import (
     AvailableMonitoringAlertsResponse,
 )
@@ -639,6 +643,25 @@ PROVISION_FUNCTIONS = {
 }
 
 
+def graylog_context_for_instance(instance: GraylogInstance) -> GraylogContext:
+    """
+    Map the requested Graylog instance to its connector context.
+
+    Network sources (Fortinet/SonicWall/syslog) are ingested by Graylog02, so
+    their event definitions must be provisioned on the Graylog-Network connector
+    or they never fire. Everything else defaults to Graylog01.
+
+    Args:
+        instance (GraylogInstance): The requested target instance.
+
+    Returns:
+        GraylogContext: The Graylog connector context to use for the request.
+    """
+    if instance == GraylogInstance.NETWORK:
+        return GraylogContext.NETWORK
+    return GraylogContext.WAZUH
+
+
 async def check_if_event_definition_exists(event_definition: str) -> bool:
     """
     Check if the event definition exists.
@@ -696,19 +719,25 @@ async def get_available_monitoring_alerts_route() -> AvailableMonitoringAlertsRe
 async def provision_monitoring_alert_route(
     request: ProvisionMonitoringAlertRequest,
 ) -> ProvisionWazuhMonitoringAlertResponse:
-    await check_if_event_definition_exists(request.alert_name.replace("_", " "))
+    # Route every downstream Graylog call (existence check + event-definition
+    # creation) to the requested instance. Network sources land on Graylog02.
+    set_graylog_context(graylog_context_for_instance(request.graylog_instance))
+    try:
+        await check_if_event_definition_exists(request.alert_name.replace("_", " "))
 
-    # Look up the provision function based on request.alert_name
-    provision_function = PROVISION_FUNCTIONS.get(request.alert_name)
+        # Look up the provision function based on request.alert_name
+        provision_function = PROVISION_FUNCTIONS.get(request.alert_name)
 
-    if provision_function is None:
-        raise HTTPException(
-            status_code=400,
-            detail=f"No provision function found for alert name {request.alert_name}",
-        )
+        if provision_function is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"No provision function found for alert name {request.alert_name}",
+            )
 
-    # Invoke the provision function
-    await provision_function(request)
+        # Invoke the provision function
+        await provision_function(request)
+    finally:
+        clear_graylog_context()
 
     return ProvisionWazuhMonitoringAlertResponse(success=True, message=f"Monitoring alert {request.alert_name} provisioned successfully.")
 
@@ -723,23 +752,29 @@ async def provision_custom_monitoring_alert_route(
     request: CustomMonitoringAlertProvisionModel,
     session: AsyncSession = Depends(get_db),
 ) -> ProvisionWazuhMonitoringAlertResponse:
-    await check_if_event_definition_exists(request.alert_name.replace("_", " "))
-    # ! This is commented out because it is not used in the code. Will revisit later ! #
-    # customer_code = next((field.value for field in request.custom_fields if field.name == "CUSTOMER_CODE"), None)
-    # await get_customer_meta(customer_code=customer_code, session=session)
-    # Look up the provision function based on request.alert_name
-    provision_function = PROVISION_FUNCTIONS.get("CUSTOM")
+    # Route every downstream Graylog call (existence check + event-definition
+    # creation) to the requested instance. Network sources land on Graylog02.
+    set_graylog_context(graylog_context_for_instance(request.graylog_instance))
+    try:
+        await check_if_event_definition_exists(request.alert_name.replace("_", " "))
+        # ! This is commented out because it is not used in the code. Will revisit later ! #
+        # customer_code = next((field.value for field in request.custom_fields if field.name == "CUSTOMER_CODE"), None)
+        # await get_customer_meta(customer_code=customer_code, session=session)
+        # Look up the provision function based on request.alert_name
+        provision_function = PROVISION_FUNCTIONS.get("CUSTOM")
 
-    logger.info(f"Provisioning custom alert {request}")
+        logger.info(f"Provisioning custom alert {request}")
 
-    if provision_function is None:
-        raise HTTPException(
-            status_code=400,
-            detail=f"No provision function found for alert name {request.alert_name}",
-        )
+        if provision_function is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"No provision function found for alert name {request.alert_name}",
+            )
 
-    # Invoke the provision function
-    await provision_function(request)
+        # Invoke the provision function
+        await provision_function(request)
+    finally:
+        clear_graylog_context()
 
     return ProvisionWazuhMonitoringAlertResponse(success=True, message=f"Monitoring alert {request.alert_name} provisioned successfully.")
 

--- a/backend/app/integrations/monitoring_alert/routes/provision.py
+++ b/backend/app/integrations/monitoring_alert/routes/provision.py
@@ -18,13 +18,13 @@ from app.connectors.graylog.utils.routing import set_graylog_context
 from app.db.db_session import get_db
 from app.db.universal_models import CustomersMeta
 from app.integrations.monitoring_alert.schema.provision import AvailableMonitoringAlerts
-from app.integrations.monitoring_alert.schema.provision import GraylogInstance
 from app.integrations.monitoring_alert.schema.provision import (
     AvailableMonitoringAlertsResponse,
 )
 from app.integrations.monitoring_alert.schema.provision import (
     CustomMonitoringAlertProvisionModel,
 )
+from app.integrations.monitoring_alert.schema.provision import GraylogInstance
 from app.integrations.monitoring_alert.schema.provision import (
     ProvisionMonitoringAlertRequest,
 )

--- a/backend/app/integrations/monitoring_alert/schema/provision.py
+++ b/backend/app/integrations/monitoring_alert/schema/provision.py
@@ -9,6 +9,24 @@ from pydantic import Field
 from pydantic import field_validator
 
 
+class GraylogInstance(str, Enum):
+    """
+    The target Graylog instance a monitoring alert should be provisioned on.
+
+    Some log sources are ingested by a separate "network" Graylog (Graylog02,
+    the ``Graylog-Network`` connector) rather than the default Graylog01 that
+    handles Wazuh and third-party integrations. Fortinet/SonicWall/syslog
+    sources typically land on Graylog02, so their event definitions must be
+    created there or they never fire.
+
+    DEFAULT: Graylog01 (``Graylog`` connector) -- Wazuh + 3rd-party integrations.
+    NETWORK: Graylog02 (``Graylog-Network`` connector) -- network/syslog sources.
+    """
+
+    DEFAULT = "default"
+    NETWORK = "network"
+
+
 class AvailableMonitoringAlerts(str, Enum):
     """
     The available monitoring alerts.
@@ -292,6 +310,14 @@ class ProvisionMonitoringAlertRequest(BaseModel):
         "WAZUH_SYSLOG_LEVEL_ALERT",
         description="The name of the alert to provision.",
     )
+    graylog_instance: GraylogInstance = Field(
+        GraylogInstance.DEFAULT,
+        description=(
+            "The Graylog instance to provision the alert on. Use 'network' for "
+            "sources ingested by Graylog02 (the Graylog-Network connector, e.g. "
+            "Fortinet/SonicWall/syslog); defaults to 'default' (Graylog01)."
+        ),
+    )
 
     @field_validator("alert_name")
     @classmethod
@@ -490,6 +516,14 @@ class CustomMonitoringAlertProvisionModel(BaseModel):
         ...,
         description="The time in milliseconds to execute the alert search.",
         examples=[300000],
+    )
+    graylog_instance: GraylogInstance = Field(
+        GraylogInstance.DEFAULT,
+        description=(
+            "The Graylog instance to provision the alert on. Use 'network' for "
+            "sources ingested by Graylog02 (the Graylog-Network connector, e.g. "
+            "Fortinet/SonicWall/syslog); defaults to 'default' (Graylog01)."
+        ),
     )
 
     # ! I think I can remove the requirement for the CUSTOMER_CODE field.

--- a/frontend/src/api/endpoints/monitoring-alerts.ts
+++ b/frontend/src/api/endpoints/monitoring-alerts.ts
@@ -2,9 +2,13 @@ import type { FlaskBaseResponse } from "@/types/flask"
 import type { AvailableMonitoringAlert, CustomProvisionPriority, MonitoringAlert } from "@/types/monitoring-alerts"
 import { HttpClient } from "../http-client"
 
+/** Target Graylog instance for provisioning. "network" targets Graylog02 (Graylog-Network). */
+export type GraylogInstance = "default" | "network"
+
 export interface ProvisionsMonitoringAlertParams {
 	searchWithinLast: number
 	executeEvery: number
+	graylogInstance?: GraylogInstance
 }
 
 export interface CustomProvisionPayload {
@@ -19,6 +23,7 @@ export interface CustomProvisionPayload {
 	}[]
 	search_within_ms: number
 	execute_every_ms: number
+	graylog_instance?: GraylogInstance
 }
 
 export default {
@@ -31,7 +36,8 @@ export default {
 		return HttpClient.post<FlaskBaseResponse>(`/monitoring_alert/provision`, {
 			search_within_last: params.searchWithinLast,
 			execute_every: params.executeEvery,
-			alert_name: alertName
+			alert_name: alertName,
+			graylog_instance: params.graylogInstance ?? "default"
 		})
 	},
 	customProvision(payload: CustomProvisionPayload) {

--- a/frontend/src/components/graylog/MonitoringAlerts/CustomAlertForm.vue
+++ b/frontend/src/components/graylog/MonitoringAlerts/CustomAlertForm.vue
@@ -20,6 +20,9 @@
 					</n-form-item>
 				</div>
 				<div class="flex flex-col gap-2">
+					<n-form-item label="Graylog Instance" path="graylog_instance">
+						<n-select v-model:value="form.graylog_instance" :options="graylogInstanceOptions" />
+					</n-form-item>
 					<n-form-item label="Description" path="alert_description">
 						<n-input
 							v-model:value.trim="form.alert_description"
@@ -156,7 +159,7 @@
 
 <script setup lang="ts">
 import type { FormInst, FormItemRule, FormRules, FormValidationError, MessageReactive } from "naive-ui"
-import type { CustomProvisionPayload } from "@/api/endpoints/monitoring-alerts"
+import type { CustomProvisionPayload, GraylogInstance } from "@/api/endpoints/monitoring-alerts"
 import type { ApiError } from "@/types/common"
 import type { Stream } from "@/types/graylog/stream"
 import _get from "lodash/get"
@@ -182,6 +185,7 @@ interface CustomProvisionForm {
 	search_within_seconds: number
 	execute_every_seconds: number
 	streams: string[]
+	graylog_instance: GraylogInstance
 }
 
 const emit = defineEmits<{
@@ -227,6 +231,11 @@ const alertPriorityOptions: { label: string; value: CustomProvisionPriority }[] 
 	{ label: "Low", value: CustomProvisionPriority.LOW },
 	{ label: "Medium", value: CustomProvisionPriority.MEDIUM },
 	{ label: "High", value: CustomProvisionPriority.HIGH }
+]
+
+const graylogInstanceOptions: { label: string; value: GraylogInstance }[] = [
+	{ label: "Default (Graylog01)", value: "default" },
+	{ label: "Network (Graylog02)", value: "network" }
 ]
 
 const rules: FormRules = {
@@ -372,7 +381,8 @@ function getClearForm(): CustomProvisionForm {
 		custom_fields: [],
 		search_within_seconds: 1,
 		execute_every_seconds: 1,
-		streams: []
+		streams: [],
+		graylog_instance: "default"
 	}
 }
 
@@ -398,7 +408,8 @@ function submit() {
 		custom_fields: form.value.custom_fields,
 		search_within_ms: _toSafeInteger(form.value.search_within_seconds) * 1000,
 		execute_every_ms: _toSafeInteger(form.value.execute_every_seconds) * 1000,
-		streams: form.value.streams || []
+		streams: form.value.streams || [],
+		graylog_instance: form.value.graylog_instance
 	}
 
 	Api.monitoringAlerts

--- a/frontend/src/components/graylog/MonitoringAlerts/Item.vue
+++ b/frontend/src/components/graylog/MonitoringAlerts/Item.vue
@@ -43,6 +43,13 @@
 		>
 			<n-spin :show="loadingProvision">
 				<n-form ref="formRef" :model="formModel" :rules="formRules">
+					<n-form-item path="graylogInstance" label="Graylog Instance">
+						<n-select
+							v-model:value="formModel.graylogInstance"
+							:options="graylogInstanceOptions"
+							class="w-full"
+						/>
+					</n-form-item>
 					<n-form-item path="searchWithinLast" label="Search Within Last (time in seconds)">
 						<n-input-number
 							v-model:value="formModel.searchWithinLast"
@@ -77,10 +84,10 @@
 
 <script setup lang="ts">
 import type { FormRules, FormValidationError } from "naive-ui"
-import type { ProvisionsMonitoringAlertParams } from "@/api/endpoints/monitoring-alerts"
+import type { GraylogInstance, ProvisionsMonitoringAlertParams } from "@/api/endpoints/monitoring-alerts"
 import type { ApiError } from "@/types/common"
 import type { AvailableMonitoringAlert } from "@/types/monitoring-alerts"
-import { NButton, NForm, NFormItem, NInputNumber, NModal, NSpin, useMessage } from "naive-ui"
+import { NButton, NForm, NFormItem, NInputNumber, NModal, NSelect, NSpin, useMessage } from "naive-ui"
 import { ref } from "vue"
 import Api from "@/api"
 import Badge from "@/components/common/Badge.vue"
@@ -103,7 +110,11 @@ const showFormDialog = ref(false)
 const message = useMessage()
 
 const formRef = ref()
-const formModel = ref<{ searchWithinLast: null | number; executeEvery: null | number }>(getClearFormModel())
+const formModel = ref<{
+	searchWithinLast: null | number
+	executeEvery: null | number
+	graylogInstance: GraylogInstance
+}>(getClearFormModel())
 const formRules: FormRules = {
 	searchWithinLast: [
 		{
@@ -117,10 +128,16 @@ const formRules: FormRules = {
 	]
 }
 
+const graylogInstanceOptions: { label: string; value: GraylogInstance }[] = [
+	{ label: "Default (Graylog01)", value: "default" },
+	{ label: "Network (Graylog02)", value: "network" }
+]
+
 function getClearFormModel() {
 	return {
 		searchWithinLast: null,
-		executeEvery: null
+		executeEvery: null,
+		graylogInstance: "default" as GraylogInstance
 	}
 }
 
@@ -157,7 +174,8 @@ function provisionsMonitoringAlert() {
 
 		const params: ProvisionsMonitoringAlertParams = {
 			searchWithinLast: formModel.value.searchWithinLast,
-			executeEvery: formModel.value.executeEvery
+			executeEvery: formModel.value.executeEvery,
+			graylogInstance: formModel.value.graylogInstance
 		}
 
 		Api.monitoringAlerts


### PR DESCRIPTION
Closes #967

## Problem

Predefined **monitoring alerts** are provisioned as Graylog **event definitions** via `app/integrations/monitoring_alert/`. Every alert type funnels through `provision_alert_definition()`, which called `send_post_request_create_entity(endpoint="/api/events/definitions", ...)` **without a `connector_name` and without any Graylog context set**.

So the connector resolved to the default → `GraylogContext.WAZUH` = `"Graylog"` (**Graylog01**). Result: **all** predefined alerts — including Fortinet — were created on Graylog01. But Fortinet / SonicWall / syslog sources are ingested by **Graylog02** (`Graylog-Network`), so those event definitions never matched anything and the alerts silently never fired.

## Fix

Let the frontend choose the target instance and set the existing Graylog context before dispatching. A single `set_graylog_context(...)` call covers the whole downstream flow (duplicate-check → event-definition creation → version probe) since they all read the same request-scoped `ContextVar`. The routing machinery already existed and is already used by the Fortinet/SonicWall/SentinelOne stack-provisioning routes — the `monitoring_alert` routes were just never wired up.

### Backend
- `schema/provision.py` — new `GraylogInstance` enum (`default` | `network`); optional `graylog_instance` field (defaults `default`, so existing callers are unchanged) on `ProvisionMonitoringAlertRequest` and `CustomMonitoringAlertProvisionModel`.
- `routes/provision.py` — new `graylog_context_for_instance()` helper; both `POST /monitoring_alert/provision` and `POST /monitoring_alert/provision/custom` wrap their body in `set_graylog_context(...)` / `try…finally: clear_graylog_context()`.

### Frontend
- `api/endpoints/monitoring-alerts.ts` — `GraylogInstance` type; threads `graylog_instance` on both provision calls (defaults `"default"`).
- `MonitoringAlerts/Item.vue` — "Graylog Instance" selector on the predefined-alert enable dialog.
- `MonitoringAlerts/CustomAlertForm.vue` — "Graylog Instance" selector on the custom-alert form.

**API contract:** `graylog_instance: "default" | "network"` — `"network"` routes to Graylog02 (`Graylog-Network`); omitted/`"default"` preserves prior behavior (Graylog01).

## Testing
- Provisioned a Fortinet predefined alert with **Network (Graylog02)** selected → event definition lands on the `Graylog-Network` instance.
- Backend syntax OK; frontend `type-check` + `eslint` clean.

## Known follow-ups (out of scope — read paths, not the provisioning bug)
Both currently read Graylog01 only, so when targeting the network instance:
1. `List.vue` "Enabled" badge reads `getEventDefinitions()` (Graylog01) — a network-provisioned alert still shows "Not Enabled".
2. `CustomAlertForm.vue` streams picker reads `getStreams()` (Graylog01) — a custom network alert can't select a Graylog02 stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
