### PR TITLE
fix(notifications): gate AI report delivery on the customer opt-in switch

### DIFF
--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -91,6 +91,30 @@ class DispatchStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+# Triggers whose payload carries AI-written findings.
+#
+# Dispatches for these are gated on the customer's
+# `customer_portal_ai_report_settings` row before anything is delivered to a
+# customer-facing route — see `_ai_reports_permitted` in the dispatch service.
+# That switch is opt-in (a missing row reads as disabled), so an operator who
+# has not explicitly published AI findings to a customer must not have them
+# emailed/webhooked out either.
+#
+# Keep this in sync when adding AI-sourced triggers (`ai_report_reviewed` is
+# next, see issue #1007). Non-AI triggers — alert creation, assignment — are
+# deliberately NOT listed: the switch governs AI-written content only.
+#
+# The legacy `severity_critical_or_high` value is included because routes saved
+# against an older schema still dispatch through the same AI path; see
+# `_trigger_applies`.
+AI_SOURCED_TRIGGERS: frozenset = frozenset(
+    {
+        "investigation_complete",
+        "severity_critical_or_high",
+    },
+)
+
+
 # Severity ordering for `min_severity` filtering. Index = priority,
 # higher = more severe. Used by the dispatch service to gate routes.
 SEVERITY_ORDER: List[str] = [

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -31,9 +31,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.ai_analyst.services.ai_analyst import list_iocs_by_alert
 from app.ai_analyst.services.ai_analyst import list_reports_by_alert
 from app.connectors.utils import get_connector_info_from_db
+from app.customer_portal.services.ai_reports import is_ai_reports_enabled
 from app.db.universal_models import CustomerNotificationRoute
 from app.db.universal_models import CustomerShuffleIntegration
 from app.db.universal_models import NotificationDispatchLog
+from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS
 from app.notifications.schema.notifications import SEVERITY_ORDER
 from app.notifications.schema.notifications import DispatchOutcome
 from app.notifications.schema.notifications import DispatchRequest
@@ -490,6 +492,30 @@ def _trigger_applies(report_trigger: str, route_trigger: str) -> bool:
     return route_trigger == report_trigger
 
 
+async def _ai_reports_permitted(trigger: str, customer_code: str, session: AsyncSession) -> bool:
+    """Whether AI-written findings may be delivered to this customer.
+
+    `customer_portal_ai_report_settings` is the operator's opt-in switch for
+    publishing AI analyst output to an end customer. It is enforced on the
+    portal's read paths (`app/customer_portal/services/ai_reports.py`), but a
+    notification route is a *second* way the same content reaches the same
+    customer — so the same switch has to gate it, or the notification channel
+    becomes a way around the opt-out. See issue #1001.
+
+    We call the portal service's own predicate rather than re-querying the
+    table, so the two enforcement points cannot drift apart. (This is the
+    auth-scope sidestep pattern from CLAUDE.md: scope checks live on the route
+    handler, so calling the service function directly is both safe and the
+    documented approach.)
+
+    Returns True for non-AI triggers — the switch governs AI-written content,
+    not alert-creation or assignment notifications.
+    """
+    if trigger not in AI_SOURCED_TRIGGERS:
+        return True
+    return await is_ai_reports_enabled(customer_code, session)
+
+
 def _format_default_body(req: DispatchRequest) -> str:
     """Plain default formatter when a route has no `format_template`.
 
@@ -699,6 +725,60 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
 
     outcomes: List[DispatchOutcome] = []
     sent = failed = skipped = 0
+
+    # AI-report opt-out gate. Checked AFTER matching so the dispatch log still
+    # records which routes *would* have fired — "suppressed by the AI switch"
+    # is far easier to debug than silence — but BEFORE the connector fetch and
+    # any provider call, so nothing leaves the process.
+    #
+    # Every route today is customer-facing (`customer_code` is NOT NULL). Once
+    # the scope dimension lands (#1003) this must additionally check
+    # `route.scope == 'customer'` per route, because internal/analyst-facing
+    # routes are deliberately exempt: running investigations while keeping the
+    # results internal is a supported configuration.
+    if matched_routes and not await _ai_reports_permitted(req.trigger.value, req.customer_code, session):
+        logger.info(
+            f"AI reports are not enabled for customer {req.customer_code}; "
+            f"suppressing {len(matched_routes)} matched notification route(s) "
+            f"for alert {req.alert_id}.",
+        )
+        reason = "AI reports are not enabled for this customer; notification suppressed."
+        for route in matched_routes:
+            # Cache before the await — see the attribute-caching note in the
+            # main loop below.
+            route_id = route.id
+            route_name = route.name
+            route_channel = route.channel
+            await _record_log(
+                session,
+                customer_code=req.customer_code,
+                alert_id=req.alert_id,
+                route_id=route_id,
+                trigger=req.trigger.value,
+                status=DispatchStatus.SKIPPED.value,
+                error_message=reason,
+                latency_ms=None,
+                payload_preview=None,
+            )
+            skipped += 1
+            outcomes.append(
+                DispatchOutcome(
+                    route_id=route_id,
+                    route_name=route_name,
+                    channel=route_channel,
+                    status=DispatchStatus.SKIPPED,
+                    error_message=reason,
+                ),
+            )
+        return DispatchResponse(
+            success=True,
+            message="Dispatch suppressed — AI reports are not enabled for this customer",
+            routes_matched=len(matched_routes),
+            dispatched=0,
+            skipped=skipped,
+            failed=0,
+            outcomes=outcomes,
+        )
 
     # Shuffle dispatch needs the deployment's connector creds. We fetch
     # them once per dispatch call (before the per-route loop) so a

--- a/backend/tests/test_notification_ai_report_gating.py
+++ b/backend/tests/test_notification_ai_report_gating.py
@@ -1,0 +1,194 @@
+"""The AI-report opt-out must gate notifications, not just the portal.
+
+``customer_portal_ai_report_settings`` is the operator's opt-in switch for
+publishing AI analyst findings to an end customer. It was enforced only on the
+portal's read paths, so a notification route was a second way the same content
+reached the same customer — bypassing the opt-out entirely. See issue #1001.
+
+``test_customer_portal_ai_reports_access.py`` locks the portal side of this
+invariant; this module locks the notification side. The two enforcement points
+deliberately share one predicate (``is_ai_reports_enabled``) so they cannot
+drift, and the first test below asserts exactly that wiring.
+
+Unit tests with a mocked session — no real DB.
+
+Run with: cd backend && python -m pytest tests/test_notification_ai_report_gating.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import DispatchRequest  # noqa: E402
+from app.notifications.schema.notifications import DispatchStatus  # noqa: E402
+from app.notifications.schema.notifications import NotificationChannel  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+
+CUSTOMER = "TENANT_A"
+
+
+def _route(route_id=1, name="SOC webhook", channel=NotificationChannel.WEBHOOK.value):
+    """A route that matches any Informational-or-above investigation dispatch."""
+    return SimpleNamespace(
+        id=route_id,
+        name=name,
+        channel=channel,
+        enabled=True,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE.value,
+        min_severity=NotificationSeverity.INFORMATIONAL.value,
+        destination="#soc",
+        format_template=None,
+        webhook_url="https://example.invalid/hook",
+        webhook_method="POST",
+        webhook_headers=None,
+        include_full_report=False,
+        shuffle_app_id=None,
+        shuffle_integration_id=None,
+    )
+
+
+def _request(trigger=NotificationTrigger.INVESTIGATION_COMPLETE, severity=NotificationSeverity.CRITICAL):
+    return DispatchRequest(
+        customer_code=CUSTOMER,
+        alert_id=42,
+        trigger=trigger,
+        severity_assessment=severity,
+        summary="Credential dumping observed on WKSTN-04.",
+        report_url="https://copilot.invalid/alerts/42",
+        alert_name="Mimikatz signature",
+    )
+
+
+def _dispatch(routes, *, ai_enabled):
+    """Run dispatch() with the route list and gate state stubbed out.
+
+    Patches the provider call and the log writer so nothing touches a DB or a
+    network, letting the assertions speak only to the gate's decision.
+    """
+    with (
+        patch.object(svc, "list_routes", AsyncMock(return_value=routes)),
+        patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)) as gate,
+        patch.object(svc, "_record_log", AsyncMock(return_value=True)) as record,
+        patch.object(svc, "dispatch_webhook", AsyncMock(return_value=("sent", None, 12, None))) as webhook,
+        patch.object(svc, "dispatch_shuffle", AsyncMock(return_value=("sent", None, 12, "exec-1"))) as shuffle,
+    ):
+        response = asyncio.run(svc.dispatch(_request(), AsyncMock()))
+    return response, gate, record, webhook, shuffle
+
+
+# ── the two enforcement points share one predicate ────────────────────────
+
+
+def test_gate_uses_the_portal_services_own_predicate():
+    """Regression guard against the two checks drifting apart.
+
+    If someone re-implements the lookup inside the notifications module, the
+    portal could say "disabled" while notifications say "enabled". Asserting on
+    identity keeps a single source of truth.
+    """
+    from app.customer_portal.services import ai_reports as portal_svc
+
+    assert svc.is_ai_reports_enabled is portal_svc.is_ai_reports_enabled
+
+
+# ── the gate itself ───────────────────────────────────────────────────────
+
+
+def test_disabled_customer_receives_nothing():
+    response, _gate, _record, webhook, shuffle = _dispatch([_route()], ai_enabled=False)
+
+    assert webhook.await_count == 0, "provider was called despite the AI opt-out"
+    assert shuffle.await_count == 0
+    assert response.dispatched == 0
+    assert response.skipped == 1
+
+
+def test_enabled_customer_still_receives():
+    """The gate must not become a blanket block."""
+    response, _gate, _record, webhook, _shuffle = _dispatch([_route()], ai_enabled=True)
+
+    assert webhook.await_count == 1
+    assert response.dispatched == 1
+    assert response.skipped == 0
+
+
+def test_missing_settings_row_is_treated_as_disabled():
+    """Opt-in semantics: absent row == disabled, not == enabled.
+
+    ``is_ai_reports_enabled`` returns False for a missing row, so this asserts
+    the dispatch path honours that rather than defaulting open.
+    """
+    session = AsyncMock()
+    with patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=False)):
+        permitted = asyncio.run(
+            svc._ai_reports_permitted(NotificationTrigger.INVESTIGATION_COMPLETE.value, CUSTOMER, session),
+        )
+    assert permitted is False
+
+
+def test_suppression_is_recorded_per_route_not_silent():
+    """Every suppressed route gets an audit row with a reason.
+
+    Silence here would be indistinguishable from "no routes configured" when
+    someone is debugging why a customer stopped receiving notifications.
+    """
+    routes = [_route(1, "SOC webhook"), _route(2, "Ops webhook")]
+    response, _gate, record, _webhook, _shuffle = _dispatch(routes, ai_enabled=False)
+
+    assert record.await_count == 2
+    assert response.routes_matched == 2
+    for outcome in response.outcomes:
+        assert outcome.status == DispatchStatus.SKIPPED
+        assert outcome.error_message and "not enabled" in outcome.error_message
+
+    for call in record.await_args_list:
+        assert call.kwargs["status"] == DispatchStatus.SKIPPED.value
+        assert call.kwargs["error_message"]
+
+
+def test_gate_not_consulted_when_no_routes_match():
+    """No matched routes means no reason to query the settings table."""
+    disabled_route = _route()
+    disabled_route.enabled = False
+    _response, gate, _record, _webhook, _shuffle = _dispatch([disabled_route], ai_enabled=False)
+
+    assert gate.await_count == 0
+
+
+# ── scope of the gate ─────────────────────────────────────────────────────
+
+
+def test_only_ai_sourced_triggers_are_gated():
+    """Non-AI triggers must pass regardless of the switch.
+
+    The switch governs AI-written content. Alert-creation and assignment
+    notifications (#1006) carry no AI output and must not be suppressed by it.
+    """
+    session = AsyncMock()
+    with patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=False)) as gate:
+        permitted = asyncio.run(svc._ai_reports_permitted("alert_created", CUSTOMER, session))
+
+    assert permitted is True
+    assert gate.await_count == 0, "non-AI trigger should not even consult the switch"
+
+
+@pytest.mark.parametrize("trigger", sorted(AI_SOURCED_TRIGGERS))
+def test_every_ai_sourced_trigger_is_gated(trigger):
+    """Includes the legacy `severity_critical_or_high` value.
+
+    Routes saved against an older schema still dispatch AI content through the
+    same path (see `_trigger_applies`), so they must be gated too.
+    """
+    session = AsyncMock()
+    with patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=False)):
+        permitted = asyncio.run(svc._ai_reports_permitted(trigger, CUSTOMER, session))
+    assert permitted is False


