### PR TITLE
fix(shuffle): surface failed notification workflow executions (#963)

### DIFF
--- a/backend/app/connectors/shuffle/services/integrations.py
+++ b/backend/app/connectors/shuffle/services/integrations.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from loguru import logger
 
 from app.connectors.shuffle.schema.integrations import ExecuteWorkflowRequest
@@ -35,7 +36,23 @@ async def execute_workflow(request: ExecuteWorkflowRequest) -> dict:
     try:
         response = await send_post_request(f"/api/v1/workflows/{request.workflow_id}/execute", request.model_dump())
         logger.info(f"Response: {response}")
-        return response
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error executing workflow: {e}")
-        return {"error": str(e)}
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to reach Shuffle while executing workflow {request.workflow_id}: {e}",
+        )
+
+    # `send_post_request` folds both the HTTP status and Shuffle's in-body
+    # `success` flag into `response["success"]`. A workflow that can't be
+    # retrieved/executed (e.g. wrong regional Shuffle API endpoint) comes back
+    # here as success=false — surface it instead of reporting a phantom
+    # success to the caller/UI. See GitHub issue #963.
+    if not response or response.get("success") is not True:
+        detail = (response or {}).get("message") or "Failed to execute Shuffle workflow"
+        logger.error(f"Shuffle workflow {request.workflow_id} did not execute successfully: {response}")
+        raise HTTPException(status_code=502, detail=detail)
+
+    return response

--- a/backend/app/connectors/shuffle/utils/universal.py
+++ b/backend/app/connectors/shuffle/utils/universal.py
@@ -180,10 +180,26 @@ async def send_post_request(
                 "message": "Successfully completed request with no content",
             }
         else:
+            body = response.json()
+            # Shuffle frequently answers HTTP 200 while signalling a logical
+            # failure in the body via `{"success": false, "reason": "..."}`
+            # (e.g. a workflow that can't be retrieved because the connector
+            # points at the wrong region). Fold that in-body flag into our
+            # wrapper `success` so callers don't mistake a 200 for a real
+            # execution. See GitHub issue #963.
+            http_ok = response.status_code < 400
+            body_ok = not (isinstance(body, dict) and body.get("success") is False)
+            success = http_ok and body_ok
+            if success:
+                message = "Successfully retrieved data"
+            elif isinstance(body, dict) and body.get("reason"):
+                message = f"Shuffle returned success=false: {body['reason']}"
+            else:
+                message = "Failed to retrieve data"
             return {
-                "data": response.json(),
-                "success": False if response.status_code >= 400 else True,
-                "message": "Successfully retrieved data" if response.status_code < 400 else "Failed to retrieve data",
+                "data": body,
+                "success": success,
+                "message": message,
             }
     except Exception as e:
         logger.debug(f"Response: {response}")

