### PR TITLE
refactor(notifications): channel provider registry + generic event envelope

### DIFF
--- a/backend/app/notifications/channels/__init__.py
+++ b/backend/app/notifications/channels/__init__.py
@@ -1,0 +1,54 @@
+"""Channel provider registry.
+
+The single place that knows which delivery channels exist. Adding a channel is
+one module plus one line here — no migration, no dispatch-loop edit, and (once
+#1018 lands) no route-form work either, because the form renders from each
+provider's declared config schema.
+
+Kept deliberately small: the registry maps ``key -> provider instance``, and
+providers are stateless singletons (per-dispatch state lives on
+``DispatchContext``).
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from app.notifications.channels.base import ChannelProvider
+from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import SendResult
+from app.notifications.channels.shuffle import ShuffleChannel
+from app.notifications.channels.webhook import WebhookChannel
+
+_PROVIDERS: List[ChannelProvider] = [
+    ShuffleChannel(),
+    WebhookChannel(),
+]
+
+CHANNEL_REGISTRY: Dict[str, ChannelProvider] = {p.key: p for p in _PROVIDERS}
+
+
+def get_channel(key: str) -> Optional[ChannelProvider]:
+    """Look up a provider, or None for an unknown channel.
+
+    Returns None rather than raising so the dispatch loop can record an
+    unsupported channel as a per-route failure — a misconfigured row surfaces in
+    the dispatch log instead of aborting the batch.
+    """
+    return CHANNEL_REGISTRY.get(key)
+
+
+def channel_keys() -> List[str]:
+    return list(CHANNEL_REGISTRY.keys())
+
+
+__all__ = [
+    "CHANNEL_REGISTRY",
+    "ChannelProvider",
+    "DispatchContext",
+    "SendResult",
+    "channel_keys",
+    "get_channel",
+]

--- a/backend/app/notifications/channels/base.py
+++ b/backend/app/notifications/channels/base.py
@@ -1,0 +1,125 @@
+"""The channel provider contract.
+
+Before this, delivery was an ``if/elif`` on ``route.channel`` inside
+``dispatch()``, with a dedicated column set per channel on the route table.
+Adding a channel meant a migration plus another branch — and #1000 needs four
+more channels.
+
+A provider owns everything channel-specific: how to read its config, how to
+build the outgoing request, and what a successful send looks like. The dispatch
+loop stays generic.
+
+**In this phase providers still read the existing per-channel columns.** Moving
+that configuration into a JSON ``config`` column is #1018 — deliberately a
+separate change so the abstraction is proven against real dispatch behaviour
+before a migration commits data to it.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from abc import abstractmethod
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import ClassVar
+from typing import Dict
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.notifications.schema.events import NotificationEvent
+
+
+class SendResult(BaseModel):
+    """Outcome of one delivery attempt.
+
+    Generalizes the ``(status, error, latency_ms, shuffle_execution_id)`` tuple
+    the dispatchers returned. ``provider_reference`` is the vendor-agnostic name
+    for that last slot — Shuffle's execution id, and later Resend's message id.
+    The dispatch-log *column* is still ``shuffle_execution_id`` until #1019
+    renames it; the mapping happens in the dispatch loop.
+    """
+
+    status: str  # 'sent' | 'failed' | 'skipped'
+    error_message: Optional[str] = None
+    latency_ms: Optional[int] = None
+    provider_reference: Optional[str] = None
+
+    @classmethod
+    def failed(cls, message: str, latency_ms: Optional[int] = 0) -> "SendResult":
+        return cls(status="failed", error_message=message, latency_ms=latency_ms)
+
+    @classmethod
+    def skipped(cls, message: str, latency_ms: Optional[int] = 0) -> "SendResult":
+        return cls(status="skipped", error_message=message, latency_ms=latency_ms)
+
+
+class DispatchContext:
+    """Per-dispatch-call shared state.
+
+    Providers are stateless singletons held in the registry, so anything cached
+    for the duration of one ``dispatch()`` call must live here rather than on
+    the provider — otherwise concurrent dispatches would share it.
+
+    ``memoize`` preserves the pre-refactor property that expensive lookups
+    (the Shuffle connector row, an alert's AI report) are fetched at most once
+    per dispatch call even when several routes need them. It is lazier than the
+    code it replaces, which pre-fetched Shuffle credentials by scanning matched
+    routes up front; the number of DB reads is the same or lower.
+    """
+
+    def __init__(self, session: AsyncSession, event: NotificationEvent) -> None:
+        self.session = session
+        self.event = event
+        self._memo: Dict[str, Any] = {}
+
+    async def memoize(self, key: str, factory: Callable[[], Awaitable[Any]]) -> Any:
+        if key not in self._memo:
+            self._memo[key] = await factory()
+        return self._memo[key]
+
+
+class ChannelProvider(ABC):
+    """One delivery channel.
+
+    Subclasses are instantiated once at import time and registered by ``key``.
+    They must be stateless — see ``DispatchContext``.
+    """
+
+    #: Value stored in ``customer_notification_route.channel``.
+    key: ClassVar[str]
+
+    #: Human label for the route form's channel picker.
+    display_name: ClassVar[str]
+
+    @abstractmethod
+    async def send(
+        self,
+        *,
+        route: Any,
+        event: NotificationEvent,
+        rendered_body: str,
+        ctx: DispatchContext,
+    ) -> SendResult:
+        """Deliver one notification.
+
+        Must not raise: return ``SendResult.failed(...)`` instead. The dispatch
+        loop does catch exceptions as a backstop, but a provider that raises
+        produces a generic "Dispatcher exception" message in the log rather than
+        something an operator can act on.
+
+        ``route`` is the ORM row. Read what you need from it **before** the
+        first ``await`` — an expired SQLAlchemy object triggers an implicit
+        refresh on attribute access, which throws ``MissingGreenlet`` under
+        ``AsyncSession``.
+        """
+
+    async def after_send(self, *, route: Any, result: SendResult, ctx: DispatchContext) -> None:
+        """Optional side effect after a successful send, inside the same commit.
+
+        Used by Shuffle to stamp ``last_used_at`` on the integration row. Called
+        only when ``result.status == "sent"``.
+        """
+        return None

