### PR TITLE
feat(notifications): generalize the dispatch log beyond alerts

### DIFF
--- a/backend/alembic/versions/459ad67895be_generalize_notification_dispatch_log.py
+++ b/backend/alembic/versions/459ad67895be_generalize_notification_dispatch_log.py
@@ -1,0 +1,95 @@
+"""generalize notification dispatch log
+
+Revision ID: 459ad67895be
+Revises: 87cd5b105199
+Create Date: 2026-08-01 14:50:28.452469
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "459ad67895be"
+down_revision: Union[str, None] = "87cd5b105199"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    # server_default is only needed to add a NOT NULL column to a populated
+    # table; it is dropped once the rows are settled (see below), so the column
+    # matches the model, which carries a Python-side default only.
+    op.add_column("notification_dispatch_log", sa.Column("entity_type", sa.String(32), nullable=False, server_default="alert"))
+
+    op.add_column("notification_dispatch_log", sa.Column("entity_id", sa.Integer(), nullable=True))
+    op.execute("UPDATE notification_dispatch_log SET entity_id = alert_id")
+    op.alter_column("notification_dispatch_log", "entity_id", existing_type=sa.Integer(), nullable=False)
+
+    op.add_column("notification_dispatch_log", sa.Column("dedupe_key", sa.String(255), nullable=True))
+    # `trigger` is a MySQL reserved word and must be backticked in raw SQL.
+    # SQLAlchemy quotes identifiers automatically in generated DDL, which is why
+    # the column could be created unquoted — but op.execute() passes this string
+    # through verbatim. Without the backticks this fails mid-migration, and
+    # since MySQL DDL is non-transactional the ADD COLUMNs above would already
+    # have committed while alembic_version stayed behind.
+    op.execute("UPDATE notification_dispatch_log SET dedupe_key = CONCAT('alert:', alert_id, ':', `trigger`)")
+    op.alter_column("notification_dispatch_log", "dedupe_key", existing_type=sa.String(255), nullable=False)
+
+    op.alter_column("notification_dispatch_log", "alert_id", existing_type=sa.Integer(), nullable=True)
+
+    op.alter_column(
+        "notification_dispatch_log",
+        "shuffle_execution_id",
+        new_column_name="provider_reference",
+        existing_type=sa.String(128),
+        existing_nullable=True,
+    )
+
+    op.drop_constraint("uq_notif_dispatch_idem", "notification_dispatch_log", type_="unique")
+    op.create_unique_constraint("uq_notif_dispatch_idem", "notification_dispatch_log", ["route_id", "dedupe_key"])
+
+    op.create_index("ix_notification_dispatch_log_entity_type", "notification_dispatch_log", ["entity_type"])
+    op.create_index("ix_notification_dispatch_log_entity_id", "notification_dispatch_log", ["entity_id"])
+    op.create_index("ix_notification_dispatch_log_dedupe_key", "notification_dispatch_log", ["dedupe_key"])
+
+    # Every row now has entity_type, and the application always sets it, so the
+    # scaffolding default comes off — otherwise the column keeps a server_default
+    # the model doesn't declare and autogenerate flags the drift later.
+    op.alter_column("notification_dispatch_log", "entity_type", existing_type=sa.String(32), server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notification_dispatch_log_dedupe_key", table_name="notification_dispatch_log")
+    op.drop_index("ix_notification_dispatch_log_entity_id", table_name="notification_dispatch_log")
+    op.drop_index("ix_notification_dispatch_log_entity_type", table_name="notification_dispatch_log")
+
+    op.drop_constraint("uq_notif_dispatch_idem", "notification_dispatch_log", type_="unique")
+
+    op.alter_column(
+        "notification_dispatch_log",
+        "provider_reference",
+        new_column_name="shuffle_execution_id",
+        existing_type=sa.String(128),
+        existing_nullable=True,
+    )
+
+    # LOSSY, unavoidably: rows for non-alert entities (case, case_task) have no
+    # alert_id and cannot satisfy the old NOT NULL column or its unique tuple.
+    # They are audit rows for events the pre-migration schema could not
+    # represent at all, so reverting necessarily discards them.
+    #
+    # This makes downgrade an escape hatch for "the migration went wrong right
+    # now", not a routine rollback to run once case/task notifications are live.
+    op.execute("DELETE FROM notification_dispatch_log WHERE alert_id IS NULL")
+
+    op.alter_column("notification_dispatch_log", "alert_id", existing_type=sa.Integer(), nullable=False)
+
+    op.create_unique_constraint("uq_notif_dispatch_idem", "notification_dispatch_log", ["customer_code", "alert_id", "route_id", "trigger"])
+
+    op.drop_column("notification_dispatch_log", "dedupe_key")
+    op.drop_column("notification_dispatch_log", "entity_id")
+    op.drop_column("notification_dispatch_log", "entity_type")

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -991,22 +991,41 @@ class CustomerNotificationRoute(SQLModel, table=True):
 class NotificationDispatchLog(SQLModel, table=True):
     __tablename__ = "notification_dispatch_log"
     __table_args__ = (
-        # Idempotency key: re-running the same investigation must not
-        # re-fire the same notification. The dispatch service does
-        # "INSERT ... ON CONFLICT DO NOTHING" against this constraint and
-        # short-circuits if a row already exists.
+        # Idempotency key: re-dispatching the same event must not re-fire the
+        # same notification. The dispatch service checks this before calling a
+        # provider and short-circuits if a `sent` row already exists.
+        #
+        # Was (customer_code, alert_id, route_id, trigger). `route_id` already
+        # determines the customer, and each trigger now owns its own dedupe
+        # semantics via `dedupe_key` — notably manual sends (#1010) need a
+        # per-invocation unique key so repeat sends stay repeatable, which a
+        # fixed tuple cannot express.
         UniqueConstraint(
-            "customer_code",
-            "alert_id",
             "route_id",
-            "trigger",
+            "dedupe_key",
             name="uq_notif_dispatch_idem",
         ),
     )
 
     id: Optional[int] = Field(primary_key=True)
     customer_code: str = Field(max_length=64, index=True, nullable=False)
-    alert_id: int = Field(nullable=False, index=True)
+
+    # Nullable since the log stopped being alert-only: a case-task assignment
+    # has no alert. Retained alongside entity_id (rather than replaced by it)
+    # because existing queries and the UI filter on it, and because "which
+    # alert" stays the common question even for non-alert entities later.
+    alert_id: Optional[int] = Field(default=None, nullable=True, index=True)
+
+    # What this dispatch was about. 'alert' | 'case' | 'case_task' — plain
+    # strings so a new entity type is a data-only change.
+    entity_type: str = Field(default="alert", max_length=32, nullable=False, index=True)
+    entity_id: int = Field(nullable=False, index=True)
+
+    # Per-trigger idempotency token, carried on NotificationEvent so each
+    # trigger owns its own semantics. Backfilled as 'alert:{alert_id}:{trigger}'
+    # for pre-existing rows, which reproduces the old tuple's meaning exactly.
+    dedupe_key: str = Field(max_length=255, nullable=False, index=True)
+
     route_id: int = Field(
         foreign_key="customer_notification_route.id",
         nullable=False,
@@ -1028,12 +1047,14 @@ class NotificationDispatchLog(SQLModel, table=True):
     # a customer says "the message looked wrong" we want to see what we
     # actually sent without storing the entire body history.
     payload_preview: Optional[str] = Field(sa_column=Column(Text), default=None)
-    # Phase 2: Shuffle's POST /apps/{id}/mcp returns a fire-and-record
-    # execution_id. Stored here so an admin can pivot from "this
-    # notification didn't arrive at Slack" → look up the run in
-    # shuffler.io's UI to see whether Shuffle accepted the dispatch but
-    # the downstream app rejected it. Null for non-Shuffle channels.
-    shuffle_execution_id: Optional[str] = Field(default=None, max_length=128)
+    # Vendor-side identifier for this delivery, whatever the channel calls it —
+    # Shuffle's execution id, and later Resend's message id. Lets an admin pivot
+    # from "the notification didn't arrive" to the run in the provider's own UI
+    # and see whether the provider accepted it but the downstream app rejected
+    # it. Null for channels that return no reference.
+    #
+    # Was `shuffle_execution_id`; renamed once a second channel needed the slot.
+    provider_reference: Optional[str] = Field(default=None, max_length=128)
 
     # See note on CustomerNotificationRoute.dispatches — back_populates
     # removed deliberately to keep AsyncSession flush() synchronous-IO-free.

--- a/backend/app/notifications/channels/base.py
+++ b/backend/app/notifications/channels/base.py
@@ -38,8 +38,7 @@ class SendResult(BaseModel):
     Generalizes the ``(status, error, latency_ms, shuffle_execution_id)`` tuple
     the dispatchers returned. ``provider_reference`` is the vendor-agnostic name
     for that last slot — Shuffle's execution id, and later Resend's message id.
-    The dispatch-log *column* is still ``shuffle_execution_id`` until #1019
-    renames it; the mapping happens in the dispatch loop.
+    It maps straight onto the dispatch log's column of the same name.
     """
 
     status: str  # 'sent' | 'failed' | 'skipped'

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -447,7 +447,12 @@ class NotificationRouteResponse(BaseModel):
 class DispatchLogRead(BaseModel):
     id: int
     customer_code: str
