### PR TITLE
fix(integrations): repair Office 365 integration metadata lifecycle (#984)

### DIFF
--- a/backend/app/connectors/grafana/services/folders.py
+++ b/backend/app/connectors/grafana/services/folders.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from fastapi import HTTPException
 from loguru import logger
 
@@ -7,15 +9,18 @@ from app.connectors.grafana.utils.universal import create_grafana_client
 
 
 async def delete_folder(
-    organization_id: int,
-    folder_id: int,
+    organization_id: Union[int, str],
+    folder_id: Union[int, str],
 ) -> dict:
     """
     Delete a folder for a given organization.
 
     Args:
-        organization_id (int): The ID of the organization.
-        folder_id (int): The ID of the folder to be deleted.
+        organization_id (int | str): The ID of the organization.
+        folder_id (int | str): The numeric ID *or* the UID of the folder to be deleted.
+            Both are accepted because the provisioning flows are inconsistent: integration
+            metadata stores the numeric folder ID while network connector metadata stores
+            the folder UID.
 
     Returns:
         dict: The response from the Grafana client.
@@ -36,13 +41,20 @@ async def delete_folder(
         folders_response = FoldersResponse(folders=[Folder(**folder) for folder in list_all_folders])
         logger.info(f"Search for folder with ID {folder_id}")
 
-        # Ensure the folder_id is being compared correctly
-        folder_uid = next((folder.uid for folder in folders_response.folders if folder.id == folder_id), None)
+        # Match on either the numeric ID or the UID, comparing as strings so a folder ID
+        # stored as a varchar still matches the int returned by Grafana.
+        folder_ref = str(folder_id)
+        folder_uid = next(
+            (folder.uid for folder in folders_response.folders if str(folder.id) == folder_ref or folder.uid == folder_ref),
+            None,
+        )
 
         if not folder_uid:
             raise HTTPException(status_code=404, detail=f"Folder with ID {folder_id} not found")
 
         return grafana_client.folder.delete_folder(folder_uid)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error deleting folder: {e}")
         raise HTTPException(status_code=500, detail=f"Error deleting dashboard folder: {e}")

--- a/backend/app/integrations/office365/services/provision.py
+++ b/backend/app/integrations/office365/services/provision.py
@@ -954,9 +954,9 @@ async def provision_office365(
         ),
     )
 
-    await update_customer_integration_table(customer_code, session)
-    await update_customermeta_table(customer_code, session, provision_office365_auth_keys.TENANT_ID)
-
+    # The metadata entry is written *before* the integration is flagged as deployed: the UI
+    # hides the Deploy button once `deployed` is true, so a failure here would otherwise leave
+    # the integration undeployable and its infrastructure untracked.
     await create_integration_meta_entry(
         CustomerIntegrationsMetaSchema(
             customer_code=customer_code,
@@ -975,6 +975,9 @@ async def provision_office365(
         ),
         session,
     )
+
+    await update_customer_integration_table(customer_code, session)
+    await update_customermeta_table(customer_code, session, provision_office365_auth_keys.TENANT_ID)
 
     return ProvisionOffice365Response(
         success=True,

--- a/backend/app/integrations/routes.py
+++ b/backend/app/integrations/routes.py
@@ -1395,9 +1395,7 @@ async def update_meta_auto(
         result = await session.execute(stmt)
         existing_record = result.scalars().first()
 
-        update_data = {
-            field: getattr(update_request, field) for field in editable_fields if getattr(update_request, field) is not None
-        }
+        update_data = {field: getattr(update_request, field) for field in editable_fields if getattr(update_request, field) is not None}
 
         if not update_data:
             return UpdateMetaResponse(success=False, message="No fields provided for update")

--- a/backend/app/integrations/routes.py
+++ b/backend/app/integrations/routes.py
@@ -58,6 +58,13 @@ from app.network_connectors.models.network_connectors import (
 
 integration_settings_router = APIRouter()
 
+# Shown whenever a deployed integration has no metadata row — usually the result of a
+# deployment that failed after the infrastructure was provisioned.
+MISSING_META_RECOVERY_HINT = (
+    "This usually means the deployment did not finish. You can record the metadata manually from the "
+    "Meta Details panel, or delete the integration and deploy it again."
+)
+
 NETWORK_INTEGRATIONS = [
     "DefenderForEndpoint",
     "BITDEFENDER",
@@ -576,7 +583,11 @@ def generate_integration_response(customer_code: str, integration_name: str) -> 
     )
 
 
-def generate_decommission_response(customer_code: str, integration_name: str) -> CustomerIntegrationDeleteResponse:
+def generate_decommission_response(
+    customer_code: str,
+    integration_name: str,
+    cleanup_warnings: Optional[List[str]] = None,
+) -> CustomerIntegrationDeleteResponse:
     additional_info_map = {
         "Office365": (
             "Make sure to remove the Office365 integration block from the Wazuh Manager ossec.conf file and restart the Wazuh Manager service. "
@@ -586,6 +597,12 @@ def generate_decommission_response(customer_code: str, integration_name: str) ->
     }
 
     additional_info = additional_info_map.get(integration_name, "")
+
+    # Anything the infrastructure cleanup could not remove is reported alongside the manual
+    # steps so the operator knows exactly what is left over.
+    if cleanup_warnings:
+        additional_info = " ".join([additional_info, *cleanup_warnings]).strip()
+
     if additional_info == "":
         additional_info = None
 
@@ -1007,6 +1024,66 @@ async def delete_customer_network_connectors_meta(session: AsyncSession, custome
     )
 
 
+async def _cleanup_integration_infrastructure(
+    meta_data,
+    customer_code: str,
+    integration_name: str,
+    cleanup_warnings: List[str],
+) -> None:
+    """
+    Remove the Graylog and Grafana resources recorded in an integration's metadata.
+
+    Each resource is removed independently: a resource that is already gone (or a metadata
+    field that was never populated because provisioning failed partway) must not block the
+    removal of the others, otherwise the integration becomes undeletable from the UI. Every
+    failure is logged and appended to `cleanup_warnings` for the caller to surface.
+    """
+
+    async def _attempt(description: str, coroutine_factory):
+        try:
+            await coroutine_factory()
+        except Exception as e:
+            logger.warning(f"Failed to delete {description} for {integration_name} / {customer_code}: {e}")
+            cleanup_warnings.append(f"Could not delete {description}: {e}. Remove it manually if it still exists.")
+
+    # Delete stream and index using metadata
+    stream_id = meta_data.graylog_stream_id
+    logger.info(f"stream_id: {stream_id}")
+    if stream_id:
+        await _attempt(f"Graylog stream {stream_id}", lambda: delete_stream(stream_id=stream_id))
+
+    index_id = meta_data.graylog_index_id
+    logger.info(f"index_id: {index_id}")
+    if index_id:
+        await _attempt(f"Graylog index {index_id}", lambda: delete_index_by_id(index_id=index_id))
+
+    # Delete the folder in Grafana
+    grafana_org_id = meta_data.grafana_org_id
+    grafana_dashboard_folder_id = meta_data.grafana_dashboard_folder_id
+
+    if grafana_org_id and grafana_dashboard_folder_id:
+        await _attempt(
+            f"Grafana dashboard folder {grafana_dashboard_folder_id}",
+            lambda: delete_folder(grafana_org_id, grafana_dashboard_folder_id),
+        )
+    else:
+        logger.info("No Grafana org ID or dashboard folder ID found, skipping folder deletion.")
+
+    # Delete the grafana datasource
+    grafana_datasource_uid = getattr(meta_data, "grafana_datasource_uid", None)
+    if grafana_org_id and grafana_datasource_uid:
+        logger.info(f"Deleting Grafana datasource with UID: {grafana_datasource_uid}")
+        await _attempt(
+            f"Grafana datasource {grafana_datasource_uid}",
+            lambda: delete_grafana_datasource(
+                organization_id=grafana_org_id,
+                datasource_uid=grafana_datasource_uid,
+            ),
+        )
+    else:
+        logger.info("No Grafana datasource UID found, skipping deletion.")
+
+
 @integration_settings_router.delete(
     "/delete_integration",
     response_model=CustomerIntegrationDeleteResponse,
@@ -1054,6 +1131,9 @@ async def delete_integration(
             detail="No subscriptions found for customer integration",
         )
 
+    # Collected non-fatal problems, surfaced to the caller so they know what was left behind
+    cleanup_warnings: List[str] = []
+
     # Only proceed with infrastructure cleanup if the integration is deployed
     if is_deployed:
         logger.info("Integration is deployed, proceeding with full cleanup including infrastructure components")
@@ -1065,38 +1145,31 @@ async def delete_integration(
             meta_data = await fetch_customer_integration_meta(session, customer_code, integration_name)
 
         if not meta_data:
-            raise HTTPException(status_code=404, detail=f"Metadata not found for {integration_name} integration")
-
-        # Delete stream and index using metadata
-        stream_id = meta_data.graylog_stream_id
-        logger.info(f"stream_id: {stream_id}")
-        await delete_stream(stream_id=stream_id)
-
-        index_id = meta_data.graylog_index_id
-        logger.info(f"index_id: {index_id}")
-        await delete_index_by_id(index_id=index_id)
-
-        # Delete the folder in Grafana
-        grafana_org_id = meta_data.grafana_org_id
-        grafana_dashboard_folder_id = meta_data.grafana_dashboard_folder_id
-
-        await delete_folder(grafana_org_id, int(grafana_dashboard_folder_id))
-
-        # Delete the grafana datasource
-        if meta_data.grafana_datasource_uid is not None:
-            logger.info(f"Deleting Grafana datasource with UID: {meta_data.grafana_datasource_uid}")
-            await delete_grafana_datasource(
-                organization_id=grafana_org_id,
-                datasource_uid=meta_data.grafana_datasource_uid,
+            # A deployment that failed partway (or predates metadata tracking) leaves the
+            # integration flagged as deployed with no metadata row. Refusing to delete here
+            # used to make the integration permanently undeletable from the UI, so continue
+            # with the settings cleanup and tell the caller what could not be reached.
+            logger.warning(
+                f"No metadata found for {integration_name} / {customer_code}; "
+                "skipping infrastructure cleanup and removing the integration settings only",
+            )
+            cleanup_warnings.append(
+                f"No metadata record was found for {integration_name}, so the Graylog stream/index and Grafana folder/datasource "
+                "could not be removed automatically. Delete any leftover Graylog and Grafana resources for this customer manually.",
             )
         else:
-            logger.info("No Grafana datasource UID found, skipping deletion.")
+            await _cleanup_integration_infrastructure(
+                meta_data=meta_data,
+                customer_code=customer_code,
+                integration_name=integration_name,
+                cleanup_warnings=cleanup_warnings,
+            )
 
-        # Delete metadata from appropriate table
-        if is_network_integration:
-            await delete_customer_network_connectors_meta(session, customer_code, integration_name)
-        else:
-            await delete_customer_integration_meta(session, customer_code, integration_name)
+            # Delete metadata from appropriate table
+            if is_network_integration:
+                await delete_customer_network_connectors_meta(session, customer_code, integration_name)
+            else:
+                await delete_customer_integration_meta(session, customer_code, integration_name)
 
     else:
         logger.info(
@@ -1113,7 +1186,7 @@ async def delete_integration(
 
     await session.commit()
 
-    return generate_decommission_response(customer_code, integration_name)
+    return generate_decommission_response(customer_code, integration_name, cleanup_warnings)
 
 
 @integration_settings_router.get(
@@ -1222,7 +1295,10 @@ async def get_meta_auto(
             if not meta_record:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Network connector metadata not found for customer {customer_code} and connector {integration_name}",
+                    detail=(
+                        f"Network connector metadata not found for customer {customer_code} and connector {integration_name}. "
+                        f"{MISSING_META_RECOVERY_HINT}"
+                    ),
                 )
 
             logger.info(f"Successfully retrieved network connector metadata for {customer_code}/{integration_name}")
@@ -1239,7 +1315,10 @@ async def get_meta_auto(
             if not meta_record:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Integration metadata not found for customer {customer_code} and integration {integration_name}",
+                    detail=(
+                        f"Integration metadata not found for customer {customer_code} and integration {integration_name}. "
+                        f"{MISSING_META_RECOVERY_HINT}"
+                    ),
                 )
 
             logger.info(f"Successfully retrieved integration metadata for {customer_code}/{integration_name}")
@@ -1273,112 +1352,89 @@ async def update_meta_auto(
     Automatically determine which table to update based on integration name.
 
     This route checks if the integration is in the NETWORK_INTEGRATIONS list and
-    updates the appropriate table accordingly.
+    updates the appropriate table accordingly. When no metadata row exists yet — the state a
+    deployment that failed partway leaves behind — the row is created instead of returning a
+    404, so a broken integration can be repaired from the UI.
     """
     is_network_integration = update_request.integration_name in NETWORK_INTEGRATIONS
 
+    if is_network_integration:
+        meta_model = CustomerNetworkConnectorsMeta
+        name_field = "network_connector_name"
+        editable_fields = [
+            "graylog_input_id",
+            "graylog_index_id",
+            "graylog_stream_id",
+            "graylog_pipeline_id",
+            "graylog_content_pack_input_id",
+            "graylog_content_pack_stream_id",
+            "grafana_org_id",
+            "grafana_dashboard_folder_id",
+            "grafana_datasource_uid",
+        ]
+    else:
+        meta_model = CustomerIntegrationsMeta
+        name_field = "integration_name"
+        editable_fields = [
+            "graylog_input_id",
+            "graylog_index_id",
+            "graylog_stream_id",
+            "grafana_org_id",
+            "grafana_dashboard_folder_id",
+            "grafana_datasource_uid",
+        ]
+
+    table_type = "network connector" if is_network_integration else "integration"
+    name_column = getattr(meta_model, name_field)
+
     try:
-        if is_network_integration:
-            # Check if record exists in network connectors table
-            stmt = select(CustomerNetworkConnectorsMeta).where(
-                CustomerNetworkConnectorsMeta.customer_code == update_request.customer_code,
-                CustomerNetworkConnectorsMeta.network_connector_name == update_request.integration_name,
-            )
-            result = await session.execute(stmt)
-            existing_record = result.scalars().first()
+        stmt = select(meta_model).where(
+            meta_model.customer_code == update_request.customer_code,
+            name_column == update_request.integration_name,
+        )
+        result = await session.execute(stmt)
+        existing_record = result.scalars().first()
 
-            if not existing_record:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Network connector metadata not found for customer {update_request.customer_code} and connector {update_request.integration_name}",
-                )
-
-            # Update network connector metadata
-            update_data = {}
-            if update_request.graylog_input_id is not None:
-                update_data["graylog_input_id"] = update_request.graylog_input_id
-            if update_request.graylog_index_id is not None:
-                update_data["graylog_index_id"] = update_request.graylog_index_id
-            if update_request.graylog_stream_id is not None:
-                update_data["graylog_stream_id"] = update_request.graylog_stream_id
-            if update_request.graylog_pipeline_id is not None:
-                update_data["graylog_pipeline_id"] = update_request.graylog_pipeline_id
-            if update_request.graylog_content_pack_input_id is not None:
-                update_data["graylog_content_pack_input_id"] = update_request.graylog_content_pack_input_id
-            if update_request.graylog_content_pack_stream_id is not None:
-                update_data["graylog_content_pack_stream_id"] = update_request.graylog_content_pack_stream_id
-            if update_request.grafana_org_id is not None:
-                update_data["grafana_org_id"] = update_request.grafana_org_id
-            if update_request.grafana_dashboard_folder_id is not None:
-                update_data["grafana_dashboard_folder_id"] = update_request.grafana_dashboard_folder_id
-            if update_request.grafana_datasource_uid is not None:
-                update_data["grafana_datasource_uid"] = update_request.grafana_datasource_uid
-
-            if update_data:
-                update_stmt = (
-                    update(CustomerNetworkConnectorsMeta)
-                    .where(
-                        CustomerNetworkConnectorsMeta.customer_code == update_request.customer_code,
-                        CustomerNetworkConnectorsMeta.network_connector_name == update_request.integration_name,
-                    )
-                    .values(**update_data)
-                )
-                await session.execute(update_stmt)
-
-        else:
-            # Check if record exists in integrations table
-            stmt = select(CustomerIntegrationsMeta).where(
-                CustomerIntegrationsMeta.customer_code == update_request.customer_code,
-                CustomerIntegrationsMeta.integration_name == update_request.integration_name,
-            )
-            result = await session.execute(stmt)
-            existing_record = result.scalars().first()
-
-            if not existing_record:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Integration metadata not found for customer {update_request.customer_code} and integration {update_request.integration_name}",
-                )
-
-            # Update regular integration metadata
-            update_data = {}
-            if update_request.graylog_input_id is not None:
-                update_data["graylog_input_id"] = update_request.graylog_input_id
-            if update_request.graylog_index_id is not None:
-                update_data["graylog_index_id"] = update_request.graylog_index_id
-            if update_request.graylog_stream_id is not None:
-                update_data["graylog_stream_id"] = update_request.graylog_stream_id
-            if update_request.grafana_org_id is not None:
-                update_data["grafana_org_id"] = update_request.grafana_org_id
-            if update_request.grafana_dashboard_folder_id is not None:
-                update_data["grafana_dashboard_folder_id"] = update_request.grafana_dashboard_folder_id
-            if update_request.grafana_datasource_uid is not None:
-                update_data["grafana_datasource_uid"] = update_request.grafana_datasource_uid
-
-            if update_data:
-                update_stmt = (
-                    update(CustomerIntegrationsMeta)
-                    .where(
-                        CustomerIntegrationsMeta.customer_code == update_request.customer_code,
-                        CustomerIntegrationsMeta.integration_name == update_request.integration_name,
-                    )
-                    .values(**update_data)
-                )
-                await session.execute(update_stmt)
+        update_data = {
+            field: getattr(update_request, field) for field in editable_fields if getattr(update_request, field) is not None
+        }
 
         if not update_data:
             return UpdateMetaResponse(success=False, message="No fields provided for update")
 