--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -648,20 +648,28 @@ async def handle_customer_notifications(
     customer_notifications = await get_customer_notification(customer_code, session)
     if customer_notifications and customer_notifications[0].enabled:
         logger.info(f"Executing workflow for customer code {customer_code}")
-        await execute_workflow(
-            ExecuteWorkflowRequest(
-                workflow_id=customer_notifications[0].shuffle_workflow_id,
-                execution_arguments={
-                    "type": type,
-                    "customer_code": customer_code,
-                    "asset_name": asset_name,
-                    "alert_context_payload": alert_payload.alert_context_payload,
-                    "alert_title": alert_payload.alert_title_payload,
-                    "alert_id": alert_payload.alert_id,
-                },
-                start="",
-            ),
-        )
+        # Best-effort: this runs inside the alert-ingestion path, so a Shuffle
+        # failure (e.g. workflow not retrievable because of a wrong regional
+        # endpoint) must never abort alert creation. `execute_workflow` now
+        # raises on failure (issue #963), so we log and swallow it here — the
+        # analyst-driven case path deliberately lets it propagate instead.
+        try:
+            await execute_workflow(
+                ExecuteWorkflowRequest(
+                    workflow_id=customer_notifications[0].shuffle_workflow_id,
+                    execution_arguments={
+                        "type": type,
+                        "customer_code": customer_code,
+                        "asset_name": asset_name,
+                        "alert_context_payload": alert_payload.alert_context_payload,
+                        "alert_title": alert_payload.alert_title_payload,
+                        "alert_id": alert_payload.alert_id,
+                    },
+                    start="",
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to execute customer notification workflow for customer code {customer_code}: {e}")
 
     # Forward alerts (not cases) to SOCFortress MDR when the customer has the
     # integration deployed. Best-effort: never breaks alert creation.

--- a/backend/app/incidents/services/incident_case.py
+++ b/backend/app/incidents/services/incident_case.py
@@ -1,3 +1,4 @@
+from fastapi import HTTPException
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,19 +14,32 @@ async def handle_customer_notifications_case(
     session: AsyncSession,
     type: str = "case",
 ) -> None:
+    """Invoke the customer's Shuffle notification workflow for a case.
+
+    This is triggered directly by an analyst ("Invoke Customer Notification"),
+    so failures must be surfaced rather than swallowed — `execute_workflow`
+    raises an HTTPException when Shuffle reports the workflow could not be
+    retrieved/executed, and we let it propagate so the UI reflects the real
+    result instead of a phantom success. See GitHub issue #963.
+    """
     customer_notifications = await get_customer_notification(customer_code, session)
     logger.info(f"Sending case_payload {case_payload} to customer code {customer_code}")
-    if customer_notifications and customer_notifications[0].enabled:
-        logger.info(f"Executing workflow for customer code {customer_code}")
-        await execute_workflow(
-            ExecuteWorkflowRequest(
-                workflow_id=customer_notifications[0].shuffle_workflow_id,
-                execution_arguments={
-                    "type": type,
-                    "customer_code": customer_code,
-                    "case_name": case_payload.case_name,
-                    "alerts": case_payload.alerts,
-                },
-                start="",
-            ),
+    if not customer_notifications or not customer_notifications[0].enabled:
+        raise HTTPException(
+            status_code=400,
+            detail=f"No enabled customer notification workflow is configured for customer '{customer_code}'.",
         )
+
+    logger.info(f"Executing workflow for customer code {customer_code}")
+    await execute_workflow(
+        ExecuteWorkflowRequest(
+            workflow_id=customer_notifications[0].shuffle_workflow_id,
+            execution_arguments={
+                "type": type,
+                "customer_code": customer_code,
+                "case_name": case_payload.case_name,
+                "alerts": case_payload.alerts,
+            },
+            start="",
+        ),
+    )

--- a/docs/user/shuffle-integration.md
+++ b/docs/user/shuffle-integration.md
@@ -86,12 +86,26 @@ In Shuffle:
 1. Go to **User Account / Settings**
 2. Copy the **API key**
 
-### Step 2 — Add the Shuffle API key to CoPilot
+### Step 2 — Add the Shuffle connector URL + API key to CoPilot
 In CoPilot:
 
 1. Navigate to **Connectors**
 2. Locate **Shuffle**
-3. Paste the API key and **verify**
+3. Set the **connector URL** to the API endpoint for the region where your Shuffle organization resides (see below)
+4. Paste the API key and **verify**
+
+> ⚠️ **The connector URL must be region-specific for Shuffle Cloud.**
+> Shuffle Cloud runs multiple regional backends, and an API key/org only exists on the backend where it was created. Pointing the connector at the wrong region lets the connection "verify" (the API key is accepted) but **workflow lookups silently fail** — CoPilot can't find your Workflow ID, so notifications never run even though the UI looks fine.
+>
+> Use the endpoint that matches your Shuffle org's region:
+>
+> | Region | Connector URL |
+> |---|---|
+> | US | `https://shuffler.io` |
+> | EU | `https://eu.shuffler.io` |
+> | Self-hosted | `https://<your-shuffle-host>` (your own deployment URL) |
+>
+> If you're unsure which region your org is in, check the URL in your browser while logged into the Shuffle UI, or the Shuffle API documentation for the current list of regional endpoints. Older setup guides/videos that show only `https://shuffler.io` may be out of date if your org lives in another region.
 
 ### Step 3 — Create a Shuffle workflow to receive CoPilot notifications
 Create a workflow in Shuffle (example: `SIEM Alert — <customer>`). The workflow will receive the CoPilot payload as input.
@@ -143,8 +157,12 @@ So when you want to automate enrichment in Shuffle (e.g., look up related events
 3. **Is the Source configured correctly?**
    - Ensure the Source matches the event’s `syslog_type` and correct field mapping.
 4. **Is the Shuffle connector verified in CoPilot?**
-5. **Is the customer’s Shuffle Workflow ID set?**
-6. **Check Shuffle runs** for the workflow.
+5. **Is the connector URL pointed at the correct Shuffle region?**
+   - A verified connection only proves the API key is valid on that backend. If the workflow won't run and you see `Shuffle returned success=false: Can't retrieve data` (or `Failed to retrieve data`), the connector URL is almost certainly pointing at the wrong region — the workflow lives on a different Shuffle backend. Update the connector URL to the region-specific endpoint (see Step 2).
+6. **Is the customer’s Shuffle Workflow ID set?**
+7. **Check Shuffle runs** for the workflow.
+
+> **Where do errors show up now?** When you click **Invoke Customer Notification** on a case, CoPilot surfaces the real result. If Shuffle can't retrieve or execute the workflow, the UI shows the failure (e.g. `Shuffle returned success=false: Can't retrieve data`) instead of a false success. Automatic (alert-driven) notifications remain best-effort — a Shuffle failure is logged in the backend but never blocks alert creation.
 
 ---
 

--- a/docs/user/ui/alerting-shuffle.md
+++ b/docs/user/ui/alerting-shuffle.md
@@ -18,6 +18,8 @@ This is the recommended way to extend CoPilot alerting into external systems wit
 
 > 🎥 [Revolutionize Your SIEM Alerts: Integrate CoPilot & Shuffle](https://youtu.be/Ko5jLfkSCrk?si=YHEv-wHYhY3FuRUe)
 
+> ⚠️ **Note:** the video sets the Shuffle connector URL to `https://shuffler.io`. Shuffle Cloud now runs **region-specific** API backends, and your workflow only exists on the backend for your org's region. If your Shuffle org is not in the US region, set the connector URL to your regional endpoint (e.g. `https://eu.shuffler.io`) — otherwise the connector verifies but workflow lookups fail and notifications silently don't run. See the region table in the [full guide](../../shuffle-integration.md#step-2--add-the-shuffle-connector-url--api-key-to-copilot).
+
 ## Read the full guide
 
 - **CoPilot ↔ Shuffle Integration (Admin/Operator)**: ../../shuffle-integration.md

--- a/frontend/src/components/incidentManagement/cases/CaseNotificationButton.vue
+++ b/frontend/src/components/incidentManagement/cases/CaseNotificationButton.vue
@@ -45,11 +45,11 @@ function invoke() {
 	Api.incidentManagement.cases
 		.createCaseNotification(caseId)
 		.then(res => {
-			if (res.data) {
+			if (res.data?.success) {
 				emit("invoked")
 				message.success(res.data.message || "Case notification created successfully.")
 			} else {
-				message.warning("An error occurred. Please try again later.")
+				message.warning(res.data?.message || "The notification workflow was not executed. Please try again later.")
 			}
 		})
 		.catch(err => {


### PR DESCRIPTION
Closes #963

## Problem
When invoking a customer notification workflow (or on automatic alert-driven notifications), CoPilot reported **success even when Shuffle never executed the workflow**. A common trigger: the Shuffle connector URL points at the wrong regional Cloud backend (`https://shuffler.io` when the org lives in EU), so the connection "verifies" but workflow lookups return `{"success": false, "reason": "Can't retrieve data"}`. The failure was invisible unless you read backend logs.

Failures were swallowed at three layers:
1. `send_post_request` derived `success` from the HTTP status only — a **200 with `{"success": false}`** body was labeled success.
2. The notification `execute_workflow` returned the response verbatim without inspecting `success`.
3. The case route hardcoded `success=True` and the handlers discarded the result.

## Changes

### Backend
- **`shuffle/utils/universal.py`** — `send_post_request` folds Shuffle's in-body `success`/`reason` into the wrapper flag, so a 200-with-`success:false` is caught and the message becomes `Shuffle returned success=false: <reason>`.
- **`shuffle/services/integrations.py`** — `execute_workflow` raises `HTTPException(502)` carrying Shuffle's reason instead of returning an unchecked response.
- **`incidents/services/incident_case.py`** — analyst-driven case path now **propagates** the failure to the UI, and returns a clear 400 when no workflow is configured/enabled.
- **`incidents/services/incident_alert.py`** — automatic (alert-ingestion) path stays **best-effort**: catches the new exception so a Shuffle failure logs but never breaks alert creation.

### Frontend
- **`CaseNotificationButton.vue`** — honors `res.data.success`; surfaces the Shuffle reason instead of a phantom success.

### Docs
- **`shuffle-integration.md`** — Step 2 now documents **region-specific connector URLs** (US `https://shuffler.io`, EU `https://eu.shuffler.io`, self-hosted), warns that a verified connection doesn't imply the correct region, and adds a troubleshooting entry for the `Can't retrieve data` symptom.
- **`ui/alerting-shuffle.md`** — note that the referenced setup video shows only `https://shuffler.io` and may be outdated for non-US orgs.

## Behavior split (by design)
- **Case invocation** (analyst clicks the button) → failures are surfaced to the UI.
- **Alert ingestion** (automatic) → best-effort; a Shuffle failure is logged but never blocks alert creation.

## Testing
- `py_compile` passes on all changed backend modules.
- Frontend change is type-safe against `FlaskBaseResponse` (`success`/`message`).