--- a/backend/app/notifications/channels/shuffle.py
+++ b/backend/app/notifications/channels/shuffle.py
@@ -1,0 +1,146 @@
+"""Shuffle hosted-MCP delivery.
+
+Ported verbatim from the ``if/elif`` branch in ``dispatch()``. Every status,
+error string and latency value below is reproduced exactly — the pre-refactor
+behaviour is the spec, and the dispatch log is a customer-visible surface.
+
+Fire-and-record: we POST to ``/api/v1/apps/{app_id}/mcp`` with the deployment's
+admin Bearer plus the customer's Org-Id, capture the execution id, and treat
+HTTP 200 as sent. We do not poll for the downstream app's terminal state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from typing import Optional
+from typing import Tuple
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy import update
+
+from app.connectors.utils import get_connector_info_from_db
+from app.db.universal_models import CustomerShuffleIntegration
+from app.notifications.channels.base import ChannelProvider
+from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import SendResult
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.services.dispatchers import dispatch_shuffle
+
+_CREDS_MEMO_KEY = "shuffle_creds"
+
+SHUFFLE_CONNECTOR_NAME = "Shuffle"
+
+
+async def get_shuffle_connector(session) -> Tuple[str, str]:
+    """Fetch (base_url, api_key) for the Shuffle connector. Raises
+    HTTPException if the connector row is missing or unconfigured —
+    surfaces a clear 4xx in the dispatch endpoint instead of a generic
+    500 when an admin forgets to configure Shuffle.
+
+    Lives here rather than in the service module so the provider owns its own
+    credential lookup; the service's app/org/verify helpers import it from here.
+    """
+    info = await get_connector_info_from_db(SHUFFLE_CONNECTOR_NAME, session)
+    if not info:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Shuffle connector is not configured in CoPilot. "
+                "Add the Shuffle connector with a valid API key before "
+                "creating Shuffle-channel notification routes."
+            ),
+        )
+    api_key = info.get("connector_api_key") or ""
+    base_url = info.get("connector_url") or "https://shuffler.io"
+    if not api_key:
+        raise HTTPException(
+            status_code=503,
+            detail="Shuffle connector is configured but has no API key set.",
+        )
+    return (base_url, api_key)
+
+
+class ShuffleChannel(ChannelProvider):
+    key = "shuffle"
+    display_name = "Shuffle"
+
+    async def send(
+        self,
+        *,
+        route: Any,
+        event: NotificationEvent,
+        rendered_body: str,
+        ctx: DispatchContext,
+    ) -> SendResult:
+        # Read every attribute before the first await — an expired ORM object
+        # would otherwise trigger a synchronous refresh and MissingGreenlet.
+        app_id = route.shuffle_app_id
+        integration_id = route.shuffle_integration_id
+        destination = route.destination
+
+        # Memoized per dispatch call: several Shuffle routes for one customer
+        # share a single connector read, matching the pre-refactor behaviour.
+        creds: Optional[Tuple[str, str]] = None
+        try:
+            creds = await ctx.memoize(_CREDS_MEMO_KEY, lambda: get_shuffle_connector(ctx.session))
+        except HTTPException as e:
+            # Caught here rather than in the dispatch loop so the operator sees
+            # the connector's own detail string instead of a generic
+            # "Dispatcher exception".
+            logger.warning(f"Shuffle connector unavailable: {e.detail}")
+            return SendResult.failed(str(e.detail) or "Shuffle connector unavailable")
+
+        if creds is None:
+            return SendResult.failed("Shuffle connector unavailable")
+        if not app_id:
+            return SendResult.failed("Route has no shuffle_app_id (data integrity issue)")
+
+        integration = await ctx.session.get(CustomerShuffleIntegration, integration_id)
+        if not integration or integration.customer_code != event.customer_code:
+            # Defense in depth: tenant isolation is enforced at create/update
+            # time, but a hand-edited row could still slip through. Refusing at
+            # dispatch time prevents cross-tenant leaks.
+            return SendResult.failed(
+                "Route's shuffle_integration is missing or belongs to a different customer; refusing to dispatch.",
+            )
+        if not integration.enabled:
+            return SendResult.skipped("Shuffle integration is disabled")
+
+        base_url, api_key = creds
+        org_id = integration.shuffle_org_id
+
+        # Shuffle's input_text is natural language. We prepend a
+        # "send to {destination}" hint so the app agent knows where to deliver.
+        input_text = f"Send to {destination}: {rendered_body}" if destination else rendered_body
+
+        status, error_message, latency_ms, execution_id = await dispatch_shuffle(
+            base_url=base_url,
+            api_key=api_key,
+            org_id=org_id,
+            app_id=app_id,
+            input_text=input_text,
+        )
+        return SendResult(
+            status=status,
+            error_message=error_message,
+            latency_ms=latency_ms,
+            provider_reference=execution_id,
+        )
+
+    async def after_send(self, *, route: Any, result: SendResult, ctx: DispatchContext) -> None:
+        """Stamp the integration's ``last_used_at``.
+
+        Gives the integration list a "fired 2h ago" signal without joining the
+        dispatch log on every render.
+        """
+        integration_id = route.shuffle_integration_id
+        if not integration_id:
+            return
+
+        await ctx.session.execute(
+            update(CustomerShuffleIntegration)
+            .where(CustomerShuffleIntegration.id == integration_id)
+            .values(last_used_at=datetime.utcnow()),
+        )

--- a/backend/app/notifications/channels/webhook.py
+++ b/backend/app/notifications/channels/webhook.py
@@ -1,0 +1,154 @@
+"""Direct HTTP webhook delivery.
+
+Ported verbatim from the ``if/elif`` branch in ``dispatch()``. The structured
+JSON payload below is an **external contract** — customers' automation platforms
+consume these exact field names — so the shape, the key order and the
+``None``-vs-empty-string distinctions are reproduced exactly.
+
+Fire-and-record: POST/PUT to the route's URL, treat any 2xx/3xx as sent.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from loguru import logger
+
+from app.notifications.channels.base import ChannelProvider
+from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import SendResult
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.services.dispatchers import dispatch_webhook
+
+
+def decode_webhook_headers(raw: Optional[str]) -> Optional[Dict[str, str]]:
+    """Deserialize the route's JSON-string ``webhook_headers`` column.
+
+    Returns a flat str→str dict, or None when unset/blank/malformed. Failing
+    closed (None) rather than raising keeps a bad row from aborting the whole
+    dispatch — the request just goes out with the dispatcher's default headers.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        logger.warning(f"Malformed webhook_headers JSON, ignoring: {raw[:120]!r}")
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
+async def build_full_report(alert_id: int, session) -> Optional[Dict[str, Any]]:
+    """Fetch the alert's latest AI report's *extra* fields as a flat dict.
+
+    Returns only the fields NOT already present at the top level of the webhook
+    payload — it deliberately omits ``summary`` and the severity to avoid
+    duplicating them. Returns None when no report exists yet, so a webhook never
+    fails just because the report write-back hasn't landed.
+
+    Reuses the ai_analyst service layer (the canonical read path) so the shape
+    stays in sync with the AI Analyst API. ``list_reports_by_alert`` returns
+    newest-first, so element 0 is the report this dispatch is about.
+    """
+    from app.ai_analyst.services.ai_analyst import list_iocs_by_alert
+    from app.ai_analyst.services.ai_analyst import list_reports_by_alert
+
+    reports = await list_reports_by_alert(alert_id, session)
+    if not reports:
+        return None
+    report = reports[0]
+    iocs = await list_iocs_by_alert(alert_id, session)
+    return {
+        "report_id": report.id,
+        "recommended_actions": report.recommended_actions,
+        "report_markdown": report.report_markdown,
+        "report_created_at": report.created_at.isoformat() if report.created_at else None,
+        "iocs": [
+            {
+                "ioc_value": i.ioc_value,
+                "ioc_type": i.ioc_type,
+                "vt_verdict": i.vt_verdict,
+                "vt_score": i.vt_score,
+                "details": i.details,
+            }
+            for i in iocs
+        ],
+    }
+
+
+class WebhookChannel(ChannelProvider):
+    key = "webhook"
+    display_name = "Webhook"
+
+    async def send(
+        self,
+        *,
+        route: Any,
+        event: NotificationEvent,
+        rendered_body: str,
+        ctx: DispatchContext,
+    ) -> SendResult:
+        # Read every attribute before the first await — an expired ORM object
+        # would otherwise trigger a synchronous refresh and MissingGreenlet.
+        url = route.webhook_url
+        method = route.webhook_method
+        raw_headers = route.webhook_headers
+        include_full_report = bool(route.include_full_report)
+        has_template = bool(route.format_template)
+
+        if not url:
+            return SendResult.failed("Route has no webhook_url (data integrity issue)")
+
+        # Structured default payload — automation platforms consume these fields
+        # directly, so the names and null-vs-empty semantics are load-bearing.
+        structured_payload: Dict[str, Any] = {
+            "customer_code": event.customer_code,
+            "alert_id": event.entity_id,
+            "alert_name": event.context.get("alert_name"),
+            "severity": event.severity.value,
+            "summary": event.summary,
+            "report_url": event.link_url,
+            "text": rendered_body,
+        }
+
+        # Two mutually-exclusive body modes (enforced in the UI, guarded here):
+        #   1. include_full_report → merge the report's extra fields flat into
+        #      the structured payload. Template ignored.
+        #   2. custom template → that rendered string is the body. If it
+        #      contains the {{report}} token, inject the same report fields as
+        #      a JSON object at that spot.
+        rendered_template: Optional[str] = None
+        if include_full_report:
+            report_fields = await self._report(event, ctx)
+            if report_fields is not None:
+                structured_payload.update(report_fields)
+        elif has_template:
+            rendered_template = rendered_body
+            if "{{report}}" in rendered_template:
+                report_fields = await self._report(event, ctx)
+                rendered_template = rendered_template.replace(
+                    "{{report}}",
+                    json.dumps(report_fields) if report_fields is not None else "null",
+                )
+
+        status, error_message, latency_ms, _ = await dispatch_webhook(
+            url=url,
+            method=method or "POST",
+            headers=decode_webhook_headers(raw_headers),
+            structured_payload=structured_payload,
+            rendered_template=rendered_template,
+        )
+        return SendResult(status=status, error_message=error_message, latency_ms=latency_ms)
+
+    async def _report(self, event: NotificationEvent, ctx: DispatchContext) -> Optional[Dict[str, Any]]:
+        """Memoized per dispatch call — several webhook routes on one alert
+        share a single report read."""
+        return await ctx.memoize(
+            f"full_report:{event.entity_id}",
+            lambda: build_full_report(event.entity_id, ctx.session),
+        )

--- a/backend/app/notifications/schema/events.py
+++ b/backend/app/notifications/schema/events.py
@@ -1,0 +1,107 @@
+"""The trigger-agnostic event envelope every dispatch flows through.
+
+``DispatchRequest`` (the body Talon POSTs to ``/notifications/dispatch``) is
+shaped entirely around a completed AI investigation — it *requires* a severity
+assessment and a summary, and offers a report URL. An "alert assigned to Bob"
+event has none of those, so new triggers (#1006) cannot reuse it.
+
+``NotificationEvent`` is the shape the dispatch loop and every channel provider
+actually consume. ``DispatchRequest`` is adapted into one at the route boundary,
+which keeps Talon's contract byte-for-byte unchanged while freeing the internals
+to grow new event types.
+
+This module is deliberately schema-only: no DB columns correspond to it. The
+persisted side of the same generalization (``entity_type`` / ``entity_id`` /
+``dedupe_key`` on the dispatch log) is #1019.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import Field
+
+from app.notifications.schema.notifications import DispatchRequest
+from app.notifications.schema.notifications import NotificationSeverity
+from app.notifications.schema.notifications import NotificationTrigger
+
+
+class EntityType:
+    """What kind of object an event is about.
+
+    Plain string constants rather than an enum: the dispatch log column added in
+    #1019 is a varchar, and new entity types should be a data-only change.
+    """
+
+    ALERT = "alert"
+    CASE = "case"
+    CASE_TASK = "case_task"
+
+
+class NotificationEvent(BaseModel):
+    """One thing that happened, in a form any channel can render.
+
+    Field notes:
+
+    ``customer_code`` is Optional because internal-scope routes (#1018) belong
+    to no tenant. Today every event carries one.
+
+    ``entity_id`` is the alert id for AI triggers, so it maps onto the existing
+    ``notification_dispatch_log.alert_id`` column without a schema change.
+
+    ``dedupe_key`` is carried on the envelope rather than derived at write time
+    so each trigger owns its own idempotency semantics — notably, manual sends
+    (#1010) need a per-invocation unique key to stay repeatable. Unused until
+    #1019 puts it on the log; present here so the shape is settled first.
+
+    ``context`` holds trigger-specific extras that would otherwise bloat the
+    envelope — ``alert_name`` for investigations, task titles for assignments.
+    Template rendering and the webhook payload read from it.
+    """
+
+    customer_code: Optional[str] = None
+    trigger: NotificationTrigger
+    severity: NotificationSeverity
+    subject: str = Field(description="One-line title. Email subject, card title, chat message heading.")
+    summary: str = Field(description="Human-readable body.")
+    entity_type: str = EntityType.ALERT
+    entity_id: int
+    dedupe_key: str
+    link_url: Optional[str] = Field(default=None, description="Deep link back into CoPilot.")
+    assignee_username: Optional[str] = None
+    actor_username: Optional[str] = None
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def alert_id(self) -> int:
+        """Back-compat accessor while the log column is still ``alert_id``.
+
+        Removed in #1019 when the column becomes ``entity_id``.
+        """
+        return self.entity_id
+
+
+def event_from_dispatch_request(req: DispatchRequest) -> NotificationEvent:
+    """Adapt Talon's request body into the internal envelope.
+
+    Every field the pre-refactor dispatch loop read off ``DispatchRequest`` has
+    to survive this mapping unchanged, because the rendered body and the webhook
+    JSON payload are both external contracts. In particular ``alert_name`` and
+    ``report_url`` keep their ``None``-vs-empty-string distinction: the webhook
+    payload sends ``None``, while template substitution renders ``""``.
+    """
+    return NotificationEvent(
+        customer_code=req.customer_code,
+        trigger=req.trigger,
+        severity=req.severity_assessment,
+        subject=req.alert_name or f"Alert #{req.alert_id}",
+        summary=req.summary,
+        entity_type=EntityType.ALERT,
+        entity_id=req.alert_id,
+        dedupe_key=f"{EntityType.ALERT}:{req.alert_id}:{req.trigger.value}",
+        link_url=req.report_url,
+        context={"alert_name": req.alert_name},
+    )

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any
-from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -28,13 +26,15 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.ai_analyst.services.ai_analyst import list_iocs_by_alert
-from app.ai_analyst.services.ai_analyst import list_reports_by_alert
-from app.connectors.utils import get_connector_info_from_db
 from app.customer_portal.services.ai_reports import is_ai_reports_enabled
 from app.db.universal_models import CustomerNotificationRoute
 from app.db.universal_models import CustomerShuffleIntegration
 from app.db.universal_models import NotificationDispatchLog
+from app.notifications.channels import DispatchContext
+from app.notifications.channels import SendResult
+from app.notifications.channels import get_channel
+from app.notifications.channels.shuffle import get_shuffle_connector
+from app.notifications.schema.events import event_from_dispatch_request
 from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS
 from app.notifications.schema.notifications import SEVERITY_ORDER
 from app.notifications.schema.notifications import DispatchOutcome
@@ -49,8 +49,6 @@ from app.notifications.schema.notifications import ShuffleApp
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
 from app.notifications.schema.notifications import ShuffleOrg
-from app.notifications.services.dispatchers import dispatch_shuffle
-from app.notifications.services.dispatchers import dispatch_webhook
 from app.notifications.services.dispatchers import (
     list_shuffle_apps as shuffle_apps_client,
 )
@@ -60,38 +58,6 @@ from app.notifications.services.dispatchers import (
 from app.notifications.services.dispatchers import (
     verify_shuffle_org as verify_shuffle_org_client,
 )
-
-# Name of the Shuffle row in CoPilot's connectors table. The
-# `connector_url` (Shuffle base URL) and `connector_api_key` (admin
-# Bearer token) are read fresh on every dispatch so a key rotation
-# takes effect without restarting the backend.
-_SHUFFLE_CONNECTOR_NAME = "Shuffle"
-
-
-async def _get_shuffle_connector(session: AsyncSession) -> tuple[str, str]:
-    """Fetch (base_url, api_key) for the Shuffle connector. Raises
-    HTTPException if the connector row is missing or unconfigured —
-    surfaces a clear 4xx in the dispatch endpoint instead of a generic
-    500 when an admin forgets to configure Shuffle."""
-    info = await get_connector_info_from_db(_SHUFFLE_CONNECTOR_NAME, session)
-    if not info:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Shuffle connector is not configured in CoPilot. "
-                "Add the Shuffle connector with a valid API key before "
-                "creating Shuffle-channel notification routes."
-            ),
-        )
-    api_key = info.get("connector_api_key") or ""
-    base_url = info.get("connector_url") or "https://shuffler.io"
-    if not api_key:
-        raise HTTPException(
-            status_code=503,
-            detail="Shuffle connector is configured but has no API key set.",
-        )
-    return (base_url, api_key)
-
 
 # ---------------------------------------------------------------------------
 # CRUD
