### PR TITLE
fix(notification): populate timefield, alert_id, and index pointers in case notification payload (#979)

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -2511,10 +2511,19 @@ async def create_case_notification_endpoint(
                 if alert.assets
                 else None,  # Populate with actual alert context data
                 asset_payload=alert.assets[0].asset_name if alert.assets else "",  # Populate with actual asset data
-                timefield_payload="",  # Populate with actual timefield data
+                # The CoPilot alert-creation time is set from the configured Timefield during
+                # ingest (see update_alert_creation_time), so it's the case-side equivalent of
+                # the automatic alert payload's timefield_payload. Issue #979 Bug 1.
+                timefield_payload=alert.alert_creation_time or "",
                 alert_title_payload=alert.alert_name,  # Populate with actual alert title data
                 ioc_payload={ioc.value: ioc.type for ioc in alert.iocs} if alert.iocs else {},  # Populate with actual IoC data if available
                 source=alert.source,
+                # Carry the CoPilot alert ID and the raw-event index pointer so downstream
+                # notifications can deeplink back to the alert and pivot to the source event
+                # in Graylog/OpenSearch. Issue #979 Bugs 2 & 3.
+                alert_id=alert.id,
+                index_name=alert.assets[0].index_name if alert.assets else None,
+                index_id=alert.assets[0].index_id if alert.assets else None,
             )
             for alert in case_details.alerts
         ],


### PR DESCRIPTION
## Summary

Fixes #979. The case notification payload (`type: "case"`, sent when an analyst clicks **Invoke Notification**) was missing values that the automatic alert payload (`type: "alert"`) already populates. All three bugs traced to one payload builder in `create_case_notification_endpoint` (`backend/app/incidents/routes/db_operations.py`), which hardcoded an empty `timefield_payload` and never passed `alert_id`, `index_name`, or `index_id` — even though the `CreatedAlertPayload` schema supports all four and the source `AlertOut` (plus its eager-loaded `assets`) carries them.

## Fixes

- **Bug 1 — `timefield_payload` always empty**: now set to `alert.alert_creation_time`, which is derived from the configured Timefield during ingest (`update_alert_creation_time`) — the case-side equivalent of the auto-alert payload's `timefield_payload`.
- **Bug 2 — `alert_id` null**: now set to `alert.id`, so downstream tools can build a direct deeplink back to the alert.
- **Bug 3 — `index_name` / `index_id` null**: now sourced from `alert.assets[0]` (guarded for alerts with no assets), enabling pivots to the raw event in Graylog/OpenSearch.

## Notes

- Data is already eager-loaded by `get_case_by_id` (`selectinload(Alert.assets)`), so there is no async lazy-load / `MissingGreenlet` risk.
- The `$exec.start` question from the issue is a separate Shuffle execution concern (not a CoPilot payload field) and is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)