### PR TITLE
feat(threshold): env-configurable SOURCE→index mapping with convention fallback (#976)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,3 +196,19 @@ MCP_VELOCIRAPTOR_PORT=8001
 MDR_ENABLED=false
 MDR_SERVER_URL=https://mdr-server.socfortress.co
 MDR_COLLECTOR_UUID=
+
+# Graylog Threshold Alert -> OpenSearch index mapping
+# A Graylog threshold/aggregation event does not carry the source index pattern, so
+# CoPilot must be told which index to search per SOURCE value to resolve the underlying
+# events (alert asset/title + timeline). Built-in defaults cover wazuh and office365.
+#
+# THRESHOLD_SOURCE_INDEX_MAPPING: JSON object mapping a custom SOURCE to an index
+#   pattern string, or a [index_pattern, time_field] pair (time field defaults to
+#   "timestamp"). Merges over and overrides the built-in defaults. Example:
+#   THRESHOLD_SOURCE_INDEX_MAPPING={"bitwarden": "bitwarden-*", "dellswitch": ["dellswitch-*", "timestamp"]}
+#
+# THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED: when true (default), an unmapped SOURCE
+#   falls back to "<source>-*" with a "timestamp" time field, so most custom sources
+#   work with no config. Set false to raise on unknown sources instead of guessing.
+THRESHOLD_SOURCE_INDEX_MAPPING=
+THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED=true

--- a/backend/app/incidents/config/threshold_index_mapping.py
+++ b/backend/app/incidents/config/threshold_index_mapping.py
@@ -142,6 +142,6 @@ def get_index_config_for_source(source: str) -> Tuple[str, str]:
     )
     raise ValueError(
         f"No index mapping configured for threshold alert source '{source}'. "
-        f"Add it to the {_ENV_MAPPING_VAR} env var (e.g. '{{\"{key}\": \"{key}-*\"}}') "
+        f'Add it to the {_ENV_MAPPING_VAR} env var (e.g. \'{{"{key}": "{key}-*"}}\') '
         f"or enable {_ENV_FALLBACK_VAR}.",
     )

--- a/backend/app/incidents/config/threshold_index_mapping.py
+++ b/backend/app/incidents/config/threshold_index_mapping.py
@@ -1,45 +1,147 @@
 """
 Mapping of Graylog threshold alert SOURCE field values to OpenSearch index patterns.
 
-When a threshold alert arrives from Graylog, the SOURCE custom field (e.g. "wazuh", "DELLSWITCH")
-is used to determine which OpenSearch index pattern to query for the underlying events.
+Why this mapping has to exist
+-----------------------------
+A Graylog threshold / aggregation Event Definition does **not** include the source
+index pattern in the notification payload it sends to CoPilot. We receive the
+``replay_info`` (Lucene query + timerange) and the group-by fields, but *not* the
+OpenSearch index the underlying messages actually live in. Graylog knows the
+stream/index internally, but it is not exposed on the threshold event.
 
-Add new entries here as new source types are configured in Graylog threshold alert definitions.
+So when CoPilot needs to go back and pull the contributing events (to build the
+alert asset/title and the timeline), it has to be *told* which index pattern a
+given SOURCE maps to. That is the sole reason this table exists — it is not a
+redundant copy of the ingest-side Incident Management Sources (those describe
+per-source field-name mappings, not the physical index a replay query targets).
+
+How a SOURCE is resolved (priority order)
+-----------------------------------------
+1. ``THRESHOLD_SOURCE_INDEX_MAPPING`` (.env) — a JSON object mapping a SOURCE
+   value to either an index-pattern string or a ``[index_pattern, time_field]``
+   pair. Lets operators add custom sources without editing code + rebuilding::
+
+       THRESHOLD_SOURCE_INDEX_MAPPING={"bitwarden": "bitwarden-*", "dellswitch": ["dellswitch-*", "timestamp"]}
+
+   Env entries merge over and override the built-in defaults.
+2. Built-in defaults — ``wazuh`` and ``office365``, shipped for the common case.
+3. Convention fallback — when a SOURCE is not found in either of the above and
+   ``THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED`` is true (the default), CoPilot
+   derives ``<source>-*`` with a ``timestamp`` time field. This makes most custom
+   sources — whose index follows the ``<source>-*`` naming convention — resolve
+   with no configuration at all. Set the flag to false for strict behavior (raise
+   instead of guessing).
 """
 