@@ -337,7 +303,7 @@ async def list_apps_for_integration(
     cache — fresh data on every form open is fine for v1.
     """
     integration = await _ensure_integration_belongs_to_customer(integration_id, customer_code, session)
-    base_url, api_key = await _get_shuffle_connector(session)
+    base_url, api_key = await get_shuffle_connector(session)
     ok, apps_raw, error = await shuffle_apps_client(
         base_url=base_url,
         api_key=api_key,
@@ -369,7 +335,7 @@ async def list_apps_for_integration(
 
 async def verify_integration(integration_id: int, customer_code: str, session: AsyncSession) -> dict:
     integration = await _ensure_integration_belongs_to_customer(integration_id, customer_code, session)
-    base_url, api_key = await _get_shuffle_connector(session)
+    base_url, api_key = await get_shuffle_connector(session)
     ok, app_count, error = await verify_shuffle_org_client(
         base_url=base_url,
         api_key=api_key,
@@ -393,7 +359,7 @@ async def list_orgs(session: AsyncSession) -> List[ShuffleOrg]:
     each org is then attached to a specific customer via the
     integration row at create time.
     """
-    base_url, api_key = await _get_shuffle_connector(session)
+    base_url, api_key = await get_shuffle_connector(session)
     ok, orgs_raw, error = await shuffle_orgs_client(base_url=base_url, api_key=api_key)
     if not ok:
         raise HTTPException(
@@ -536,66 +502,6 @@ def _format_default_body(req: DispatchRequest) -> str:
     return "\n".join(parts)
 
 
-def _decode_webhook_headers(raw: Optional[str]) -> Optional[Dict[str, str]]:
-    """Deserialize the route's JSON-string `webhook_headers` column.
-
-    Returns a flat str→str dict, or None when unset/blank/malformed.
-    Failing closed (None) rather than raising keeps a bad row from
-    aborting the whole dispatch — the request just goes out with the
-    dispatcher's default headers.
-    """
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except ValueError:
-        logger.warning(f"Malformed webhook_headers JSON, ignoring: {raw[:120]!r}")
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    return {str(k): str(v) for k, v in parsed.items()}
-
-
-async def _build_full_report(alert_id: int, session: AsyncSession) -> Optional[Dict[str, Any]]:
-    """Fetch the alert's latest AI report's *extra* fields as a flat dict.
-
-    Returns only the fields NOT already present at the top level of the
-    webhook payload — i.e. it deliberately omits `summary` and the
-    severity (those are already sent as `summary`/`severity`) to avoid
-    duplicating them. The dispatcher merges this flat into the payload.
-
-    Reuses the ai_analyst service layer (the canonical read path) so the
-    shape stays in sync with the AI Analyst API. Returns None when no
-    report exists yet — the dispatcher then sends the base payload
-    unchanged, so a webhook never fails just because the report
-    write-back hasn't landed.
-
-    `list_reports_by_alert` returns newest-first, so element 0 is the
-    report this dispatch is about. IOCs are scoped to the same alert.
-    """
-    reports = await list_reports_by_alert(alert_id, session)
-    if not reports:
-        return None
-    report = reports[0]
-    iocs = await list_iocs_by_alert(alert_id, session)
-    return {
-        "report_id": report.id,
-        "recommended_actions": report.recommended_actions,
-        "report_markdown": report.report_markdown,
-        "report_created_at": report.created_at.isoformat() if report.created_at else None,
-        "iocs": [
-            {
-                "ioc_value": i.ioc_value,
-                "ioc_type": i.ioc_type,
-                "vt_verdict": i.vt_verdict,
-                "vt_score": i.vt_score,
-                "details": i.details,
-            }
-            for i in iocs
-        ],
-    }
-
-
 def _render_body(route: CustomerNotificationRoute, req: DispatchRequest) -> str:
     """Apply the route's `format_template` if set, else fall back.
 
@@ -714,7 +620,13 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
     *before* calling the provider, so a re-dispatch sees the existing
     row and short-circuits without sending. (The cost is one wasted
     INSERT in the race case, which is fine.)
+
+    ``req`` is Talon's wire format and stays untouched (it is an external
+    contract); it is adapted into a ``NotificationEvent`` here, and everything
+    downstream — providers included — sees only the envelope. New triggers
+    (#1006) construct the envelope directly and never build a DispatchRequest.
     """
+    event = event_from_dispatch_request(req)
     routes = await list_routes(req.customer_code, session)
 
     matched_routes = [
@@ -780,42 +692,22 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
             outcomes=outcomes,
         )
 
-    # Shuffle dispatch needs the deployment's connector creds. We fetch
-    # them once per dispatch call (before the per-route loop) so a
-    # whole batch shares one DB read. Only fetch if at least one
-    # matched route uses Shuffle — early-out keeps zero-route customers
-    # from touching the connectors table.
-    shuffle_creds: Optional[tuple[str, str]] = None
-    shuffle_creds_error: Optional[str] = None
-    if any(r.channel == NotificationChannel.SHUFFLE.value for r in matched_routes):
-        try:
-            shuffle_creds = await _get_shuffle_connector(session)
-        except HTTPException as e:
-            # Connector misconfigured — the dispatch endpoint surfaces
-            # the helper's 503 to ad-hoc callers, but for a batch we'd
-            # rather mark each route as failed in the log than abort
-            # the whole loop.
-            logger.warning(f"Shuffle connector unavailable: {e.detail}")
-            shuffle_creds_error = str(e.detail)
+    # Per-call context. Expensive lookups a provider needs (the Shuffle
+    # connector row, an alert's AI report) are memoized on it, so a batch of
+    # routes shares one read — the property the pre-refactor prefetch gave us,
+    # now lazy: nothing is read unless a route actually reaches that provider.
+    ctx = DispatchContext(session=session, event=event)
 
     for route in matched_routes:
-        # Cache every route attribute we'll need into locals UP FRONT.
+        # Cache every route attribute the LOOP needs into locals UP FRONT.
         # Once we cross any `await` (let alone any rollback) the route
         # SQLAlchemy state can be expired and a synchronous attribute
         # access then triggers an implicit refresh query — which in
-        # AsyncSession throws MissingGreenlet. Caching here means the
-        # rest of the loop is plain-Python access on locals.
+        # AsyncSession throws MissingGreenlet. Providers do the same for
+        # the attributes they read; see ChannelProvider.send's docstring.
         route_id = route.id
         route_name = route.name
         route_channel = route.channel
-        route_destination = route.destination
-        route_shuffle_app_id = route.shuffle_app_id
-        route_shuffle_integration_id = route.shuffle_integration_id
-        route_has_template = bool(route.format_template)
-        route_webhook_url = route.webhook_url
-        route_webhook_method = route.webhook_method
-        route_webhook_headers = route.webhook_headers
-        route_include_full_report = bool(route.include_full_report)
 
         body = _render_body(route, req)
         body_preview = body[:500]
@@ -824,126 +716,33 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         result_status = "sent"
         error_message: Optional[str] = None
         shuffle_execution_id: Optional[str] = None
+        # Stays None when the channel is unknown or send() raised. after_send
+        # guards on it rather than inferring from result_status — the two can
+        # only diverge via a future edit, and this way that edit is safe.
+        result: Optional[SendResult] = None
+
+        provider = get_channel(route_channel)
 
         try:
-            if route_channel == NotificationChannel.SHUFFLE.value:
-                # Shuffle hosted MCP. Fire-and-record — we POST to
-                # /api/v1/apps/{app_id}/mcp with the deployment's admin
-                # Bearer + the customer's Org-Id, capture the
-                # execution_id, and consider the dispatch "sent" on
-                # HTTP 200. We do NOT poll for the downstream app's
-                # terminal state.
-                if shuffle_creds is None:
-                    result_status = "failed"
-                    error_message = shuffle_creds_error or "Shuffle connector unavailable"
-                    latency_ms = 0
-                elif not route_shuffle_app_id:
-                    result_status = "failed"
-                    error_message = "Route has no shuffle_app_id (data integrity issue)"
-                    latency_ms = 0
-                else:
-                    integration = await session.get(CustomerShuffleIntegration, route_shuffle_integration_id)
-                    if not integration or integration.customer_code != req.customer_code:
-                        # Defense-in-depth: we already enforce tenant
-                        # isolation at create/update time, but a hand-
-                        # edited row could still slip through. Refusing
-                        # at dispatch time prevents cross-tenant leaks.
-                        result_status = "failed"
-                        error_message = (
-                            "Route's shuffle_integration is missing or belongs to a " "different customer; refusing to dispatch."
-                        )
-                        latency_ms = 0
-                    elif not integration.enabled:
-                        result_status = "skipped"
-                        error_message = "Shuffle integration is disabled"
-                        latency_ms = 0
-                    else:
-                        base_url, api_key = shuffle_creds
-                        # Cache integration attrs too — same reason as
-                        # the route caching above.
-                        integration_org_id = integration.shuffle_org_id
-                        # Shuffle's input_text is natural language. We
-                        # prepend a "send to {destination}" hint so the
-                        # Shuffle app agent knows where to deliver, and
-                        # follow with the formatted body.
-                        if route_destination:
-                            input_text = f"Send to {route_destination}: {body}"
-                        else:
-                            input_text = body
-                        (
-                            result_status,
-                            error_message,
-                            latency_ms,
-                            shuffle_execution_id,
-                        ) = await dispatch_shuffle(
-                            base_url=base_url,
-                            api_key=api_key,
-                            org_id=integration_org_id,
-                            app_id=route_shuffle_app_id,
-                            input_text=input_text,
-                        )
-            elif route_channel == NotificationChannel.WEBHOOK.value:
-                # Direct HTTP webhook. Fire-and-record — POST/PUT to the
-                # route's URL with either a structured JSON payload
-                # (default) or the rendered template (when the route sets
-                # one), and treat any 2xx/3xx as `sent`.
-                if not route_webhook_url:
-                    result_status = "failed"
-                    error_message = "Route has no webhook_url (data integrity issue)"
-                    latency_ms = 0
-                else:
-                    # Structured default payload — automation platforms
-                    # consume these fields directly.
-                    structured_payload: Dict[str, Any] = {
-                        "customer_code": req.customer_code,
-                        "alert_id": req.alert_id,
-                        "alert_name": req.alert_name,
-                        "severity": req.severity_assessment.value,
-                        "summary": req.summary,
-                        "report_url": req.report_url,
-                        "text": body,
-                    }
-                    # Two mutually-exclusive body modes (enforced in the UI,
-                    # guarded here):
-                    #   1. include_full_report → merge the report's extra
-                    #      fields (recommended actions, full markdown, IOCs)
-                    #      flat into the structured payload. Template ignored.
-                    #   2. custom template → that rendered string is the body.
-                    #      If it contains the `{{report}}` token, inject the
-                    #      same report fields as a JSON object at that spot.
-                    rendered_template: Optional[str] = None
-                    if route_include_full_report:
-                        report_fields = await _build_full_report(req.alert_id, session)
-                        if report_fields is not None:
-                            structured_payload.update(report_fields)
-                    elif route_has_template:
-                        rendered_template = body
-                        if "{{report}}" in rendered_template:
-                            report_fields = await _build_full_report(req.alert_id, session)
-                            rendered_template = rendered_template.replace(
-                                "{{report}}",
-                                json.dumps(report_fields) if report_fields is not None else "null",
-                            )
-                    headers = _decode_webhook_headers(route_webhook_headers)
-                    (
-                        result_status,
-                        error_message,
-                        latency_ms,
-                        _,
-                    ) = await dispatch_webhook(
-                        url=route_webhook_url,
-                        method=route_webhook_method or "POST",
-                        headers=headers,
-                        structured_payload=structured_payload,
-                        rendered_template=rendered_template,
-                    )
-            else:
-                # Unknown channel — preserved as a failure rather than
-                # silently dropped so a misconfigured row surfaces in
-                # the dispatch log.
+            if provider is None:
+                # Unknown channel — recorded as a failure rather than silently
+                # dropped, so a misconfigured row surfaces in the dispatch log.
                 result_status = "failed"
                 error_message = f"Unsupported channel: {route_channel}"
                 latency_ms = None
+            else:
+                result = await provider.send(
+                    route=route,
+                    event=event,
+                    rendered_body=body,
+                    ctx=ctx,
+                )
+                result_status = result.status
+                error_message = result.error_message
+                latency_ms = result.latency_ms
+                # The log column is still named shuffle_execution_id; #1019
+                # renames it to provider_reference.
+                shuffle_execution_id = result.provider_reference
         except Exception as e:  # noqa: BLE001 — best-effort, never raise
             logger.exception(f"Dispatcher raised for route {route_id}: {e!r}")
             result_status = "failed"
@@ -995,15 +794,11 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
                     last_dispatched_at=datetime.utcnow(),
                 ),
             )