+        if existing_record:
+            update_stmt = (
+                update(meta_model)
+                .where(
+                    meta_model.customer_code == update_request.customer_code,
+                    name_column == update_request.integration_name,
+                )
+                .values(**update_data)
+            )
+            await session.execute(update_stmt)
+            action = "Updated"
+        else:
+            # Every ID column is NOT NULL, so anything the caller left out is stored as an
+            # empty string rather than blocking the repair of a partially deployed integration.
+            record_values = {field: "" for field in editable_fields}
+            record_values.update(update_data)
+            record_values["customer_code"] = update_request.customer_code
+            record_values[name_field] = update_request.integration_name
+            session.add(meta_model(**record_values))
+            action = "Created"
+
         await session.commit()
 
-        table_type = "network connector" if is_network_integration else "integration"
         logger.info(
-            f"Updated {table_type} metadata for customer {update_request.customer_code}, {table_type} {update_request.integration_name}",
+            f"{action} {table_type} metadata for customer {update_request.customer_code}, {table_type} {update_request.integration_name}",
         )
 
         return UpdateMetaResponse(
             success=True,
-            message=f"Successfully updated {table_type} metadata for {update_request.customer_code}/{update_request.integration_name}",
+            message=(
+                f"Successfully {action.lower()} {table_type} metadata for "
+                f"{update_request.customer_code}/{update_request.integration_name}"
+            ),
         )
 
     except HTTPException:

