### PR TITLE
feat(notification): enrich Shuffle payloads with root case fields, rule_level, and severity (#980)

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -241,6 +241,8 @@ from app.incidents.services.db_operations import upload_report_template
 from app.incidents.services.db_operations import upload_report_template_to_data_store
 from app.incidents.services.db_operations import validate_source_exists
 from app.incidents.services.incident_case import handle_customer_notifications_case
+from app.incidents.services.notification_enrichment import extract_rule_level
+from app.incidents.services.notification_enrichment import severity_from_rule_level
 from app.middleware.customer_access import customer_access_handler
 
 incidents_db_operations_router = APIRouter()
@@ -2501,15 +2503,17 @@ async def create_case_notification_endpoint(
     if not await customer_access_handler.check_customer_access(current_user, case_details.customer_code, db):
         raise HTTPException(status_code=403, detail=f"Access denied to case {request.case_id} - insufficient customer permissions")
 
-    case_notification_payload = CreatedCaseNotificationPayload(
-        case_name=case_details.case_name,
-        case_description=case_details.case_description,
-        case_creation_time=case_details.case_creation_time,
-        alerts=[
+    case_alert_payloads = []
+    for alert in case_details.alerts:
+        # Fetch the stored alert context once and reuse it for both the payload
+        # body and the derived rule_level/severity (issue #980).
+        alert_context = (await get_alert_context_by_id(alert.assets[0].alert_context_id, db)).context if alert.assets else None
+        # Non-Wazuh sources (e.g. firewall events) carry no rule level, so this
+        # stays None rather than failing.
+        rule_level = extract_rule_level(alert_context)
+        case_alert_payloads.append(
             CreatedAlertPayload(
-                alert_context_payload=(await get_alert_context_by_id(alert.assets[0].alert_context_id, db)).context
-                if alert.assets
-                else None,  # Populate with actual alert context data
+                alert_context_payload=alert_context,  # Populate with actual alert context data
                 asset_payload=alert.assets[0].asset_name if alert.assets else "",  # Populate with actual asset data
                 # The CoPilot alert-creation time is set from the configured Timefield during
                 # ingest (see update_alert_creation_time), so it's the case-side equivalent of
@@ -2524,9 +2528,17 @@ async def create_case_notification_endpoint(
                 alert_id=alert.id,
                 index_name=alert.assets[0].index_name if alert.assets else None,
                 index_id=alert.assets[0].index_id if alert.assets else None,
-            )
-            for alert in case_details.alerts
-        ],
+                # Default rule level + normalized severity (issue #980).
+                rule_level=rule_level,
+                severity=severity_from_rule_level(rule_level),
+            ),
+        )
+
+    case_notification_payload = CreatedCaseNotificationPayload(
+        case_name=case_details.case_name,
+        case_description=case_details.case_description,
+        case_creation_time=case_details.case_creation_time,
+        alerts=case_alert_payloads,
     )
 
     logger.info(f"Creating case notification for case {case_notification_payload}")

--- a/backend/app/incidents/schema/incident_alert.py
+++ b/backend/app/incidents/schema/incident_alert.py
@@ -164,6 +164,10 @@ class CreatedAlertPayload(BaseModel):
     index_name: Optional[str] = None
     index_id: Optional[str] = None
     alert_id: Optional[int] = None
+    # Wazuh rule level (1-15) surfaced by default plus a normalized severity label
+    # so downstream Shuffle consumers don't need custom mapping logic. Issue #980.
+    rule_level: Optional[int] = None
+    severity: Optional[str] = None
 
 
 class CreatedCaseNotificationPayload(BaseModel):

--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -46,6 +46,8 @@ from app.incidents.services.db_operations import get_customer_notification
 from app.incidents.services.db_operations import get_field_names
 from app.incidents.services.db_operations import get_ioc_names
 from app.incidents.services.db_operations import get_timefield_names
+from app.incidents.services.notification_enrichment import extract_rule_level
+from app.incidents.services.notification_enrichment import severity_from_rule_level
 from app.incidents.services.threshold_alert import retrieve_threshold_alert_timeline
 from app.integrations.alert_creation_settings.models.alert_creation_settings import (
     AlertCreationSettings,
@@ -626,6 +628,11 @@ async def build_alert_payload(
     raw_alert_title = alert_payload.get(field_names.alert_title_name)
     cleaned_alert_title = clean_alert_title(raw_alert_title) if raw_alert_title else None
 
+    # Surface the Wazuh rule level + normalized severity by default (issue #980).
+    # Non-Wazuh sources (e.g. firewall events) have no rule level, so this stays
+    # None and callers simply omit/null the field rather than failing.
+    rule_level = extract_rule_level(alert_payload)
+
     return CreatedAlertPayload(
         alert_context_payload=await build_alert_context_payload(alert_payload, field_names),
         asset_payload=asset_name_value,
@@ -635,6 +642,8 @@ async def build_alert_payload(
         source=syslog_type,
         index_name=index_name,
         index_id=index_id,
+        rule_level=rule_level,
+        severity=severity_from_rule_level(rule_level),
     )
 
 
@@ -664,6 +673,10 @@ async def handle_customer_notifications(
                         "alert_context_payload": alert_payload.alert_context_payload,
                         "alert_title": alert_payload.alert_title_payload,
                         "alert_id": alert_payload.alert_id,
+                        # Default rule level + normalized severity (issue #980).
+                        # Null for non-Wazuh sources that carry no rule level.
+                        "rule_level": alert_payload.rule_level,
+                        "severity": alert_payload.severity,
                     },
                     start="",
                 ),

--- a/backend/app/incidents/services/incident_case.py
+++ b/backend/app/incidents/services/incident_case.py
@@ -31,6 +31,13 @@ async def handle_customer_notifications_case(
         )
 
     logger.info(f"Executing workflow for customer code {customer_code}")
+
+    # Shuffle's variable-substitution engine can't index into arrays
+    # ($exec...alerts.0.asset_payload returns the whole array), so also expose
+    # the primary (first) alert's fields at the payload root. Issue #980 Feature 1.
+    primary_alert = case_payload.alerts[0] if case_payload.alerts else None
+    primary_context = primary_alert.alert_context_payload if primary_alert else None
+
     await execute_workflow(
         ExecuteWorkflowRequest(
             workflow_id=customer_notifications[0].shuffle_workflow_id,
@@ -38,6 +45,16 @@ async def handle_customer_notifications_case(
                 "type": type,
                 "customer_code": customer_code,
                 "case_name": case_payload.case_name,
+                "primary_asset": primary_alert.asset_payload if primary_alert else None,
+                "primary_source": primary_alert.source if primary_alert else None,
+                "primary_alert_title": primary_alert.alert_title_payload if primary_alert else None,
+                "primary_timefield": primary_alert.timefield_payload if primary_alert else None,
+                "primary_alert_id": primary_alert.alert_id if primary_alert else None,
+                "primary_mitre_id": (primary_context or {}).get("rule_mitre_id") if primary_context else None,
+                # Default rule level + normalized severity, from the primary alert
+                # (null for non-Wazuh sources with no rule level). Issue #980 Feature 3.
+                "rule_level": primary_alert.rule_level if primary_alert else None,
+                "severity": primary_alert.severity if primary_alert else None,
                 "alerts": case_payload.alerts,
             },
             start="",

--- a/backend/app/incidents/services/notification_enrichment.py
+++ b/backend/app/incidents/services/notification_enrichment.py
@@ -1,0 +1,62 @@
+"""Shared helpers for enriching CoPilot → Shuffle notification payloads.
+
+Both the automatic alert path (`app/incidents/services/incident_alert.py`) and
+the analyst-driven case path (`app/incidents/services/incident_case.py`) send
+payloads to a customer's Shuffle workflow. Downstream consumers (Teams Adaptive
+Cards, ticketing) benefit from a couple of normalized fields that neither path
+guaranteed before — a numeric `rule_level` and a human-readable `severity`
+label. Keeping the derivation here means both paths map identically. See
+GitHub issue #980.
+"""
+from typing import Any
+from typing import Optional
+
+
+def extract_rule_level(context: Optional[dict]) -> Optional[int]:
+    """Pull the Wazuh rule level (1-15) out of an alert context dict.
+
+    Tries the Graylog-flat convention (`rule_level`) first, then the nested
+    Wazuh-vanilla shape (`rule.level`). Returns None when neither is present or
+    the value can't be coerced to an int, so callers can leave the field null
+    rather than guess.
+    """
+    if not context:
+        return None
+
+    candidate: Any = context.get("rule_level")
+    if candidate is None:
+        rule = context.get("rule")
+        if isinstance(rule, dict):
+            candidate = rule.get("level")
+
+    if candidate is None:
+        return None
+
+    try:
+        return int(candidate)
+    except (TypeError, ValueError):
+        return None
+
+
+def severity_from_rule_level(rule_level: Optional[int]) -> Optional[str]:
+    """Map a Wazuh rule level to a normalized severity label.
+
+    | rule_level | severity  |
+    |------------|-----------|
+    | 12-15      | Critical  |
+    | 8-11       | High      |
+    | 4-7        | Medium    |
+    | 1-3        | Low       |
+
+    Returns None when `rule_level` is None so downstream tools can distinguish
+    "no level available" from a real severity band.
+    """
+    if rule_level is None:
+        return None
+    if rule_level >= 12:
+        return "Critical"
+    if rule_level >= 8:
+        return "High"
+    if rule_level >= 4:
+        return "Medium"
+    return "Low"


### PR DESCRIPTION
## Summary

Implements #980. Enriches the CoPilot → Shuffle notification payloads so downstream tools (Teams Adaptive Cards, ticketing) can consume them without custom logic in Shuffle. A new shared helper (`app/incidents/services/notification_enrichment.py`) keeps the derivation identical across the automatic alert path and the analyst-driven case path.

## Features

- **Feature 1 — root-level primary alert fields (case payload):** Shuffle's variable-substitution engine can't index into arrays (`$exec...alerts.0.asset_payload` returns the whole array), so the case payload now also exposes the primary (first) alert's fields at the root: `primary_asset`, `primary_source`, `primary_alert_title`, `primary_timefield`, `primary_alert_id`, `primary_mitre_id`. The full `alerts[]` array is still sent.
- **Feature 2 — `rule_level` by default (alert payload):** `rule_level` (Wazuh 1–15) is now a top-level field in the alert payload, extracted from the raw event during `build_alert_payload` rather than only when explicitly configured as a context field.
- **Feature 3 — normalized `severity` (both payloads):** a `severity` label mapped from `rule_level` (12–15 Critical, 8–11 High, 4–7 Medium, 1–3 Low) is added to alert and case payloads, and to each element of the case `alerts[]` array.

## Notes

- `rule_level` is coerced from string (it's stored as a string) and handles both the Graylog-flat `rule_level` and nested Wazuh `rule.level` shapes.
- Non-Wazuh sources (e.g. firewall events) carry no rule level, so `rule_level`/`severity` stay `null` rather than failing.
- Case-notification builder refactored to fetch each alert's context once and reuse it for the payload body and the derived fields (no double fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)