-            # Bump the integration's last_used_at on a successful
-            # Shuffle dispatch — gives the integration list a "fired
-            # 2h ago" signal without a join against the log.
-            if route_channel == NotificationChannel.SHUFFLE.value and route_shuffle_integration_id:
-                await session.execute(
-                    update(CustomerShuffleIntegration)
-                    .where(CustomerShuffleIntegration.id == route_shuffle_integration_id)
-                    .values(last_used_at=datetime.utcnow()),
-                )
+            # Channel-specific post-send side effects, inside the same commit.
+            # Shuffle stamps last_used_at on the integration row so its list can
+            # show "fired 2h ago" without joining the dispatch log.
+            if provider is not None and result is not None:
+                await provider.after_send(route=route, result=result, ctx=ctx)
             await session.commit()
         elif result_status == "skipped":
             skipped += 1

--- a/backend/tests/test_notification_ai_report_gating.py
+++ b/backend/tests/test_notification_ai_report_gating.py
@@ -26,6 +26,8 @@ import pytest
 os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
 
 import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels.base import SendResult  # noqa: E402
 from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS  # noqa: E402
 from app.notifications.schema.notifications import DispatchRequest  # noqa: E402
 from app.notifications.schema.notifications import DispatchStatus  # noqa: E402
@@ -71,15 +73,27 @@ def _request(trigger=NotificationTrigger.INVESTIGATION_COMPLETE, severity=Notifi
 def _dispatch(routes, *, ai_enabled):
     """Run dispatch() with the route list and gate state stubbed out.
 
-    Patches the provider call and the log writer so nothing touches a DB or a
-    network, letting the assertions speak only to the gate's decision.
+    Patches at the channel-provider seam rather than at the underlying HTTP
+    dispatchers: `provider.send` is what the loop actually calls, so asserting
+    on it answers "did anything reach a channel" directly and survives changes
+    to how a given provider talks to its vendor.
     """
     with (
         patch.object(svc, "list_routes", AsyncMock(return_value=routes)),
         patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)) as gate,
         patch.object(svc, "_record_log", AsyncMock(return_value=True)) as record,