-    alert_id: int
+    # Nullable since the log stopped being alert-only — a case-task assignment
+    # has no alert. Use entity_type/entity_id for the general case.
+    alert_id: Optional[int] = None
+    entity_type: str = "alert"
+    entity_id: int
+    dedupe_key: str
     route_id: int
     trigger: str
     dispatched_at: datetime
@@ -455,7 +460,7 @@ class DispatchLogRead(BaseModel):
     error_message: Optional[str] = None
     latency_ms: Optional[int] = None
     payload_preview: Optional[str] = None
-    shuffle_execution_id: Optional[str] = None
+    provider_reference: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -498,10 +503,13 @@ class DispatchOutcome(BaseModel):
     status: DispatchStatus
     error_message: Optional[str] = None
     latency_ms: Optional[int] = None
-    # Shuffle's POST /apps/{id}/mcp returns this on a successful kickoff.
-    # Surfaced in the response so the calling agent (Talon) can include
-    # it in its analyst summary if the dispatch went through Shuffle.
-    shuffle_execution_id: Optional[str] = None
+    # Vendor-side identifier for the delivery, whatever the channel calls it —
+    # Shuffle's execution id today, Resend's message id next. Surfaced in the
+    # response so the calling agent (Talon) can cite it in its analyst summary.
+    #
+    # NOTE: renamed from `shuffle_execution_id`. This is Talon-facing, so if a
+    # Talon build still reads the old name it needs updating alongside this.
+    provider_reference: Optional[str] = None
 
 
 class DispatchResponse(BaseModel):

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -8,7 +8,8 @@ walks every enabled route for the customer, filters by trigger and
 severity, formats the message body per channel, calls the appropriate
 dispatcher, and records the outcome in `notification_dispatch_log`. The
 log row is what gives us idempotency — re-dispatching the same