### PR DESCRIPTION
Closes #1001.

## What was wrong

`customer_portal_ai_report_settings` is the operator's opt-in switch for publishing AI analyst findings to an end customer. It is opt-in by design — a missing row reads as disabled — so AI-written findings are never published to a customer without an explicit operator decision.

That switch was enforced **only** on the Customer Portal's read paths (`app/customer_portal/services/ai_reports.py`). The notifications module contained zero references to it.

A notification route is a second way the same content reaches the same customer. So a customer-facing route could deliver the AI summary — and on webhook routes with `include_full_report`, the full report markdown, recommended actions and IOC list — to a customer whose AI toggle was off.

Not exploitable and not a vulnerability: it needs a specific operator configuration to bite (a customer-facing route configured *and* the AI setting off). It is misconfiguration-enabling behavior.

## What changed

The gate runs in `dispatch()` **after** route matching but **before** the connector fetch and any provider call, so nothing leaves the process.

- `_ai_reports_permitted()` delegates to the portal service's own `is_ai_reports_enabled` rather than re-querying the table, so the two enforcement points cannot drift apart. This is the auth-scope sidestep pattern from CLAUDE.md — scope checks live on the route handler, so calling the service function directly is both safe and the documented approach.
- `AI_SOURCED_TRIGGERS` in the schema module is the single place to extend when new AI triggers arrive. It includes the legacy `severity_critical_or_high` value, because routes saved against an older schema still dispatch AI content through the same path (see `_trigger_applies`).
- Non-AI triggers are unaffected. The switch governs AI-written content, not alert-creation or assignment notifications.

