### PR TITLE
fix(github-audit): resolve circular structure JSON error when adding a customer

### DIFF
--- a/frontend/src/components/githubAudit/GitHubAuditConfigForm.vue
+++ b/frontend/src/components/githubAudit/GitHubAuditConfigForm.vue
@@ -221,7 +221,7 @@ watch(
 	() => props.config,
 	config => {
 		if (config) {
-			Object.assign(formData, {
+			Object.assign(formData.value, {
 				customer_code: config.customer_code,
 				github_token: "",
 				organization: config.organization,
@@ -242,7 +242,7 @@ watch(
 				minimum_passing_score: config.minimum_passing_score
 			})
 		} else {
-			Object.assign(formData, defaultFormData())
+			Object.assign(formData.value, defaultFormData())
 		}
 	},
 	{ immediate: true }
@@ -267,7 +267,7 @@ async function handleSubmit() {
 			message.success("Configuration updated successfully")
 		} else {
 			const createData: GitHubAuditConfigCreate = {
-				...formData,
+				...formData.value,
 				customer_code: formData.value.customer_code ?? "",
 				github_token: formData.value.github_token ?? "",
 				organization: formData.value.organization ?? ""


### PR DESCRIPTION
Fixes #977

## Problem
Adding/configuring a customer under **GitHub Audit Configurations** failed immediately with a red toast (`Converting circular structure to JSON` / `ReactiveEffect → deps → Link → sub`), and no backend call was ever made.

## Root cause
`GitHubAuditConfigForm.vue` spread the Vue **ref object itself** (`...formData`) instead of its value (`...formData.value`). A ref carries reactivity internals (`ReactiveEffect` → `deps` → `Link` → `sub`, a circular chain). `JSON.stringify` on the axios payload hit that cycle and threw before the request left the browser.

## Fix
- `...formData` → `...formData.value` in the create/add-customer path (the reported bug).
- `Object.assign(formData, …)` → `Object.assign(formData.value, …)` in the config-populate and reset paths — a latent bug that wrote props onto the ref wrapper, so the edit form never actually loaded existing config values.

## Testing
- Adding a GitHub Audit customer now serializes a plain config object and hits the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)