+import json
+import os
 from typing import Dict
 from typing import Tuple
 
 from loguru import logger
 
-# Maps SOURCE field value (case-insensitive lookup) to (index_pattern, time_field)
-SOURCE_TO_INDEX_CONFIG: Dict[str, Tuple[str, str]] = {
-    "wazuh": ("wazuh-*", "timestamp"),
-    "office365": ("office365-*", "timestamp"),
+# Default OpenSearch time field for threshold replay queries. Overridable per-source
+# via the second element of a THRESHOLD_SOURCE_INDEX_MAPPING entry.
+DEFAULT_TIME_FIELD = "timestamp"
+
+# Built-in SOURCE (lower-cased) -> (index_pattern, time_field) defaults. Operators
+# extend this via THRESHOLD_SOURCE_INDEX_MAPPING rather than editing this dict.
+BUILTIN_SOURCE_TO_INDEX_CONFIG: Dict[str, Tuple[str, str]] = {
+    "wazuh": ("wazuh-*", DEFAULT_TIME_FIELD),
+    "office365": ("office365-*", DEFAULT_TIME_FIELD),
 }
+
+_ENV_MAPPING_VAR = "THRESHOLD_SOURCE_INDEX_MAPPING"
+_ENV_FALLBACK_VAR = "THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED"
+
+
+def _parse_env_mapping() -> Dict[str, Tuple[str, str]]:
+    """
+    Parse THRESHOLD_SOURCE_INDEX_MAPPING (a JSON object) into a lower-cased
+    ``{source: (index_pattern, time_field)}`` dict.
+
+    Each value may be either a string (index pattern; time field defaults to
+    ``timestamp``) or a ``[index_pattern, time_field]`` list/tuple. Malformed input
+    is logged and skipped rather than raising, so one bad entry can't take down the
+    whole threshold flow.
+    """
+    raw = os.getenv(_ENV_MAPPING_VAR, "").strip()
+    if not raw:
+        return {}
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.warning(f"{_ENV_MAPPING_VAR} is not valid JSON, ignoring it: {e}")
+        return {}
+
+    if not isinstance(parsed, dict):
+        logger.warning(f"{_ENV_MAPPING_VAR} must be a JSON object of source -> pattern, ignoring it")
+        return {}
+
+    mapping: Dict[str, Tuple[str, str]] = {}
+    for source, value in parsed.items():
+        if isinstance(value, str) and value.strip():
+            mapping[source.lower()] = (value.strip(), DEFAULT_TIME_FIELD)
+        elif isinstance(value, (list, tuple)) and len(value) >= 1 and value[0]:
+            index_pattern = str(value[0]).strip()
+            time_field = str(value[1]).strip() if len(value) >= 2 and value[1] else DEFAULT_TIME_FIELD
+            mapping[source.lower()] = (index_pattern, time_field)
+        else:
+            logger.warning(
+                f"Ignoring {_ENV_MAPPING_VAR} entry for '{source}': "
+                f"expected an index-pattern string or a [index_pattern, time_field] pair.",
+            )
+    return mapping
+
+
+def _fallback_enabled() -> bool:
+    """Whether an unmapped SOURCE falls back to the ``<source>-*`` convention."""
+    return os.getenv(_ENV_FALLBACK_VAR, "true").strip().lower() in ("true", "1", "yes")
+
+
+def get_configured_sources() -> Dict[str, Tuple[str, str]]:
+    """Return the effective explicit mapping (built-in defaults with env overrides applied)."""
+    return {**BUILTIN_SOURCE_TO_INDEX_CONFIG, **_parse_env_mapping()}
 
 
 def get_index_config_for_source(source: str) -> Tuple[str, str]:
     """
     Look up the OpenSearch index pattern and time field for a given SOURCE value.
 
+    Resolution order: THRESHOLD_SOURCE_INDEX_MAPPING (.env) -> built-in defaults ->
+    ``<source>-*`` convention fallback (when THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED).
+
     Args:
-        source: The SOURCE field value from the Graylog threshold alert (e.g. "wazuh", "DELLSWITCH").
+        source: The SOURCE field value from the Graylog threshold alert (e.g. "wazuh", "bitwarden").
 
     Returns:
         Tuple of (index_pattern, time_field).
 
     Raises:
-        ValueError: If the source is not mapped.
+        ValueError: If the source is not mapped and the convention fallback is disabled.
     """
-    config = SOURCE_TO_INDEX_CONFIG.get(source.lower())
-    if config is None:
-        logger.warning(
-            f"No index mapping configured for threshold alert source '{source}'. "
-            f"Available sources: {list(SOURCE_TO_INDEX_CONFIG.keys())}",
+    key = source.lower()
+
+    config = get_configured_sources().get(key)
+    if config is not None:
+        return config
+
+    if _fallback_enabled():
+        derived = (f"{key}-*", DEFAULT_TIME_FIELD)
+        logger.info(
+            f"No explicit index mapping for threshold alert source '{source}'; "
+            f"using convention fallback index '{derived[0]}' (time field '{derived[1]}'). "
+            f"Set {_ENV_MAPPING_VAR} to override, or {_ENV_FALLBACK_VAR}=false to disable this fallback.",
         )
-        raise ValueError(
-            f"No index mapping configured for threshold alert source '{source}'. "
-            f"Add an entry to SOURCE_TO_INDEX_CONFIG in threshold_index_mapping.py.",
-        )
-    return config
+        return derived
+
+    logger.warning(
+        f"No index mapping configured for threshold alert source '{source}' and the "
+        f"convention fallback is disabled. Configured sources: {list(get_configured_sources().keys())}",
+    )
+    raise ValueError(
+        f"No index mapping configured for threshold alert source '{source}'. "
+        f"Add it to the {_ENV_MAPPING_VAR} env var (e.g. '{{\"{key}\": \"{key}-*\"}}') "
+        f"or enable {_ENV_FALLBACK_VAR}.",
+    )


### PR DESCRIPTION
## Summary

Fixes #976 — custom sources configured in CoPilot (e.g. Bitwarden) can't be resolved by the Graylog **threshold alert** flow, which fails with:

```
No index mapping configured for threshold alert source 'bitwarden'. Available sources: ['wazuh', 'office365']
```

### Root cause

A Graylog threshold/aggregation Event Definition **does not carry the source index pattern** in its notification payload — we get the `replay_info` (Lucene query + timerange) and group-by fields, but not the OpenSearch index the underlying messages live in. So CoPilot must be *told* which index pattern maps to a given `SOURCE` to pull the contributing events (alert asset/title + timeline). That map was hard-coded to `wazuh`/`office365` in `threshold_index_mapping.py`, so any custom source required patching the source and rebuilding.

### The change

`get_index_config_for_source` now resolves in three layers:

1. **`.env` mapping** — `THRESHOLD_SOURCE_INDEX_MAPPING`, a JSON object mapping a `SOURCE` to an index-pattern string or `[index_pattern, time_field]` pair. Merges over / overrides the built-ins. Malformed JSON is logged and skipped, never crashes the flow.
   ```
   THRESHOLD_SOURCE_INDEX_MAPPING={"bitwarden": "bitwarden-*", "dellswitch": ["dellswitch-*", "timestamp"]}
   ```
2. **Built-in defaults** — `wazuh`, `office365` (unchanged behavior).
3. **Convention fallback** — `THRESHOLD_SOURCE_INDEX_FALLBACK_ENABLED` (default `true`): an unmapped source falls back to `<source>-*` / `timestamp`, so most custom sources (incl. the reporter's Bitwarden case) resolve with **no config at all**. Set `false` to raise on unknown sources instead of guessing.

The module docstring now explains *why* the mapping exists (Graylog withholds the index — it is not a redundant copy of the ingest-side Incident Management Sources), and the "no mapping" log/error points at the env var + fallback.

### Files

- `backend/app/incidents/config/threshold_index_mapping.py` — three-layer resolution + docstring.
- `.env.example` — documents both new vars.

The consumer (`threshold_alert.py`) is unchanged — it already catches `ValueError` and degrades to `not_applicable`/`[]`, so disabling the fallback is safe.

### Testing

Verified all resolution paths against the repo venv:
- built-in (`wazuh`, case-insensitive `OFFICE365`)
- convention fallback (`bitwarden` → `bitwarden-*`)
- env override incl. overriding a built-in
- malformed env JSON ignored → built-ins intact
- fallback disabled → raises `ValueError`