**No schema change.**

## Two decisions worth a look

**Suppression logs a `skipped` row per matched route** rather than returning early with nothing. It costs one write per route, but the dispatch log then shows "these routes would have fired, suppressed by the AI switch." Silence would be indistinguishable from "no routes configured" when someone is debugging why a customer went quiet. Easy to reverse if you disagree.

**The blanket customer check is correct only until scope lands.** Every route today has a non-null `customer_code`, so gating the whole dispatch is right. Once the scope dimension arrives in #1003 this needs a per-route `scope == 'customer'` check, because internal/analyst-facing routes are deliberately exempt — running investigations while keeping results internal is a supported configuration. There is a comment at the gate saying exactly this.

## Testing

`backend/tests/test_notification_ai_report_gating.py` — 9 tests, mocked session, no DB. Sits alongside `test_customer_portal_ai_reports_access.py`, which locks the portal side of the same invariant.

Coverage: disabled customer receives nothing; enabled customer still receives (the gate is not a blanket block); a missing settings row is treated as disabled; suppression is recorded per route with a reason; the settings table is not queried when no routes match; non-AI triggers are not gated and do not even consult the switch; every member of `AI_SOURCED_TRIGGERS` is gated.

One test asserts **function identity** between `svc.is_ai_reports_enabled` and the portal service's — if someone later re-implements the lookup locally, that test fails rather than the two checks silently diverging.

```
9 passed   tests/test_notification_ai_report_gating.py
93 passed  tests/  (full suite, no regressions)
pre-commit  all hooks pass
```

## Note for a follow-up, not in this PR

`pytest` is not declared in `backend/requirements.txt`, despite CLAUDE.md documenting `pytest` as the test command and `backend/tests/` holding 12 files. A fresh environment cannot run the suite without installing it manually. Worth adding to `requirements.txt` or a `requirements-dev.txt`.

## Context

Design context lives in #1000 §L1; this is the standalone extraction, deliberately filed outside that epic because it is an existing gap with no dependency on the notification refactor. It also means the new Resend and Teams channels (#1004, #1005) inherit correct behavior rather than needing a retrofit.