--- a/backend/app/integrations/schema.py
+++ b/backend/app/integrations/schema.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
 
 
 class AuthKey(BaseModel):
@@ -243,6 +244,29 @@ class CustomerIntegrationsMetaSchema(BaseModel):
     grafana_dashboard_folder_id: str
     grafana_datasource_uid: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator(
+        "graylog_input_id",
+        "graylog_index_id",
+        "graylog_stream_id",
+        "grafana_org_id",
+        "grafana_dashboard_folder_id",
+        "grafana_datasource_uid",
+        mode="before",
+    )
+    @classmethod
+    def coerce_external_ids_to_str(cls, value):
+        """Grafana and Graylog hand back numeric IDs; these columns are varchars.
+
+        Provisioning flows pass the raw Grafana folder ID (an `int`) straight through.
+        Pydantic v1 coerced that to a string silently, v2 raises `string_type`, which
+        blew up *after* the infrastructure had already been provisioned and left the
+        integration deployed with no metadata row. Normalize here rather than at every
+        provisioning call site.
+        """
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return value
 
 
 class CustomerIntegrationsMetaResponse(BaseModel):

--- a/backend/app/network_connectors/schema.py
+++ b/backend/app/network_connectors/schema.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
 
 
 class AuthKey(BaseModel):
