### PR TITLE
fix(customers): agent status mismatch between Agents list and Agent General view (#956)

### DIFF
--- a/backend/app/customers/schema/customers.py
+++ b/backend/app/customers/schema/customers.py
@@ -150,6 +150,11 @@ class AgentModel(BaseModel):
     velociraptor_id: Optional[str] = None
     wazuh_agent_version: Optional[str] = None
     customer_code: Optional[str] = None
+    # Both fields mirror columns on `Agents` and drive UI badges (ONLINE/OFFLINE, Quarantined).
+    # Omitting them made every agent in the customer Agents tab render as OFFLINE because the
+    # frontend compares an undefined `wazuh_agent_status` against "active" (issue #956).
+    wazuh_agent_status: Optional[str] = None
+    quarantined: Optional[bool] = None
     model_config = ConfigDict(from_attributes=True)
 
 


### PR DESCRIPTION
Fixes #956

## Problem

An agent shown as **Online** in the agent detail view (**General** tab) was shown as **Offline** in `Customers > Select customer > Agents > Agents`.

## Root cause

Both surfaces compute the badge identically — `wazuh_agent_status === "active"`:

- `frontend/src/components/agents/AgentCard.vue:140` (list card)
- `frontend/src/views/agents/Overview.vue:182` (General tab)

…but they are fed by two different endpoints with two different response schemas:

| Surface | Endpoint | Response model |
|---|---|---|
| Agent detail (General) | `GET /agents/{agent_id}` | `app/agents/schema/agents.py:AgentsResponse` → `List[Agents]`, the full SQLModel row |
| Customers → Agents tab | `GET /customers/{customer_code}/agents` | `app/customers/schema/customers.py:AgentModel`, a hand-written subset |

That hand-written `AgentModel` declared 12 fields and **omitted `wazuh_agent_status`** (and `quarantined`). Pydantic drops undeclared fields, so `AgentModel.from_orm(agent)` silently stripped the status column off every row. The frontend then evaluated `undefined === "active"` → `false`, rendering **every** agent in that tab as OFFLINE — the reporter's screenshot happened to include one agent that was genuinely offline, which is why it looked like only one row was wrong.

Two corroborating symptoms of the same cause: the "wazuh agent status" badge on those cards rendered `-`, and the `Quarantined` tag never appeared there. The global **Agents** page was always correct because it uses `/agents`.

## Fix

Declare the two missing columns on the customer-scoped `AgentModel`. No frontend change is needed — the `Agent` TS type already carries both fields.

## Notes / risk

- Purely additive to a response schema; no migration, no behavior change on any other route.
- The two agent-healthcheck routes (`customers.py:831,889`) also build this `AgentModel` and pass it into `ExtendedAgentModel(**agent.model_dump(), ...)`. That stays safe — Pydantic v2 ignores extra constructor kwargs by default.

## Verification

`GET /customers/{code}/agents` now returns `wazuh_agent_status` per agent, so the list badge derives from the same value the detail view uses and the two surfaces agree by construction.