-        patch.object(svc, "dispatch_webhook", AsyncMock(return_value=("sent", None, 12, None))) as webhook,
-        patch.object(svc, "dispatch_shuffle", AsyncMock(return_value=("sent", None, 12, "exec-1"))) as shuffle,
+        patch.object(
+            type(CHANNEL_REGISTRY["webhook"]),
+            "send",
+            AsyncMock(return_value=SendResult(status="sent", latency_ms=12)),
+        ) as webhook,
+        patch.object(
+            type(CHANNEL_REGISTRY["shuffle"]),
+            "send",
+            AsyncMock(return_value=SendResult(status="sent", latency_ms=12, provider_reference="exec-1")),
+        ) as shuffle,
+        patch.object(type(CHANNEL_REGISTRY["webhook"]), "after_send", AsyncMock()),
+        patch.object(type(CHANNEL_REGISTRY["shuffle"]), "after_send", AsyncMock()),
     ):
         response = asyncio.run(svc.dispatch(_request(), AsyncMock()))
     return response, gate, record, webhook, shuffle

--- a/backend/tests/test_notification_channel_registry.py
+++ b/backend/tests/test_notification_channel_registry.py
@@ -1,0 +1,414 @@
+"""Channel provider registry, and byte-level equivalence with the old dispatcher.
+
+The `if/elif` on `route.channel` inside `dispatch()` became a provider registry.
+That refactor is only safe if what actually goes out over the wire is unchanged:
+the webhook payload's field names are an external contract (customers' automation
+platforms read them), and every status/error string lands in the dispatch log,
+which operators read.
+
+So the assertions below are deliberately literal — exact payload dicts, exact
+error strings — rather than "something webhook-shaped was sent". They are the
+regression bar for #1017.
+
+Unit tests with mocked sessions and stubbed HTTP — no DB, no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_channel_registry.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+
+import app.notifications.channels.shuffle as shuffle_mod  # noqa: E402
+import app.notifications.channels.webhook as webhook_mod  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels import channel_keys  # noqa: E402
+from app.notifications.channels import get_channel  # noqa: E402
+from app.notifications.channels.base import ChannelProvider  # noqa: E402
+from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.schema.events import event_from_dispatch_request  # noqa: E402
+from app.notifications.schema.notifications import DispatchRequest  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+
+CUSTOMER = "TENANT_A"
+
+
+def _request(alert_name="Mimikatz signature", report_url="https://copilot.invalid/alerts/42"):
+    return DispatchRequest(
+        customer_code=CUSTOMER,
+        alert_id=42,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity_assessment=NotificationSeverity.CRITICAL,
+        summary="Credential dumping observed on WKSTN-04.",
+        report_url=report_url,
+        alert_name=alert_name,
+    )
+
+
+def _ctx(event, session=None):
+    return DispatchContext(session=session or AsyncMock(), event=event)
+
+
+def _webhook_route(**over):
+    base = dict(
+        id=1,
+        name="SOC webhook",
+        channel="webhook",
+        destination="",
+        format_template=None,
+        webhook_url="https://example.invalid/hook",
+        webhook_method="POST",
+        webhook_headers=None,
+        include_full_report=False,
+        shuffle_app_id=None,
+        shuffle_integration_id=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _shuffle_route(**over):
+    base = dict(
+        id=2,
+        name="SOC slack",
+        channel="shuffle",
+        destination="#soc-alerts",
+        format_template=None,
+        shuffle_app_id="app-uuid",
+        shuffle_integration_id=7,
+        webhook_url=None,
+        webhook_method=None,
+        webhook_headers=None,
+        include_full_report=False,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+# ── registry ──────────────────────────────────────────────────────────────
+
+
+def test_registry_contains_the_shipped_channels():
+    assert sorted(channel_keys()) == ["shuffle", "webhook"]
+
+
+@pytest.mark.parametrize("key", ["shuffle", "webhook"])
+def test_every_provider_declares_the_required_classvars(key):
+    provider = CHANNEL_REGISTRY[key]
+    assert isinstance(provider, ChannelProvider)
+    assert provider.key == key
+    assert provider.display_name
+
+
+def test_registry_key_matches_provider_key():
+    """A mismatch would make a route dispatch through the wrong provider."""
+    for key, provider in CHANNEL_REGISTRY.items():
+        assert key == provider.key
+
+
+def test_unknown_channel_returns_none_rather_than_raising():
+    """The dispatch loop records an unsupported channel as a per-route failure;
+    raising here would abort the whole batch instead."""
+    assert get_channel("carrier-pigeon") is None
+
+
+# ── webhook: the payload is an external contract ──────────────────────────
+
+
+def _run_webhook(route, req=None, report=None):
+    """Invoke the webhook provider with the HTTP dispatcher stubbed, returning
+    the kwargs it was called with."""
+    event = event_from_dispatch_request(req or _request())
+    sent = AsyncMock(return_value=("sent", None, 12, None))
+    with (
+        patch.object(webhook_mod, "dispatch_webhook", sent),
+        patch.object(webhook_mod, "build_full_report", AsyncMock(return_value=report)),
+    ):
+        result = asyncio.run(
+            CHANNEL_REGISTRY["webhook"].send(
+                route=route,
+                event=event,
+                rendered_body="RENDERED BODY",
+                ctx=_ctx(event),
+            ),
+        )
+    return result, (sent.await_args.kwargs if sent.await_args else None)
+
+
+def test_webhook_structured_payload_is_unchanged():
+    """Exact field set and values — customers' automation reads these names."""
+    _result, kwargs = _run_webhook(_webhook_route())
+
+    assert kwargs["structured_payload"] == {
+        "customer_code": CUSTOMER,
+        "alert_id": 42,
+        "alert_name": "Mimikatz signature",
+        "severity": "Critical",
+        "summary": "Credential dumping observed on WKSTN-04.",
+        "report_url": "https://copilot.invalid/alerts/42",
+        "text": "RENDERED BODY",
+    }
+
+
+def test_webhook_preserves_none_for_absent_optional_fields():
+    """`alert_name` and `report_url` must stay None in the payload, not "".
+
+    Template substitution renders them as empty strings; the JSON payload keeps
+    them null. Collapsing the two would change what downstream automation sees.
+    """
+    _result, kwargs = _run_webhook(_webhook_route(), req=_request(alert_name=None, report_url=None))
+
+    assert kwargs["structured_payload"]["alert_name"] is None
+    assert kwargs["structured_payload"]["report_url"] is None
+
+
+def test_webhook_defaults_method_to_post():
+    _result, kwargs = _run_webhook(_webhook_route(webhook_method=None))
+    assert kwargs["method"] == "POST"
+
+
+def test_webhook_missing_url_fails_with_the_original_message():
+    result, kwargs = _run_webhook(_webhook_route(webhook_url=None))
+    assert result.status == "failed"
+    assert result.error_message == "Route has no webhook_url (data integrity issue)"
+    assert kwargs is None, "must not attempt delivery"
+
+
+def test_webhook_include_full_report_merges_flat_and_ignores_template():
+    report = {"report_id": 9, "recommended_actions": "isolate", "iocs": []}
+    _result, kwargs = _run_webhook(
+        _webhook_route(include_full_report=True, format_template="ignored {{summary}}"),
+        report=report,
+    )
+
+    assert kwargs["structured_payload"]["report_id"] == 9
+    assert kwargs["structured_payload"]["recommended_actions"] == "isolate"
+    assert kwargs["rendered_template"] is None, "include_full_report takes precedence over a template"
+
+
+def test_webhook_missing_report_still_sends_base_payload():
+    """A dispatch must not fail just because report write-back hasn't landed."""
+    _result, kwargs = _run_webhook(_webhook_route(include_full_report=True), report=None)
+
+    assert "report_id" not in kwargs["structured_payload"]
+    assert kwargs["structured_payload"]["summary"] == "Credential dumping observed on WKSTN-04."
+
+
+def test_webhook_template_body_passes_through_untouched_without_the_token():
+    """The provider only rewrites the {{report}} token; everything else in the
+    already-rendered body is left alone."""
+    _result, kwargs = _run_webhook(
+        _webhook_route(format_template="see something"),
+        report={"report_id": 9, "iocs": []},
+    )
+    assert kwargs["rendered_template"] == "RENDERED BODY"
+
+
+def test_webhook_template_report_token_substitutes_when_present_in_body():
+    report = {"report_id": 9, "iocs": []}
+    event = event_from_dispatch_request(_request())
+    sent = AsyncMock(return_value=("sent", None, 12, None))
+    with (
+        patch.object(webhook_mod, "dispatch_webhook", sent),
+        patch.object(webhook_mod, "build_full_report", AsyncMock(return_value=report)),
+    ):
+        asyncio.run(
+            CHANNEL_REGISTRY["webhook"].send(
+                route=_webhook_route(format_template="x"),
+                event=event,
+                rendered_body="prefix {{report}} suffix",
+                ctx=_ctx(event),
+            ),
+        )
+    assert sent.await_args.kwargs["rendered_template"] == f"prefix {json.dumps(report)} suffix"
+
+
+def test_webhook_headers_are_decoded_from_the_json_column():
+    _result, kwargs = _run_webhook(_webhook_route(webhook_headers='{"Authorization": "Bearer x"}'))
+    assert kwargs["headers"] == {"Authorization": "Bearer x"}
+
+
+def test_webhook_malformed_headers_do_not_abort_the_dispatch():
+    _result, kwargs = _run_webhook(_webhook_route(webhook_headers="{not json"))
+    assert kwargs["headers"] is None
+
+
+# ── shuffle: statuses and tenancy ─────────────────────────────────────────
+
+
+def _run_shuffle(route, integration, creds=("https://shuffler.io", "key")):
+    event = event_from_dispatch_request(_request())
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=integration)
+    sent = AsyncMock(return_value=("sent", None, 12, "exec-1"))
+
+    creds_mock = AsyncMock(return_value=creds) if not isinstance(creds, Exception) else AsyncMock(side_effect=creds)
+    with (
+        patch.object(shuffle_mod, "dispatch_shuffle", sent),
+        patch.object(shuffle_mod, "get_shuffle_connector", creds_mock),
+    ):
+        result = asyncio.run(
+            CHANNEL_REGISTRY["shuffle"].send(
+                route=route,
+                event=event,
+                rendered_body="RENDERED BODY",
+                ctx=_ctx(event, session),
+            ),
+        )
+    return result, (sent.await_args.kwargs if sent.await_args else None)
+
+
+def _integration(customer_code=CUSTOMER, enabled=True, org_id="org-1"):
+    return SimpleNamespace(id=7, customer_code=customer_code, enabled=enabled, shuffle_org_id=org_id)
+
+
+def test_shuffle_prepends_the_destination_hint():
+    """Shuffle's input_text is natural language; the hint tells its app agent
+    where to deliver."""
+    _result, kwargs = _run_shuffle(_shuffle_route(), _integration())
+    assert kwargs["input_text"] == "Send to #soc-alerts: RENDERED BODY"
+
+
+def test_shuffle_without_destination_sends_the_bare_body():
+    _result, kwargs = _run_shuffle(_shuffle_route(destination=""), _integration())
+    assert kwargs["input_text"] == "RENDERED BODY"
+
+
+def test_shuffle_returns_the_execution_id_as_provider_reference():
+    result, _kwargs = _run_shuffle(_shuffle_route(), _integration())
+    assert result.status == "sent"
+    assert result.provider_reference == "exec-1"
+
+
+def test_shuffle_cross_tenant_integration_is_refused():
+    """Defense in depth against a hand-edited row — this is a tenant leak."""
+    result, kwargs = _run_shuffle(_shuffle_route(), _integration(customer_code="OTHER_TENANT"))
+
+    assert result.status == "failed"
+    assert "belongs to a different customer" in result.error_message
+    assert kwargs is None, "must not attempt delivery"
+
+
+def test_shuffle_missing_integration_is_refused():
+    result, kwargs = _run_shuffle(_shuffle_route(), None)
+    assert result.status == "failed"
+    assert kwargs is None
+
+
+def test_shuffle_disabled_integration_is_skipped_not_failed():
+    """Disabled is an operator choice, not an error — the distinction shows up
+    in the dispatch log."""
+    result, kwargs = _run_shuffle(_shuffle_route(), _integration(enabled=False))
+
+    assert result.status == "skipped"
+    assert result.error_message == "Shuffle integration is disabled"
+    assert kwargs is None
+
+
+def test_shuffle_missing_app_id_fails_with_the_original_message():
+    result, _kwargs = _run_shuffle(_shuffle_route(shuffle_app_id=None), _integration())
+    assert result.status == "failed"
+    assert result.error_message == "Route has no shuffle_app_id (data integrity issue)"
+
+
+def test_shuffle_connector_error_surfaces_the_connector_detail():
+    """The operator needs the connector's own message, not a generic
+    "Dispatcher exception" from the loop's catch-all."""
+    exc = HTTPException(status_code=503, detail="Shuffle connector is configured but has no API key set.")
+    result, kwargs = _run_shuffle(_shuffle_route(), _integration(), creds=exc)
+
+    assert result.status == "failed"
+    assert result.error_message == "Shuffle connector is configured but has no API key set."
+    assert kwargs is None
+
+
+# ── per-dispatch memoization ──────────────────────────────────────────────
+
+
+def test_connector_is_read_once_across_routes_in_one_dispatch():
+    """The pre-refactor loop prefetched Shuffle credentials once per dispatch
+    call. DispatchContext.memoize replaces that prefetch — this pins that a
+    batch of Shuffle routes still causes exactly one connector read.
+    """
+    event = event_from_dispatch_request(_request())
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=_integration())
+    creds = AsyncMock(return_value=("https://shuffler.io", "key"))
+    ctx = _ctx(event, session)
+
+    with (
+        patch.object(shuffle_mod, "dispatch_shuffle", AsyncMock(return_value=("sent", None, 12, "e"))),
+        patch.object(shuffle_mod, "get_shuffle_connector", creds),
+    ):
+        for _ in range(3):
+            asyncio.run(
+                CHANNEL_REGISTRY["shuffle"].send(
+                    route=_shuffle_route(),
+                    event=event,
+                    rendered_body="B",
+                    ctx=ctx,
+                ),
+            )
+
+    assert creds.await_count == 1
+
+
+def test_report_is_read_once_across_routes_in_one_dispatch():
+    """Several webhook routes on one alert share a single AI-report read."""
+    event = event_from_dispatch_request(_request())
+    ctx = _ctx(event)
+    build = AsyncMock(return_value={"report_id": 9, "iocs": []})
+
+    with (
+        patch.object(webhook_mod, "dispatch_webhook", AsyncMock(return_value=("sent", None, 12, None))),
+        patch.object(webhook_mod, "build_full_report", build),
+    ):
+        for _ in range(3):
+            asyncio.run(
+                CHANNEL_REGISTRY["webhook"].send(
+                    route=_webhook_route(include_full_report=True),
+                    event=event,
+                    rendered_body="B",
+                    ctx=ctx,
+                ),
+            )
+
+    assert build.await_count == 1
+
+
+# ── the envelope ──────────────────────────────────────────────────────────
+
+
+def test_envelope_maps_every_dispatch_request_field():
+    event = event_from_dispatch_request(_request())
+
+    assert event.customer_code == CUSTOMER
+    assert event.entity_type == "alert"
+    assert event.entity_id == 42
+    assert event.alert_id == 42
+    assert event.severity == NotificationSeverity.CRITICAL
+    assert event.summary == "Credential dumping observed on WKSTN-04."
+    assert event.link_url == "https://copilot.invalid/alerts/42"
+    assert event.context["alert_name"] == "Mimikatz signature"
+
+
+def test_envelope_dedupe_key_reproduces_the_existing_idempotency_tuple():
+    """#1019 moves idempotency onto this key; it must mean the same thing as
+    the current (alert_id, trigger) pair for existing rows."""
+    event = event_from_dispatch_request(_request())
+    assert event.dedupe_key == "alert:42:investigation_complete"
+
+
+def test_envelope_keeps_alert_name_none_rather_than_empty():
+    event = event_from_dispatch_request(_request(alert_name=None))
+    assert event.context["alert_name"] is None