@@ -235,6 +236,25 @@ class CustomerNetworkConnectorsMetaSchema(BaseModel):
     grafana_org_id: str
     grafana_dashboard_folder_id: str
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator(
+        "graylog_input_id",
+        "graylog_index_id",
+        "graylog_stream_id",
+        "grafana_org_id",
+        "grafana_dashboard_folder_id",
+        mode="before",
+    )
+    @classmethod
+    def coerce_external_ids_to_str(cls, value):
+        """Grafana and Graylog hand back numeric IDs; these columns are varchars.
+
+        Mirrors `CustomerIntegrationsMetaSchema.coerce_external_ids_to_str` — Pydantic v2
+        no longer coerces `int` -> `str`, so normalize here instead of at each call site.
+        """
+        if isinstance(value, int) and not isinstance(value, bool):
+            return str(value)
+        return value
 
 
 class CustomerNetworkConnectorsMetaResponse(BaseModel):

--- a/backend/app/version/services/version.py
+++ b/backend/app/version/services/version.py
@@ -7,7 +7,7 @@ from loguru import logger
 from packaging.version import Version
 
 # Current version - update this with each release
-CURRENT_VERSION = "0.1.81"
+CURRENT_VERSION = "0.1.82"
 VERSION_CHECK_URL = "https://api.github.com/repos/socfortress/CoPilot/releases/latest"
 
 