-(customer, alert, route, trigger) is a no-op.
+(route, dedupe_key) pair is a no-op. The key travels on the event, so
+each trigger decides its own dedupe semantics.
 """
 
 from __future__ import annotations
@@ -34,6 +35,8 @@ from app.notifications.channels import DispatchContext
 from app.notifications.channels import SendResult
 from app.notifications.channels import get_channel
 from app.notifications.channels.shuffle import get_shuffle_connector
+from app.notifications.schema.events import EntityType
+from app.notifications.schema.events import NotificationEvent
 from app.notifications.schema.events import event_from_dispatch_request
 from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS
 from app.notifications.schema.notifications import SEVERITY_ORDER
@@ -529,15 +532,13 @@ def _render_body(route: CustomerNotificationRoute, req: DispatchRequest) -> str:
 async def _record_log(
     session: AsyncSession,
     *,
-    customer_code: str,
-    alert_id: int,
+    event: NotificationEvent,
     route_id: int,
-    trigger: str,
     status: str,
     error_message: Optional[str],
     latency_ms: Optional[int],
     payload_preview: Optional[str],
-    shuffle_execution_id: Optional[str] = None,
+    provider_reference: Optional[str] = None,
 ) -> bool:
     """Record a dispatch outcome. Returns False ONLY when the dispatch
     has already been recorded as `sent` — i.e. a true idempotency hit