### PR DESCRIPTION
Closes #1017. First of four from the #1003 split. **No schema change** — this is a pure refactor.

## Why

Delivery was an `if/elif` on `route.channel` inside `dispatch()`, with a dedicated column set per channel on the route table (`shuffle_app_id`, `shuffle_app_name`, `webhook_url`, `webhook_method`, `webhook_headers`, `include_full_report`). Adding a channel meant a migration plus another branch. Four more channels are queued — Resend (#1004), Teams (#1005), and whatever follows.

Separately, `DispatchRequest` is shaped entirely around a completed AI investigation: it *requires* a severity assessment and a summary. An "alert assigned to Bob" event (#1006) has neither, so new triggers cannot reuse it.

## What's here

**`app/notifications/channels/`** — a `ChannelProvider` ABC, a registry, and the two existing branches ported into providers. The dispatch loop's channel handling is now nine lines: look up the provider, call `send()`, map the result. An unknown channel stays a per-route failure rather than aborting the batch.

**`NotificationEvent`** — a trigger-agnostic envelope. `DispatchRequest` is Talon's wire format and an external contract, so it is untouched; it's adapted into an envelope at the route boundary and everything downstream, providers included, sees only that. New triggers will construct envelopes directly and never build a `DispatchRequest`.

**`DispatchContext`** — per-call state. Providers are stateless singletons held in the registry, so anything cached for the duration of one dispatch must live here or concurrent dispatches would share it. This preserves the "one connector read, one AI-report read per batch" property while making it lazy: the old code pre-scanned matched routes and prefetched Shuffle credentials; now nothing is fetched unless a route actually reaches that provider. Same number of DB reads or fewer.

## Explicitly not here

No migration, no column added/dropped/renamed. No `scope`, no `recipient_mode`, no `config` JSON, no Fernet. Providers still read the existing per-channel columns.

That's the point of doing this first: the registry and envelope shapes get proven against real dispatch behaviour **before** #1018's migration commits data to them.

## Regression bar

Behaviour must be identical, and the tests hold that literally rather than structurally — exact payload dicts, exact error strings:

- The **webhook structured payload** is an external contract; customers' automation platforms read those field names. Asserted as a whole-dict equality.
- **`alert_name` and `report_url` keep their null-vs-empty-string split.** The JSON payload sends `null`; template substitution renders `""`. Collapsing them would change what downstream automation sees.
- **Every status and error string** lands in the dispatch log, which operators read. The cross-tenant integration refusal, the disabled-integration `skipped` (not `failed`), the missing-`app_id` and missing-`webhook_url` messages, and the Shuffle connector's own detail string are each pinned.
- **Memoization** is pinned directly: three Shuffle routes in one dispatch cause exactly one connector read; three webhook routes on one alert cause exactly one report read.

The AI-report gate from #1014 still fires ahead of any provider call.

## Two things a reviewer should push on

**1. I modified a test #1017 said should pass untouched.**

`test_notification_ai_report_gating.py` patched `svc.dispatch_webhook` — a seam that no longer exists on that module. The behavioural assertions are unchanged; only the patch target moved, and it now patches `provider.send`, which is what the loop actually calls and survives provider-internal changes. But I did relax a bar I set myself, and it's worth agreeing that's the right call.

**2. `_render_body` still takes `DispatchRequest`, not the envelope.**

Deliberate. Body rendering is a separate seam that #1009 (templates) reworks, and converting it here would add regression surface for no benefit in this PR. The visible consequence is that `dispatch()` uses `req` for rendering and `event` for everything else, which reads as inconsistent until #1006 needs it. Happy to pull it forward if you'd rather not carry that.

## Note on how this went

A scripted edit partway through silently deleted `_format_default_body`; one test caught it, and I restored the function verbatim from `main` rather than retyping it. That near-miss is why the equivalence tests assert exact values rather than "something webhook-shaped went out" — worth knowing when weighing how much the green suite is telling you here.

## Testing

```
28 new     tests/test_notification_channel_registry.py
132 passed tests/  (full suite)
pre-commit clean
```

Also: `_get_shuffle_connector` moved into the shuffle provider (its three other callers in the service import it from there), and the docstring on `ChannelProvider.send` carries forward the attribute-caching rule — read route attributes before the first `await`, because an expired ORM object triggers an implicit refresh that throws `MissingGreenlet` under `AsyncSession`.

## Next

#1018 (route config JSON) and #1019 (dispatch log) both build on this and each carry a migration. #1019 is independent of #1018 — different table.