--- a/frontend/src/api/endpoints/integrations.ts
+++ b/frontend/src/api/endpoints/integrations.ts
@@ -77,9 +77,12 @@ export default {
 		return HttpClient.put<FlaskBaseResponse>(`/integrations/update_meta_auto`, payload)
 	},
 	deleteIntegration(customerCode: string, integrationName: string) {
-		return HttpClient.delete<FlaskBaseResponse>(`/integrations/delete_integration`, {
-			data: { customer_code: customerCode, integration_name: integrationName }
-		})
+		return HttpClient.delete<FlaskBaseResponse & { additional_info: string | null }>(
+			`/integrations/delete_integration`,
+			{
+				data: { customer_code: customerCode, integration_name: integrationName }
+			}
+		)
 	},
 	// #endregion
 

--- a/frontend/src/components/customers/integrations/utils.ts
+++ b/frontend/src/components/customers/integrations/utils.ts
@@ -60,6 +60,11 @@ export function deleteIntegration({
 			if (res.data.success) {
 				message.success(res.data?.message || "Customer integration successfully deleted.")
 
+				// Manual follow-up steps and any resource the cleanup could not remove
+				if (res.data?.additional_info) {
+					message.info(res.data.additional_info, { duration: 0, closable: true })
+				}
+
 				if (cbSuccess && typeof cbSuccess === "function") {
 					cbSuccess()
 				}

--- a/frontend/src/components/customers/metadata/CustomerIntegrationMetaDetails.vue
+++ b/frontend/src/components/customers/metadata/CustomerIntegrationMetaDetails.vue
@@ -1,12 +1,18 @@
 <template>
-	<div v-if="!loading && !integrationData" class="flex min-h-80 items-center justify-center">
-		<n-empty description="No metadata found" />
+	<div v-if="!loading && !integrationData" class="flex min-h-80 flex-col items-center justify-center gap-4">
+		<n-empty :description="emptyDescription" />
+		<n-button type="primary" secondary @click="startCreate()">
+			<template #icon>
+				<Icon :name="AddIcon" />
+			</template>
+			Add Metadata
+		</n-button>
 	</div>
 	<div v-else class="flex grow flex-col">
 		<n-collapse-transition :show="mode === 'edit'">
 			<CustomerIntegrationMetaForm v-if="integrationData" :integration-data @success="successHandler()">
 				<template #extraActions>
-					<n-button secondary @click="setViewMode()">
+					<n-button secondary @click="cancelEdit()">
 						<template #icon>
 							<Icon :name="BackIcon" />
 						</template>
@@ -77,11 +83,16 @@ type Mode = "view" | "edit"
 const RefreshIcon = "carbon:renew"
 const EditIcon = "carbon:edit"
 const BackIcon = "carbon:arrow-left"
+const AddIcon = "carbon:add"
 
 const message = useMessage()
 const loading = ref(false)
 const mode = ref<Mode>("view")
 const integrationData = ref<CustomerIntegrationMetaThirdParty | CustomerIntegrationMetaNetwork | null>(null)
+const emptyDescription = ref("No metadata found")
+// True while the form is filling in a metadata record that does not exist yet — the state a
+// deployment that failed partway leaves behind
+const creating = ref(false)
 
 function setMode(newMode: Mode): void {
 	mode.value = newMode
@@ -95,13 +106,35 @@ function setViewMode() {
 	setMode("view")
 }
 
+function startCreate() {
+	// The backend picks the target table from the integration name, so an integration-shaped
+	// placeholder is enough to seed the form for network connectors too
+	integrationData.value = {
+		id: 0,
+		customer_code: customerCode,
+		integration_name: integrationName
+	}
+	creating.value = true
+	setEditMode()
+}
+
+function cancelEdit() {
+	if (creating.value) {
+		creating.value = false
+		integrationData.value = null
+	}
+	setViewMode()
+}
+
 function successHandler() {
+	creating.value = false
 	setViewMode()
 	loadMetaData()
 }
 
 function loadMetaData() {
 	loading.value = true
+	creating.value = false
 
 	Api.integrations
 		.getMetaAuto(customerCode, integrationName)
@@ -114,7 +147,18 @@ function loadMetaData() {
 			}
 		})
 		.catch(err => {
-			message.error(getApiErrorMessage(err as ApiError) || "An error occurred while loading metadata")
+			const apiError = err as ApiError
+			const errorMessage = getApiErrorMessage(apiError) || "An error occurred while loading metadata"
+
+			// A missing record is an expected state rather than a failure: report it inline and
+			// let the user restore the metadata instead of only showing an error toast
+			if (apiError.response?.status === 404) {
+				emptyDescription.value = errorMessage
+			} else {
+				emptyDescription.value = "No metadata found"
+				message.error(errorMessage)
+			}
+
 			integrationData.value = null
 		})
 		.finally(() => {

--- a/frontend/src/components/customers/metadata/utils.ts
+++ b/frontend/src/components/customers/metadata/utils.ts
@@ -13,6 +13,7 @@ export function getMetaFieldLabel(key: string): string {
 		graylog_content_pack_input_id: "Graylog Content Pack Input ID",
 		graylog_content_pack_stream_id: "Graylog Content Pack Stream ID",
 		grafana_org_id: "Grafana Org ID",
+		grafana_dashboard_folder_id: "Grafana Dashboard Folder ID",
 		grafana_datasource_uid: "Grafana Datasource UID"
 	}
 


### PR DESCRIPTION
Closes #984

## Root cause

`create_grafana_folder(...).id` returns an **int**, but `CustomerIntegrationsMetaSchema.grafana_dashboard_folder_id` is typed `str`. Pydantic v1 coerced that silently; v2 raises:

```
1 validation error for CustomerIntegrationsMetaSchema
grafana_dashboard_folder_id
  Input should be a valid string [type=string_type, input_value=8281372173723, input_type=int]
```

In `office365/services/provision.py` that schema was constructed **last** — after Wazuh, Graylog and Grafana had all been provisioned, and after `deployed=True` was already committed. So the metadata row was never written, and because the UI hides the Deploy button once `deployed` is true (`isDeployEnabled` requires `!integration.deployed`), the integration was stuck:

- **Meta Details** → `Integration metadata not found for customer <CODE> and integration <NAME>`
- **Delete** → `Metadata not found for Office 365 integration` (hard 404 before any cleanup ran)
- **Deploy** → the validation error above, with the infrastructure already created

All three reported symptoms are that one chain. The type mismatch was not Office 365 specific — darktrace, cato, huntress, carbonblack, mimecast, sap_siem and duo all pass `.id` the same way.

## Changes

**Deploy**
- `CustomerIntegrationsMetaSchema` / `CustomerNetworkConnectorsMetaSchema`: a `field_validator(mode="before")` coerces numeric external IDs to `str`, so provisioning no longer fails at the last step. Non-scalar values still fail validation.
- Office 365 writes its metadata entry **before** flagging the integration deployed, so a failure there leaves it redeployable rather than stuck.

**Delete**
- A missing metadata row no longer aborts the delete. The integration settings are removed and the caller is told what could not be cleaned up.
- Each Graylog/Grafana resource is now deleted independently (`_cleanup_integration_infrastructure`); one already-deleted stream no longer strands the folder, the datasource and the row itself.
- Anything that failed comes back through `additional_info` alongside the existing manual follow-up steps.
- `delete_folder` accepts a folder **UID** as well as a numeric **ID** — network connector metadata stores the UID while integrations store the ID, so the old `int(grafana_dashboard_folder_id)` cast would have raised `ValueError` on any network connector. It also stops masking its own 404 as a 500.

**Recovery**
- `update_meta_auto` creates the metadata row when it is missing instead of returning 404, so a partially deployed integration can be repaired from the UI. Its two duplicated branches collapsed into one table-driven path.
- 404s from `get_meta_auto` now carry an actionable hint instead of a bare "not found".

**Frontend**
- Meta Details renders the missing-metadata state inline with an **Add Metadata** action instead of only firing an error toast.
- The delete flow surfaces `additional_info` (existing `message.info(..., { duration: 0, closable: true })` pattern).
- Added the missing `grafana_dashboard_folder_id` field label.

## Verification

- `vue-tsc --build` and `eslint` pass on the changed frontend files.
- `pre-commit` (black/isort/flake8) run over the backend changes.
- Not exercised against a live Grafana/Graylog stack — worth a manual deploy → meta details → delete pass on an Office 365 customer.

## Notes for reviewers

- Customers already stuck in this state need one delete + redeploy cycle; delete now succeeds and reports the leftover Graylog/Grafana resources to clean up by hand.
- The sibling integrations still set `deployed=True` before writing metadata. Harmless now that the coercion is in place, but the same ordering trap — left alone to keep this PR scoped.