@@ -546,8 +547,11 @@ async def _record_log(
     with the new result so retries land cleanly.
 
     Idempotency model:
-      - One row per (customer_code, alert_id, route_id, trigger) tuple
-        (enforced by a unique index)
+      - One row per (route_id, dedupe_key) pair (enforced by a unique
+        index). The key comes off the event, so each trigger owns its
+        own semantics — reassigning A → B → A re-notifies A, while a
+        no-op write does not, and manual sends (#1010) stay repeatable
+        by generating a per-invocation key.
       - If the existing row's status is `sent`, refuse the new write
         (caller treats as "already done, skip")
       - If the existing row's status is `failed`/`skipped`, overwrite
@@ -556,17 +560,15 @@ async def _record_log(
       - If no row exists yet, insert a fresh one
     """
     # Pre-flight: check whether a row already exists for this
-    # (customer, alert, route, trigger) tuple. Doing the check up front
-    # lets us update-in-place when needed — avoids the rollback path
-    # whose `session.rollback()` expires every loaded object in the
-    # session (route, integrations, etc.) and breaks subsequent
-    # attribute access in async context.
+    # (route, dedupe_key) pair. Doing the check up front lets us
+    # update-in-place when needed — avoids the rollback path whose
+    # `session.rollback()` expires every loaded object in the session
+    # (route, integrations, etc.) and breaks subsequent attribute
+    # access in async context.
     result = await session.execute(
         select(NotificationDispatchLog).where(
-            NotificationDispatchLog.customer_code == customer_code,
-            NotificationDispatchLog.alert_id == alert_id,
             NotificationDispatchLog.route_id == route_id,
-            NotificationDispatchLog.trigger == trigger,
+            NotificationDispatchLog.dedupe_key == event.dedupe_key,
         ),
     )
     existing = result.scalars().first()
@@ -582,22 +584,27 @@ async def _record_log(
         existing.error_message = error_message
         existing.latency_ms = latency_ms
         existing.payload_preview = payload_preview[:500] if payload_preview else None
-        existing.shuffle_execution_id = shuffle_execution_id
+        existing.provider_reference = provider_reference
         existing.dispatched_at = datetime.utcnow()
         await session.commit()
         return True
 
     # No prior record — insert fresh.
     log = NotificationDispatchLog(
-        customer_code=customer_code,
-        alert_id=alert_id,
+        customer_code=event.customer_code,
+        # Populated only for alert-shaped events; a case-task assignment
+        # leaves it NULL and carries its identity in entity_type/entity_id.
+        alert_id=event.entity_id if event.entity_type == EntityType.ALERT else None,
+        entity_type=event.entity_type,
+        entity_id=event.entity_id,
+        dedupe_key=event.dedupe_key,
         route_id=route_id,
-        trigger=trigger,
+        trigger=event.trigger.value,
         status=status,
         error_message=error_message,
         latency_ms=latency_ms,
         payload_preview=payload_preview[:500] if payload_preview else None,
-        shuffle_execution_id=shuffle_execution_id,
+        provider_reference=provider_reference,
     )
     session.add(log)
     try:
@@ -663,10 +670,8 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
             route_channel = route.channel
             await _record_log(
                 session,
-                customer_code=req.customer_code,
-                alert_id=req.alert_id,
+                event=event,
                 route_id=route_id,
-                trigger=req.trigger.value,
                 status=DispatchStatus.SKIPPED.value,
                 error_message=reason,
                 latency_ms=None,
@@ -715,7 +720,7 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         latency_ms: Optional[int] = None
         result_status = "sent"
         error_message: Optional[str] = None
-        shuffle_execution_id: Optional[str] = None
+        provider_reference: Optional[str] = None
         # Stays None when the channel is unknown or send() raised. after_send
         # guards on it rather than inferring from result_status — the two can
         # only diverge via a future edit, and this way that edit is safe.
@@ -740,9 +745,7 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
                 result_status = result.status
                 error_message = result.error_message
                 latency_ms = result.latency_ms
-                # The log column is still named shuffle_execution_id; #1019
-                # renames it to provider_reference.
-                shuffle_execution_id = result.provider_reference
+                provider_reference = result.provider_reference
         except Exception as e:  # noqa: BLE001 — best-effort, never raise
             logger.exception(f"Dispatcher raised for route {route_id}: {e!r}")
             result_status = "failed"
@@ -755,15 +758,13 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         # dispatch.
         recorded = await _record_log(
             session,
-            customer_code=req.customer_code,
-            alert_id=req.alert_id,
+            event=event,
             route_id=route_id,
-            trigger=req.trigger.value,
             status=result_status,
             error_message=error_message,
             latency_ms=latency_ms,
             payload_preview=body_preview,
-            shuffle_execution_id=shuffle_execution_id,
+            provider_reference=provider_reference,
         )
 
         if not recorded:
@@ -813,7 +814,7 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
                 status=DispatchStatus(result_status),
                 error_message=error_message,
                 latency_ms=latency_ms,
-                shuffle_execution_id=shuffle_execution_id,
+                provider_reference=provider_reference,
             ),
         )
 

--- a/backend/tests/test_notification_dedupe.py
+++ b/backend/tests/test_notification_dedupe.py
@@ -1,0 +1,246 @@
+"""Idempotency after the dispatch log stopped being alert-only.
+
+The unique key moved from ``(customer_code, alert_id, route_id, trigger)`` to
+``(route_id, dedupe_key)``. That swap is the risky part of #1019: too loose and
+notifications double-fire, too tight and legitimate re-notifications get
+swallowed.
+
+The key now travels on ``NotificationEvent``, so each trigger owns its own
+semantics. ``investigation_complete`` uses ``alert:{id}:{trigger}`` — the same
+meaning the old tuple had, which is also what the migration backfills, so
+pre-existing rows keep behaving identically.
+
+Unit tests with a mocked session — no DB.
+
+Run with: cd backend && python -m pytest tests/test_notification_dedupe.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.schema.events import EntityType  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+
+CUSTOMER = "TENANT_A"
+
+
+def _event(entity_type=EntityType.ALERT, entity_id=42, dedupe_key=None, trigger=NotificationTrigger.INVESTIGATION_COMPLETE):
+    return NotificationEvent(
+        customer_code=CUSTOMER,
+        trigger=trigger,
+        severity=NotificationSeverity.CRITICAL,
+        subject="Mimikatz signature",
+        summary="Credential dumping observed.",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        dedupe_key=dedupe_key or f"{entity_type}:{entity_id}:{trigger.value}",
+    )
+
+
+def _session(existing=None, raise_on_commit=False):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = existing
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    if raise_on_commit:
+        session.commit = AsyncMock(side_effect=IntegrityError("stmt", {}, Exception("dup")))
+    return session
+
+
+def _existing_row(status):
+    return SimpleNamespace(
+        status=status,
+        error_message=None,
+        latency_ms=None,
+        payload_preview=None,
+        provider_reference=None,
+        dispatched_at=None,
+    )
+
+
+def _record(session, event, *, status="sent", provider_reference=None):
+    return asyncio.run(
+        svc._record_log(
+            session,
+            event=event,
+            route_id=1,
+            status=status,
+            error_message=None,
+            latency_ms=12,
+            payload_preview="body",
+            provider_reference=provider_reference,
+        ),
+    )
+
+
+def _inserted(session):
+    """The NotificationDispatchLog instance handed to session.add()."""
+    assert session.add.call_count == 1
+    return session.add.call_args.args[0]
+
+
+# ── the lookup uses the new key ───────────────────────────────────────────
+
+
+def test_lookup_is_by_route_and_dedupe_key():
+    """A stale lookup on (customer, alert, trigger) would keep working for AI
+    events and silently mis-dedupe everything else."""
+    session = _session()
+    _record(session, _event())
+
+    where = str(session.execute.await_args.args[0])
+    assert "route_id" in where
+    assert "dedupe_key" in where
+
+
+# ── idempotency semantics, unchanged ──────────────────────────────────────
+
+
+def test_previously_sent_is_refused():
+    session = _session(existing=_existing_row("sent"))
+    assert _record(session, _event()) is False
+    assert session.add.call_count == 0
+
+
+@pytest.mark.parametrize("prior", ["failed", "skipped"])
+def test_previous_failure_is_overwritten_so_retries_land(prior):
+    """A failed attempt must not permanently block the same notification."""
+    row = _existing_row(prior)
+    session = _session(existing=row)
+
+    assert _record(session, _event(), status="sent", provider_reference="exec-9") is True
+    assert row.status == "sent"
+    assert row.provider_reference == "exec-9"
+    assert session.add.call_count == 0, "overwrite in place, don't insert a second row"
+
+
+def test_concurrent_insert_race_is_treated_as_a_hit():
+    """Another dispatch slipped in between our SELECT and INSERT."""
+    session = _session(existing=None, raise_on_commit=True)
+    assert _record(session, _event()) is False
+    session.rollback.assert_awaited()
+
+
+# ── what actually gets written ────────────────────────────────────────────
+
+
+def test_alert_event_populates_both_alert_id_and_entity_fields():
+    """alert_id is retained for existing queries and the UI filter; entity_*
+    is the general form."""
+    session = _session()
+    _record(session, _event())
+    row = _inserted(session)
+
+    assert row.alert_id == 42
+    assert row.entity_type == "alert"
+    assert row.entity_id == 42
+    assert row.dedupe_key == "alert:42:investigation_complete"
+    assert row.customer_code == CUSTOMER
+
+
+def test_non_alert_event_leaves_alert_id_null():
+    """The whole point of the migration: a case-task assignment has no alert,
+    and previously could not be logged at all because alert_id was NOT NULL."""
+    session = _session()
+    _record(session, _event(entity_type=EntityType.CASE_TASK, entity_id=7))
+    row = _inserted(session)
+
+    assert row.alert_id is None
+    assert row.entity_type == "case_task"
+    assert row.entity_id == 7
+
+
+def test_case_event_leaves_alert_id_null():
+    session = _session()
+    _record(session, _event(entity_type=EntityType.CASE, entity_id=3))
+    row = _inserted(session)
+
+    assert row.alert_id is None
+    assert row.entity_id == 3
+
+
+def test_provider_reference_is_persisted():
+    session = _session()
+    _record(session, _event(), provider_reference="exec-1")
+    assert _inserted(session).provider_reference == "exec-1"
+
+
+def test_payload_preview_is_truncated_to_500():
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+
+    asyncio.run(
+        svc._record_log(
+            session,
+            event=_event(),
+            route_id=1,
+            status="sent",
+            error_message=None,
+            latency_ms=1,
+            payload_preview="x" * 900,
+            provider_reference=None,
+        ),
+    )
+    assert len(_inserted(session).payload_preview) == 500
+
+
+# ── the key's discriminating power ────────────────────────────────────────
+
+
+def test_backfilled_key_matches_what_the_code_writes():
+    """The migration backfills 'alert:{alert_id}:{trigger}' for existing rows.
+    If the code wrote anything else, every pre-existing dispatch would look new
+    and re-fire once on upgrade.
+    """
+    event = _event()
+    assert event.dedupe_key == "alert:42:investigation_complete"
+
+
+def test_distinct_entities_produce_distinct_keys():
+    assert _event(entity_id=1).dedupe_key != _event(entity_id=2).dedupe_key
+
+
+def test_distinct_entity_types_produce_distinct_keys():
+    """A case #7 and a case-task #7 are different things."""
+    a = _event(entity_type=EntityType.CASE, entity_id=7)
+    b = _event(entity_type=EntityType.CASE_TASK, entity_id=7)
+    assert a.dedupe_key != b.dedupe_key
+
+
+def test_same_key_on_a_different_route_is_not_deduped():
+    """Two routes for the same customer must both receive the notification —
+    dedupe is per (route, key), not per key.
+    """
+    event = _event()
+    session = _session(existing=None)
+    asyncio.run(
+        svc._record_log(
+            session,
+            event=event,
+            route_id=2,
+            status="sent",
+            error_message=None,
+            latency_ms=1,
+            payload_preview=None,
+            provider_reference=None,
+        ),
+    )
+    where = str(session.execute.await_args.args[0])
+    # route_id participates in the lookup, so route 2 cannot see route 1's row.
+    assert "route_id" in where
+    assert _inserted(session).route_id == 2

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationDispatchLog.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationDispatchLog.vue
@@ -57,6 +57,12 @@ const entries = ref<DispatchLogEntry[]>([])
 
 const dFormats = useSettingsStore().dateFormat
 
+function entityLabel(entityType: string): string {
+	if (entityType === "case") return "Case"
+	if (entityType === "case_task") return "Task"
+	return "Alert"
+}
+
 function statusColor(status: string): "success" | "warning" | "danger" | undefined {
 	if (status === "sent") return "success"
 	if (status === "skipped") return "warning"
@@ -72,10 +78,12 @@ const columns = computed<DataTableColumns<DispatchLogEntry>>(() => [
 		render: row => String(formatDate(row.dispatched_at, dFormats.datetime))
 	},
 	{
-		title: "Alert",
-		key: "alert_id",
-		width: 80,
-		render: row => `#${row.alert_id}`
+		// Entity rather than Alert: the log now records case and case-task
+		// events too, which carry no alert_id.
+		title: "Entity",
+		key: "entity_id",
+		width: 130,
+		render: row => (row.entity_type === "alert" ? `#${row.entity_id}` : `${entityLabel(row.entity_type)} #${row.entity_id}`)
 	},
 	{
 		title: "Trigger",

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -61,10 +61,17 @@ export interface NotificationRoutePayload {
 
 export type NotificationRouteUpdatePayload = Partial<NotificationRoutePayload>
 
+export type NotificationEntityType = "alert" | "case" | "case_task"
+
 export interface NotificationDispatchLogEntry {
 	id: number
 	customer_code: string
-	alert_id: number
+	// Null for events that aren't about an alert (e.g. a case-task assignment).
+	// Prefer entity_type/entity_id, which are always populated.
+	alert_id: number | null
+	entity_type: NotificationEntityType
+	entity_id: number
+	dedupe_key: string
 	route_id: number
 	trigger: string
 	dispatched_at: string
@@ -72,7 +79,8 @@ export interface NotificationDispatchLogEntry {
 	error_message: string | null
 	latency_ms: number | null
 	payload_preview: string | null
-	shuffle_execution_id: string | null
+	// Vendor-side delivery id — Shuffle execution id, Resend message id, etc.
+	provider_reference: string | null
 }
 
 // ----- Shuffle integrations (Phase 2) -----


### PR DESCRIPTION
Closes #1019. Second of four from the #1003 split, after #1021.

## Why

`notification_dispatch_log.alert_id` was `NOT NULL` **and** part of the idempotency key `(customer_code, alert_id, route_id, trigger)`. A case-task assignment has no alert, so events that aren't about an alert could not be logged at all — which blocks the assignment triggers in #1006 and manual send in #1010.

## Schema

Migration `459ad67895be`, chained from `87cd5b105199`.

| Change | Column | |
|---|---|---|
| add | `entity_type` | varchar(32) NOT NULL, `'alert'` |
| add | `entity_id` | int NOT NULL |
| add | `dedupe_key` | varchar(255) NOT NULL |
| alter | `alert_id` | now nullable |
| rename | `shuffle_execution_id` → `provider_reference` | |
| swap | unique key → `(route_id, dedupe_key)` | |

`route_id` already determines the customer, so it drops out of the key. Carrying the key on `NotificationEvent` instead lets each trigger own its own semantics — reassigning A → B → A re-notifies A while a no-op write does not, and manual sends stay repeatable via a per-invocation key. A fixed column tuple can express neither.

**The backfill is the safety property.** `dedupe_key` is populated as `'alert:{alert_id}:{trigger}'`, which is exactly what the code writes for `investigation_complete` — so pre-existing rows keep their identity and nothing re-fires on upgrade. There's a test asserting the two agree, because if they ever drifted every historical dispatch would look new.

`entity_type`'s `server_default` is dropped at the end of `upgrade()` once rows are settled: it's scaffolding for adding a NOT NULL column to a populated table, and leaving it would drift from the model, which carries a Python-side default only.

`downgrade()` is complete but **lossy by necessity** — rows for non-alert entities cannot exist in the old schema, so reverting discards them. It's an escape hatch for "this went wrong just now", not a rollback to reach for once case/task notifications are live. Called out in a comment.

## Verified against a populated database

Not just "no error":

```
alert_id            int DEFAULT NULL                     ✓ nullable
provider_reference  varchar(128)                         ✓ renamed, data preserved
entity_type         varchar(32) NOT NULL, no DEFAULT     ✓ server_default shed
uq_notif_dispatch_idem (route_id, dedupe_key)            ✓ swapped, old key gone
3/3 rows backfilled correctly
```

One of those rows carries the legacy `severity_critical_or_high` trigger and backfilled to `alert:144:severity_critical_or_high`. That's the right outcome — `_trigger_applies` still treats that value as the AI catch-all, so the row keeps its identity. A backfill that normalised it to `investigation_complete` would have collided with its sibling on the same route and failed the constraint creation.

## A bug worth recording

The backfill needed `` `trigger` `` backticked — it's a **MySQL reserved word**. `op.execute()` passes raw SQL through verbatim, unlike SQLAlchemy-generated DDL, which quotes identifiers automatically (which is why the column could be *created* unquoted).

The failure mode is nastier than a syntax error suggests: the `UPDATE` is step 3 of `upgrade()`, and **MySQL DDL is not transactional**. The three preceding `ADD COLUMN`s would have committed while `alembic_version` stayed at the previous revision — so re-running would die on "duplicate column entity_type", and recovery means hand-dropping three columns first.

Nothing in the test suite could have caught this: the tests mock the session entirely and never emit SQL. It surfaced only because the pre-flight duplicate check was run separately against the real database first. There's a comment at the call site so the next person writing raw SQL against this table doesn't rediscover it.

## Judgement call for review

**`alert_id` is kept alongside `entity_id` rather than dropped.** The issue allowed either. Keeping it means the UI's alert filter and ad-hoc queries keep working, and "which alert" stays directly answerable. The cost is one denormalised column — populated for alert-shaped events, NULL otherwise. Both halves are pinned by tests. Say the word if you'd rather it go.

## Breaking-ish

`shuffle_execution_id` → `provider_reference` also applies to **`DispatchOutcome`**, which is returned to Talon in the dispatch response. You asked for both renamed rather than keeping the external field stale. If a Talon build reads the old name it needs updating alongside this — flagged in a comment on the schema.

## Testing

```
14 new     tests/test_notification_dedupe.py
146 passed tests/  (full suite)
pre-commit clean · eslint clean · type-check exit 0
```

Covers: the lookup uses the new key; `sent` is refused while `failed`/`skipped` are overwritten so retries land; the concurrent-insert race is treated as a hit; alert events populate both `alert_id` and the entity fields; case and case-task events leave `alert_id` NULL; the backfilled key matches what the code writes; distinct entities and distinct entity types produce distinct keys; the same key on a different route is not deduped.

Frontend: the log viewer's "Alert" column becomes "Entity" and renders `Case #3` / `Task #7` for non-alert rows.

## Next

#1018 (route config JSON) is the last blocking piece of Phase 1 — and the heaviest: it drops six columns after backfilling them into JSON and pulls in the 554-line route-form rewrite.
