### PR TITLE
feat(notifications): move channel settings into a JSON config column

### DIFF
--- a/backend/alembic/versions/8c41d7e2b90a_add_route_config_scope_recipient_mode.py
+++ b/backend/alembic/versions/8c41d7e2b90a_add_route_config_scope_recipient_mode.py
@@ -1,0 +1,129 @@
+"""add route config, scope and recipient_mode
+
+Revision ID: 8c41d7e2b90a
+Revises: 459ad67895be
+Create Date: 2026-08-01 15:40:00.000000
+
+Phase 1b of the notification refactor (#1018), first of two steps.
+
+This revision only ADDS and BACKFILLS. The six per-channel columns it supersedes
+(shuffle_app_id, shuffle_app_name, webhook_url, webhook_method, webhook_headers,
+include_full_report) are deliberately left in place and dual-written by the
+application for one release, so this change is losslessly revertible. #1018b
+drops them once config has been verified against them on real data.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8c41d7e2b90a"
+down_revision: Union[str, None] = "459ad67895be"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # server_default on the three NOT NULL columns is scaffolding for adding
+    # them to a populated table; it comes off at the end so the columns match
+    # the model, which declares Python-side defaults only.
+    op.add_column("customer_notification_route", sa.Column("config", sa.Text(), nullable=True))
+    op.add_column(
+        "customer_notification_route",
+        sa.Column("scope", sa.String(16), nullable=False, server_default="customer"),
+    )
+    op.add_column(
+        "customer_notification_route",
+        sa.Column("recipient_mode", sa.String(16), nullable=False, server_default="static"),
+    )
+    op.add_column(
+        "customer_notification_route",
+        sa.Column("notify_on_self_assign", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+    # customer_code becomes nullable: an internal-scope route belongs to no
+    # tenant. Every existing row backfills to scope='customer' and keeps its
+    # code, so nothing changes for them.
+    op.alter_column(
+        "customer_notification_route",
+        "customer_code",
+        existing_type=sa.String(64),
+        nullable=True,
+    )
+
+    # Backfill config from the per-channel columns.
+    #
+    # webhook_headers already holds a JSON *string*, so it is CAST to JSON
+    # rather than nested directly — nesting would double-encode it and the
+    # provider would read a string where it expects an object. The CASE guards
+    # NULL/empty, which CAST would reject.
+    #
+    # A row whose webhook_headers is present but not valid JSON would fail this
+    # statement; the pre-flight check (JSON_VALID) exists to catch that before
+    # the migration runs.
+    op.execute(
+        """
+        UPDATE customer_notification_route SET config = JSON_OBJECT(
+            'url', webhook_url,
+            'method', COALESCE(webhook_method, 'POST'),
+            'headers', CASE
+                WHEN webhook_headers IS NULL OR webhook_headers = '' THEN NULL
+                ELSE CAST(webhook_headers AS JSON)
+            END,
+            'include_full_report', COALESCE(include_full_report, 0) = 1
+        ) WHERE channel = 'webhook'
+        """,
+    )
+    op.execute(
+        """
+        UPDATE customer_notification_route SET config = JSON_OBJECT(
+            'app_id', shuffle_app_id,
+            'app_name', shuffle_app_name
+        ) WHERE channel = 'shuffle'
+        """,
+    )
+    # Any other channel value is unexpected (the registry ships two), but leave
+    # such a row with config = NULL rather than guessing: the provider lookup
+    # already records an unsupported channel as a per-route failure, and the
+    # read schema tolerates NULL config as {}.
+
+    op.create_index("ix_customer_notification_route_scope", "customer_notification_route", ["scope"])
+
+    op.alter_column("customer_notification_route", "scope", existing_type=sa.String(16), server_default=None)
+    op.alter_column("customer_notification_route", "recipient_mode", existing_type=sa.String(16), server_default=None)
+    op.alter_column(
+        "customer_notification_route",
+        "notify_on_self_assign",
+        existing_type=sa.Boolean(),
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    """Non-lossy: the legacy per-channel columns were never touched.
+
+    Any route created or edited while this revision was applied still has its
+    settings in those columns, because the application dual-writes them.
+    """
+    op.drop_index("ix_customer_notification_route_scope", table_name="customer_notification_route")
+
+    # Internal-scope routes have no customer_code and cannot exist under the
+    # old NOT NULL constraint. They can only have been created while this
+    # revision was applied, and have no representation to revert to.
+    op.execute("DELETE FROM customer_notification_route WHERE customer_code IS NULL")
+
+    op.alter_column(
+        "customer_notification_route",
+        "customer_code",
+        existing_type=sa.String(64),
+        nullable=False,
+    )
+
+    op.drop_column("customer_notification_route", "notify_on_self_assign")
+    op.drop_column("customer_notification_route", "recipient_mode")
+    op.drop_column("customer_notification_route", "scope")
+    op.drop_column("customer_notification_route", "config")

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -893,12 +893,33 @@ class CustomerNotificationRoute(SQLModel, table=True):
     __tablename__ = "customer_notification_route"
 
     id: Optional[int] = Field(primary_key=True)
-    customer_code: str = Field(
+
+    # Nullable because an internal-scope route belongs to no tenant: assignment
+    # notifications go to the SOC, not to the customer whose alert was assigned.
+    # The CRUD layer enforces the invariant both ways —
+    # scope='customer' => customer_code IS NOT NULL; scope='internal' => NULL.
+    customer_code: Optional[str] = Field(
+        default=None,
         foreign_key="customers.customer_code",
         max_length=64,
         index=True,
-        nullable=False,
+        nullable=True,
     )
+
+    # 'customer' — delivers to the end customer's channel.
+    # 'internal'  — delivers to the SOC's own channel, tenant-agnostic. This is
+    #               where assignment notifications land, so analyst chatter
+    #               never reaches a customer's Slack.
+    scope: str = Field(default="customer", max_length=16, nullable=False, index=True)
+
+    # 'static'   — destination comes from `config`.
+    # 'assignee' — resolve the event's assignee to their email at dispatch time.
+    #              Only valid on channels whose supports_recipient_modes allows
+    #              it (a webhook targets a fixed URL, so it cannot).
+    recipient_mode: str = Field(default="static", max_length=16, nullable=False)
+
+    # An analyst picking up their own alert doesn't need an email about it.
+    notify_on_self_assign: bool = Field(default=False, nullable=False)
 
     # Human label shown in the UI list. Without this, users would have to
     # mentally parse channel+destination columns to identify a rule.
@@ -942,35 +963,39 @@ class CustomerNotificationRoute(SQLModel, table=True):
     # management. Populated from the auth context in the route handler.
     created_by: Optional[str] = Field(default=None, max_length=128)
 
-    # ----- Phase 2: Shuffle channel routing -----
-    # Populated when channel='shuffle'. NULL for legacy SMTP routes.
-    # The (integration_id, app_id, app_name) triple together describes
-    # "which Shuffle org" + "which app inside that org" + "label for the
-    # UI." `app_id` is the Shuffle app UUID we POST to
-    # /api/v1/apps/{app_id}/mcp; `app_name` is the human-readable label
-    # (e.g. "Slack") we cache so the UI doesn't have to roundtrip to
-    # Shuffle to render the route list.
+    # Per-channel settings, as a JSON string validated against the provider's
+    # declared `config_schema`. This replaced a column-per-channel-per-setting
+    # scheme that required a migration for every new channel; adding one is now
+    # a data-only change.
+    #
+    # Shapes (see each provider's ConfigSchema for the authority):
+    #   shuffle -> {"app_id": …, "app_name": …}
+    #   webhook -> {"url": …, "method": …, "headers": {…}, "include_full_report": bool}
+    #
+    # Stored as Text rather than a native JSON column for portability across
+    # the MySQL/SQLite backends, matching how webhook_headers was stored.
+    config: Optional[str] = Field(sa_column=Column(Text), default=None)
+
+    # `shuffle_integration_id` stays a real column while the rest of the Shuffle
+    # settings moved into `config`: it is a foreign key, and burying an FK
+    # inside JSON gives up referential integrity and the cross-tenant check the
+    # dispatcher relies on.
     shuffle_integration_id: Optional[int] = Field(
         default=None,
         foreign_key="customer_shuffle_integration.id",
         index=True,
     )
+
+    # ----- Legacy per-channel columns (dropped in #1018b) -----
+    # Superseded by `config`, retained for one release and dual-written on every
+    # create/update. That makes reverting this change lossless and lets the
+    # follow-up verify config against them on real data before dropping.
+    # Nothing reads these — the providers read `config`.
     shuffle_app_id: Optional[str] = Field(default=None, max_length=64)
     shuffle_app_name: Optional[str] = Field(default=None, max_length=128)
-
-    # ----- Direct webhook channel routing -----
-    # Populated when channel='webhook'. NULL for shuffle routes. The
-    # dispatch service POSTs/PUTs to `webhook_url` with either a
-    # structured JSON payload (default) or the rendered format_template
-    # (when set). `webhook_headers` is a JSON-encoded string of custom
-    # request headers (auth tokens etc.) — stored as text for portability
-    # across the MySQL/SQLite backends rather than a native JSON column.
     webhook_url: Optional[str] = Field(sa_column=Column(Text), default=None)
     webhook_method: Optional[str] = Field(default=None, max_length=8)
     webhook_headers: Optional[str] = Field(sa_column=Column(Text), default=None)
-    # Webhook-only: inline the full AI analyst report (markdown + recommended
-    # actions + IOCs) in the dispatched JSON payload. Default False; NULL on
-    # legacy/shuffle rows reads back as falsy.
     include_full_report: Optional[bool] = Field(default=False)
 
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)

--- a/backend/app/notifications/channels/base.py
+++ b/backend/app/notifications/channels/base.py
@@ -17,6 +17,7 @@ before a migration commits data to it.
 
 from __future__ import annotations
 
+import json
 from abc import ABC
 from abc import abstractmethod
 from typing import Any
@@ -25,8 +26,11 @@ from typing import Callable
 from typing import ClassVar
 from typing import Dict
 from typing import Optional
+from typing import Set
+from typing import Type
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.notifications.schema.events import NotificationEvent
@@ -80,6 +84,17 @@ class DispatchContext:
         return self._memo[key]
 
 
+class ChannelConfig(BaseModel):
+    """Base for a provider's ``config`` shape.
+
+    ``extra="forbid"`` on purpose: a typo'd key should be a 400 at save time,
+    not a setting that silently does nothing until someone debugs why their
+    webhook has no auth header.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ChannelProvider(ABC):
     """One delivery channel.
 
@@ -92,6 +107,37 @@ class ChannelProvider(ABC):
 
     #: Human label for the route form's channel picker.
     display_name: ClassVar[str]
+
+    #: Validates ``customer_notification_route.config``. The API validates
+    #: against this at save time and the route form renders from its JSON
+    #: schema, so a new channel needs neither a migration nor bespoke form work.
+    config_schema: ClassVar[Type[ChannelConfig]]
+
+    #: Which ``recipient_mode`` values make sense here. A webhook targets a
+    #: fixed URL so it cannot resolve an assignee; email can.
+    supports_recipient_modes: ClassVar[Set[str]] = {"static"}
+
+    #: Config keys holding secrets. Encrypted at rest and redacted on read in
+    #: #1020; declared here so providers own the classification.
+    secret_fields: ClassVar[Set[str]] = set()
+
+    def parse_config(self, route: Any) -> ChannelConfig:
+        """Validate and return this route's config.
+
+        Raises ``ValueError`` on malformed JSON or a shape mismatch. Providers
+        call this at the top of ``send`` and convert failures into a logged
+        per-route failure rather than letting them abort the batch.
+        """
+        raw = getattr(route, "config", None)
+        if not raw:
+            return self.config_schema()
+        try:
+            data = json.loads(raw)
+        except ValueError as e:
+            raise ValueError(f"config is not valid JSON: {e}") from e
+        if not isinstance(data, dict):
+            raise ValueError("config must be a JSON object")
+        return self.config_schema.model_validate(data)
 
     @abstractmethod
     async def send(

--- a/backend/app/notifications/channels/shuffle.py
+++ b/backend/app/notifications/channels/shuffle.py
@@ -22,6 +22,7 @@ from sqlalchemy import update
 
 from app.connectors.utils import get_connector_info_from_db
 from app.db.universal_models import CustomerShuffleIntegration
+from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
 from app.notifications.channels.base import SendResult
@@ -62,9 +63,26 @@ async def get_shuffle_connector(session) -> Tuple[str, str]:
     return (base_url, api_key)
 
 
+class ShuffleConfig(ChannelConfig):
+    """`customer_notification_route.config` when channel='shuffle'.
+
+    `app_id` is the Shuffle app UUID we POST to /api/v1/apps/{id}/mcp;
+    `app_name` is the human label ("Slack") cached so the route list renders
+    without a round-trip to Shuffle.
+
+    The org lives on `shuffle_integration_id`, which stays a real FK column —
+    see the note on the model.
+    """
+
+    app_id: Optional[str] = None
+    app_name: Optional[str] = None
+
+
 class ShuffleChannel(ChannelProvider):
     key = "shuffle"
     display_name = "Shuffle"
+    config_schema = ShuffleConfig
+    supports_recipient_modes = {"static"}
 
     async def send(
         self,
@@ -76,9 +94,15 @@ class ShuffleChannel(ChannelProvider):
     ) -> SendResult:
         # Read every attribute before the first await — an expired ORM object
         # would otherwise trigger a synchronous refresh and MissingGreenlet.
-        app_id = route.shuffle_app_id
         integration_id = route.shuffle_integration_id
         destination = route.destination
+        try:
+            cfg = self.parse_config(route)
+        except ValueError as e:
+            # A malformed config is a data-integrity problem on one route; log
+            # it against that route rather than failing the whole batch.
+            return SendResult.failed(f"Invalid shuffle config: {e}")
+        app_id = cfg.app_id
 
         # Memoized per dispatch call: several Shuffle routes for one customer
         # share a single connector read, matching the pre-refactor behaviour.
@@ -95,7 +119,7 @@ class ShuffleChannel(ChannelProvider):
         if creds is None:
             return SendResult.failed("Shuffle connector unavailable")
         if not app_id:
-            return SendResult.failed("Route has no shuffle_app_id (data integrity issue)")
+            return SendResult.failed("Route config has no app_id (data integrity issue)")
 
         integration = await ctx.session.get(CustomerShuffleIntegration, integration_id)
         if not integration or integration.customer_code != event.customer_code:

--- a/backend/app/notifications/channels/webhook.py
+++ b/backend/app/notifications/channels/webhook.py
@@ -16,7 +16,9 @@ from typing import Dict
 from typing import Optional
 
 from loguru import logger
+from pydantic import field_validator
 
+from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
 from app.notifications.channels.base import SendResult
@@ -81,9 +83,37 @@ async def build_full_report(alert_id: int, session) -> Optional[Dict[str, Any]]:
     }
 
 
+class WebhookConfig(ChannelConfig):
+    """`customer_notification_route.config` when channel='webhook'.
+
+    `headers` is a real dict here, unlike the legacy `webhook_headers` column,
+    which stored a JSON *string* inside a Text column and needed hand-decoding
+    on every read.
+    """
+
+    url: Optional[str] = None
+    method: str = "POST"
+    headers: Optional[Dict[str, str]] = None
+    include_full_report: bool = False
+
+    @field_validator("method")
+    @classmethod
+    def _method_supported(cls, v: str) -> str:
+        upper = (v or "POST").upper()
+        if upper not in {"POST", "PUT"}:
+            raise ValueError("method must be POST or PUT")
+        return upper
+
+
 class WebhookChannel(ChannelProvider):
     key = "webhook"
     display_name = "Webhook"
+    config_schema = WebhookConfig
+    # A webhook targets a fixed URL, so it cannot deliver to a resolved
+    # assignee — that needs an addressable channel like email.
+    supports_recipient_modes = {"static"}
+    # Authorization / X-API-Key and friends live here; encrypted in #1020.
+    secret_fields = {"headers"}
 
     async def send(
         self,
@@ -95,14 +125,21 @@ class WebhookChannel(ChannelProvider):
     ) -> SendResult:
         # Read every attribute before the first await — an expired ORM object
         # would otherwise trigger a synchronous refresh and MissingGreenlet.
-        url = route.webhook_url
-        method = route.webhook_method
-        raw_headers = route.webhook_headers
-        include_full_report = bool(route.include_full_report)
         has_template = bool(route.format_template)
+        try:
+            cfg = self.parse_config(route)
+        except ValueError as e:
+            # A malformed config is a data-integrity problem on one route; log
+            # it against that route rather than failing the whole batch.
+            return SendResult.failed(f"Invalid webhook config: {e}")
+
+        url = cfg.url
+        method = cfg.method
+        headers = cfg.headers
+        include_full_report = cfg.include_full_report
 
         if not url:
-            return SendResult.failed("Route has no webhook_url (data integrity issue)")
+            return SendResult.failed("Route config has no url (data integrity issue)")
 
         # Structured default payload — automation platforms consume these fields
         # directly, so the names and null-vs-empty semantics are load-bearing.
@@ -139,7 +176,7 @@ class WebhookChannel(ChannelProvider):
         status, error_message, latency_ms, _ = await dispatch_webhook(
             url=url,
             method=method or "POST",
-            headers=decode_webhook_headers(raw_headers),
+            headers=headers,
             structured_payload=structured_payload,
             rendered_template=rendered_template,
         )

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -27,6 +27,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.models.users import User
 from app.auth.utils import AuthHandler
 from app.db.db_session import get_db
+from app.notifications.channels import CHANNEL_REGISTRY
+from app.notifications.schema.notifications import ChannelDescriptor
+from app.notifications.schema.notifications import ChannelListResponse
 from app.notifications.schema.notifications import DispatchLogListResponse
 from app.notifications.schema.notifications import DispatchRequest
 from app.notifications.schema.notifications import DispatchResponse
@@ -129,6 +132,35 @@ async def delete_route_route(
 ) -> dict:
     await svc.delete_route(route_id, customer_code, session)
     return {"success": True, "message": "Route deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Channel catalog
+# ---------------------------------------------------------------------------
+
+
+@notifications_router.get(
+    "/notification_channels",
+    response_model=ChannelListResponse,
+    description=(
+        "Delivery channels this deployment supports, with each one's config JSON Schema. "
+        "The route form renders generic inputs from the schema for channels without a "
+        "bespoke block, so adding a channel needs no frontend change."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def list_channels_route() -> ChannelListResponse:
+    channels = [
+        ChannelDescriptor(
+            key=provider.key,
+            display_name=provider.display_name,
+            config_schema=provider.config_schema.model_json_schema(),
+            supports_recipient_modes=sorted(provider.supports_recipient_modes),
+            secret_fields=sorted(provider.secret_fields),
+        )
+        for provider in CHANNEL_REGISTRY.values()
+    ]
+    return ChannelListResponse(success=True, message=f"{len(channels)} channel(s) retrieved", channels=channels)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -10,8 +10,10 @@ purely for input validation at the API boundary.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from enum import Enum
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -19,6 +21,7 @@ from typing import Optional
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import ValidationError as PydanticValidationError
 from pydantic import field_validator
 from pydantic import model_validator
 
@@ -81,6 +84,31 @@ class NotificationSeverity(str, Enum):
     MEDIUM = "Medium"
     LOW = "Low"
     INFORMATIONAL = "Informational"
+
+
+class NotificationScope(str, Enum):
+    """Who a route serves.
+
+    CUSTOMER routes deliver to the end customer and carry a customer_code.
+    INTERNAL routes deliver to the SOC, belong to no tenant, and are where
+    assignment notifications land — an ACME alert assigned to an analyst should
+    reach the analyst, not ACME's Slack.
+    """
+
+    CUSTOMER = "customer"
+    INTERNAL = "internal"
+
+
+class RecipientMode(str, Enum):
+    """Where the destination comes from.
+
+    STATIC reads it from the route's `config`. ASSIGNEE resolves the event's
+    assignee to their email at dispatch time, and is only valid on channels
+    that declare support for it.
+    """
+
+    STATIC = "static"
+    ASSIGNEE = "assignee"
 
 
 class DispatchStatus(str, Enum):
@@ -153,15 +181,14 @@ class NotificationRouteBase(BaseModel):
             return NotificationTrigger.INVESTIGATION_COMPLETE.value
         return v
 
-    # For Shuffle: free-form destination hint (e.g. '#soc-alerts',
-    # 'ir@corp.com') that gets injected into Shuffle's natural-language
-    # input — Shuffle's app agent figures out how to route it within the
-    # authenticated app. For webhook: optional, unused by the dispatcher
-    # (the URL is the real target); kept as a human label only. Required
-    # for Shuffle, optional for webhook — enforced in the model validator.
+    # Free-form destination hint. Shuffle injects it into the app agent's
+    # natural-language input ("send to #soc-alerts"); other channels ignore it
+    # and keep it as a human label. Deliberately NOT moved into `config` — it is
+    # NOT NULL in the DB and shared across channels, and dropping a seventh
+    # column would add migration risk for marginal tidiness.
     destination: Optional[str] = Field(
         default=None,
-        description="Destination hint for the Shuffle app (channel name, email address, handle). Optional for webhook routes.",
+        description="Destination hint for the Shuffle app (channel name, email address, handle). Unused by other channels.",
     )
     min_severity: NotificationSeverity = NotificationSeverity.MEDIUM
     format_template: Optional[str] = Field(
@@ -170,49 +197,36 @@ class NotificationRouteBase(BaseModel):
     )
     enabled: bool = True
 
-    # Phase 2: Shuffle routing target. Required when channel='shuffle'.
-    # The integration row scopes the dispatch to a specific customer
-    # Shuffle org; the app id + name describe which app within that
-    # org receives the natural-language input.
+    # Which audience this route serves. 'customer' delivers to the end
+    # customer; 'internal' delivers to the SOC and belongs to no tenant, which
+    # is where assignment notifications go so analyst chatter never reaches a
+    # customer's channel.
+    scope: NotificationScope = NotificationScope.CUSTOMER
+
+    # 'static' takes the destination from `config`; 'assignee' resolves the
+    # event's assignee to their email at dispatch time. Validated against the
+    # provider's supports_recipient_modes.
+    recipient_mode: RecipientMode = RecipientMode.STATIC
+
+    notify_on_self_assign: bool = Field(
+        default=False,
+        description="Notify the assignee even when they assigned it to themselves.",
+    )
+
+    # Shuffle's org lives on a real FK column rather than inside `config`,
+    # because burying an FK in JSON gives up referential integrity and the
+    # cross-tenant check the dispatcher performs at send time.
     shuffle_integration_id: Optional[int] = Field(
         default=None,
         description="ID of the customer_shuffle_integration row (required when channel='shuffle').",
     )
-    shuffle_app_id: Optional[str] = Field(default=None, description="Shuffle app UUID (required when channel='shuffle').")
-    shuffle_app_name: Optional[str] = Field(
-        default=None,
-        description="Human-readable Shuffle app name cached for the UI list (e.g. 'Slack').",
-    )
 
-    # Webhook routing target. Required when channel='webhook'. The
-    # dispatcher POSTs (or PUTs) to `webhook_url` with the structured
-    # payload, or the rendered `format_template` if one is set. Custom
-    # headers carry auth (Authorization / X-API-Key / …).
-    webhook_url: Optional[str] = Field(
-        default=None,
-        description="Target URL for direct webhook delivery (required when channel='webhook'). Must be http(s).",
-    )
-    # Optional (not just defaulted) so reading back a non-webhook route —
-    # whose column is NULL — doesn't fail validation. New webhook routes
-    # that omit it fall back to POST at dispatch time.
-    webhook_method: Optional[str] = Field(
-        default="POST",
-        pattern="^(POST|PUT)$",
-        description="HTTP method for webhook delivery. POST (default) or PUT.",
-    )
-    webhook_headers: Optional[Dict[str, str]] = Field(
-        default=None,
-        description="Optional custom request headers for webhook delivery (e.g. {'Authorization': 'Bearer …'}).",
-    )
-    # When True (webhook channel only), the dispatcher looks up the alert's
-    # latest AI analyst report + IOCs and merges the extra fields
-    # (recommended_actions, report_markdown, iocs, …) flat into the JSON
-    # payload — for downstream automation that wants the full analysis and
-    # IOC list rather than just the one-line summary. Default off so
-    # chat-target routes and the base payload stay lean.
-    include_full_report: bool = Field(
-        default=False,
-        description="Webhook only — inline the full AI report (markdown, recommended actions, IOCs) in the payload.",
+    # Per-channel settings, validated against the selected provider's
+    # config_schema. Replaces the old column-per-setting scheme, so a new
+    # channel needs no migration and no schema edit here.
+    config: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Channel-specific settings. Shape is defined by the selected channel's config schema.",
     )
 
     @field_validator("destination")
@@ -220,103 +234,121 @@ class NotificationRouteBase(BaseModel):
     def _strip_destination(cls, v: Optional[str]) -> Optional[str]:
         return v.strip() if v is not None else v
 
-    @field_validator("webhook_url")
+    @field_validator("config", mode="before")
     @classmethod
-    def _strip_webhook_url(cls, v: Optional[str]) -> Optional[str]:
-        return v.strip() if v is not None else v
+    def _parse_config(cls, v):
+        """Deserialize the DB's JSON-string column into a dict.
 
-    @field_validator("include_full_report", mode="before")
-    @classmethod
-    def _coerce_null_full_report(cls, v):
-        """Treat a NULL column value as False on read.
-
-        The column is nullable; the migration backfills `false`, but a
-        hand-edited or pre-backfill row could be NULL. Pydantic 2 would
-        reject NULL against the `bool` field and 500 the list endpoint,
-        so coerce it here rather than surface a strictness error.
+        `config` is a Text column for MySQL/SQLite portability, so an ORM row
+        yields a string. Pydantic 2 won't coerce it, and an unparsable value
+        must not 500 the list endpoint — fall back to an empty dict so a bad
+        row is visible in the UI rather than taking the whole page down.
         """
-        return False if v is None else v
-
-    @model_validator(mode="after")
-    def _channel_fields_required(self):
-        if self.channel == NotificationChannel.SHUFFLE:
-            if not self.shuffle_integration_id:
-                raise ValueError("shuffle_integration_id is required when channel='shuffle'")
-            if not self.shuffle_app_id:
-                raise ValueError("shuffle_app_id is required when channel='shuffle'")
-            if not self.destination:
-                raise ValueError("destination is required when channel='shuffle'")
-        elif self.channel == NotificationChannel.WEBHOOK:
-            if not self.webhook_url:
-                raise ValueError("webhook_url is required when channel='webhook'")
-            if not self.webhook_url.lower().startswith(("http://", "https://")):
-                raise ValueError("webhook_url must start with http:// or https://")
-        return self
+        if v is None:
+            return {}
+        if isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            if not v.strip():
+                return {}
+            try:
+                parsed = json.loads(v)
+            except ValueError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
 
 
 class NotificationRouteCreate(NotificationRouteBase):
-    """Body for POST /customers/{code}/notification_routes."""
+    """Body for POST /customers/{code}/notification_routes.
+
+    Write-time validation lives here rather than on the shared base: reads must
+    stay lenient so a legacy or hand-edited row surfaces in the UI instead of
+    500-ing the whole list.
+    """
+
+    @model_validator(mode="after")
+    def _validate_against_provider(self):
+        """Validate `config` against the channel's declared schema.
+
+        Replaces the hand-written per-channel field checks. Import is local to
+        avoid a cycle: the channels package imports this module for the event
+        envelope's enums.
+        """
+        from app.notifications.channels import get_channel
+
+        provider = get_channel(self.channel.value)
+        if provider is None:
+            raise ValueError(f"Unsupported channel: {self.channel.value}")
+
+        try:
+            parsed = provider.config_schema.model_validate(self.config or {})
+        except PydanticValidationError as e:
+            raise ValueError(f"Invalid config for channel '{self.channel.value}': {e}") from e
+
+        # Normalize back so defaults (e.g. webhook method 'POST') are persisted
+        # rather than left implicit.
+        self.config = parsed.model_dump()
+
+        if self.recipient_mode.value not in provider.supports_recipient_modes:
+            raise ValueError(
+                f"Channel '{self.channel.value}' does not support recipient_mode "
+                f"'{self.recipient_mode.value}' (supported: {sorted(provider.supports_recipient_modes)})",
+            )
+
+        # Channel-specific requirements the generic schema can't express,
+        # because they involve columns outside `config`.
+        if self.channel == NotificationChannel.SHUFFLE:
+            if not self.shuffle_integration_id:
+                raise ValueError("shuffle_integration_id is required when channel='shuffle'")
+            if not self.config.get("app_id"):
+                raise ValueError("config.app_id is required when channel='shuffle'")
+            if not self.destination:
+                raise ValueError("destination is required when channel='shuffle'")
+        elif self.channel == NotificationChannel.WEBHOOK:
+            url = self.config.get("url")
+            if not url:
+                raise ValueError("config.url is required when channel='webhook'")
+            if not str(url).lower().startswith(("http://", "https://")):
+                raise ValueError("config.url must start with http:// or https://")
+        return self
 
 
 class NotificationRouteUpdate(BaseModel):
     """Body for PATCH — every field optional. Mirrors the editable subset
-    of NotificationRouteBase."""
+    of NotificationRouteBase.
+
+    `config` is replaced wholesale rather than merged: a partial merge makes
+    "remove this header" impossible to express, and the form always holds the
+    complete channel config anyway. It is validated against the *resulting*
+    channel in the service layer, which knows the row's current channel when
+    the PATCH doesn't change it.
+    """
 
     name: Optional[str] = Field(default=None, min_length=1, max_length=128)
     trigger: Optional[NotificationTrigger] = None
     channel: Optional[NotificationChannel] = None
-    destination: Optional[str] = Field(default=None, min_length=1)
+    destination: Optional[str] = None
     min_severity: Optional[NotificationSeverity] = None
     format_template: Optional[str] = None
     enabled: Optional[bool] = None
-    # Shuffle target — included on PATCH so admins can re-point a route
-    # at a different integration / app without recreating it.
+    scope: Optional[NotificationScope] = None
+    recipient_mode: Optional[RecipientMode] = None
+    notify_on_self_assign: Optional[bool] = None
     shuffle_integration_id: Optional[int] = None
-    shuffle_app_id: Optional[str] = None
-    shuffle_app_name: Optional[str] = None
-    # Webhook target — included on PATCH so admins can re-point a route
-    # at a different URL / method / headers without recreating it.
-    webhook_url: Optional[str] = None
-    webhook_method: Optional[str] = Field(default=None, pattern="^(POST|PUT)$")
-    webhook_headers: Optional[Dict[str, str]] = None
-    include_full_report: Optional[bool] = None
+    config: Optional[Dict[str, Any]] = None
 
 
 class NotificationRouteRead(NotificationRouteBase):
     id: int
-    customer_code: str
+    # None on internal-scope routes, which belong to no tenant.
+    customer_code: Optional[str] = None
     last_dispatched_at: Optional[datetime] = None
     dispatch_count: int = 0
     created_by: Optional[str] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
     model_config = ConfigDict(from_attributes=True)
-
-    @field_validator("webhook_headers", mode="before")
-    @classmethod
-    def _parse_webhook_headers(cls, v):
-        """Deserialize the DB's JSON-string column into a dict.
-
-        The `webhook_headers` ORM column stores a JSON string; this Read
-        schema exposes it as a dict. Pydantic 2 won't coerce a JSON
-        string to a dict on its own, so we parse it here. Tolerates the
-        already-dict case (when the schema is built from a payload
-        rather than an ORM row) and bad/empty values (→ None).
-        """
-        if v is None or isinstance(v, dict):
-            return v
-        if isinstance(v, str):
-            v = v.strip()
-            if not v:
-                return None
-            try:
-                import json
-
-                parsed = json.loads(v)
-                return parsed if isinstance(parsed, dict) else None
-            except ValueError:
-                return None
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +457,28 @@ class ShuffleOrgListResponse(BaseModel):
     success: bool = True
     message: str = "Orgs retrieved"
     orgs: List[ShuffleOrg]
+
+
+class ChannelDescriptor(BaseModel):
+    """One delivery channel, as the route form needs to see it.
+
+    `config_schema` is the provider's Pydantic model rendered as JSON Schema.
+    The form uses it two ways: to render generic inputs for channels that have
+    no hand-written block (so a new channel needs no frontend work), and to
+    label/validate the ones that do.
+    """
+
+    key: str
+    display_name: str
+    config_schema: Dict[str, Any]
+    supports_recipient_modes: List[str]
+    secret_fields: List[str]
+
+
+class ChannelListResponse(BaseModel):
+    success: bool = True
+    message: str = "Channels retrieved"
+    channels: List[ChannelDescriptor]
 
 
 class NotificationRouteListResponse(BaseModel):

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -21,6 +21,7 @@ from typing import Optional
 
 from fastapi import HTTPException
 from loguru import logger
+from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy import desc
 from sqlalchemy import select
 from sqlalchemy import update
@@ -47,6 +48,7 @@ from app.notifications.schema.notifications import DispatchStatus
 from app.notifications.schema.notifications import NotificationChannel
 from app.notifications.schema.notifications import NotificationRouteCreate
 from app.notifications.schema.notifications import NotificationRouteUpdate
+from app.notifications.schema.notifications import NotificationScope
 from app.notifications.schema.notifications import NotificationTrigger
 from app.notifications.schema.notifications import ShuffleApp
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
@@ -92,6 +94,53 @@ async def get_route(route_id: int, customer_code: str, session: AsyncSession) ->
     return route
 
 
+def _legacy_columns_from_config(channel: str, config: dict) -> dict:
+    """Mirror `config` back onto the pre-#1018 per-channel columns.
+
+    Nothing reads these — the providers read `config`. They are dual-written for
+    one release so that reverting this change is lossless and #1018b can diff
+    the two representations against real rows before dropping the columns.
+
+    Deleted along with the columns in #1018b.
+    """
+    if channel == NotificationChannel.WEBHOOK.value:
+        headers = config.get("headers")
+        return {
+            "webhook_url": config.get("url"),
+            "webhook_method": config.get("method") or "POST",
+            "webhook_headers": json.dumps(headers) if headers else None,
+            "include_full_report": bool(config.get("include_full_report")),
+            "shuffle_app_id": None,
+            "shuffle_app_name": None,
+        }
+    if channel == NotificationChannel.SHUFFLE.value:
+        return {
+            "shuffle_app_id": config.get("app_id"),
+            "shuffle_app_name": config.get("app_name"),
+            "webhook_url": None,
+            "webhook_method": None,
+            "webhook_headers": None,
+            "include_full_report": False,
+        }
+    return {}
+
+
+def _enforce_scope_invariant(scope: str, customer_code: Optional[str]) -> Optional[str]:
+    """A customer route must name a tenant; an internal route must not.
+
+    Returning the coerced code keeps the two callers from drifting. Raising a
+    400 rather than silently fixing it: a client sending scope='internal' with a
+    customer_code has a bug worth surfacing.
+    """
+    if scope == NotificationScope.INTERNAL.value:
+        if customer_code:
+            raise HTTPException(status_code=400, detail="An internal-scope route must not name a customer.")
+        return None
+    if not customer_code:
+        raise HTTPException(status_code=400, detail="A customer-scope route requires a customer_code.")
+    return customer_code
+
+
 async def create_route(
     customer_code: str,
     payload: NotificationRouteCreate,
@@ -104,8 +153,13 @@ async def create_route(
     if payload.channel == NotificationChannel.SHUFFLE:
         await _ensure_integration_belongs_to_customer(payload.shuffle_integration_id, customer_code, session)
 
+    resolved_code = _enforce_scope_invariant(payload.scope.value, customer_code)
+
     route = CustomerNotificationRoute(
-        customer_code=customer_code,
+        customer_code=resolved_code,
+        scope=payload.scope.value,
+        recipient_mode=payload.recipient_mode.value,
+        notify_on_self_assign=payload.notify_on_self_assign,
         name=payload.name,
         trigger=payload.trigger.value,
         channel=payload.channel.value,
@@ -117,18 +171,9 @@ async def create_route(
         enabled=payload.enabled,
         created_by=created_by,
         shuffle_integration_id=payload.shuffle_integration_id,
-        shuffle_app_id=payload.shuffle_app_id,
-        shuffle_app_name=payload.shuffle_app_name,
-        # Only persist webhook columns for webhook routes — leave them
-        # NULL on shuffle routes so a read-back doesn't surface a
-        # spurious method/url on a route that doesn't use them.
-        webhook_url=payload.webhook_url if payload.channel == NotificationChannel.WEBHOOK else None,
-        webhook_method=(payload.webhook_method or "POST") if payload.channel == NotificationChannel.WEBHOOK else None,
-        # Headers are stored as a JSON string in a Text column.
-        webhook_headers=(
-            json.dumps(payload.webhook_headers) if payload.channel == NotificationChannel.WEBHOOK and payload.webhook_headers else None
-        ),
-        include_full_report=(payload.include_full_report if payload.channel == NotificationChannel.WEBHOOK else False),
+        config=json.dumps(payload.config or {}),
+        # Dual-written for one release; see _legacy_columns_from_config.
+        **_legacy_columns_from_config(payload.channel.value, payload.config or {}),
     )
     session.add(route)
     await session.commit()
@@ -161,19 +206,64 @@ async def update_route(
     if new_channel_value == NotificationChannel.SHUFFLE.value and new_integration_id:
         await _ensure_integration_belongs_to_customer(new_integration_id, customer_code, session)
 
+    # `config` is validated against the channel the route will HAVE after this
+    # PATCH — which may be the row's current channel when the PATCH doesn't
+    # change it. NotificationRouteUpdate can't do this itself: it has no view of
+    # the stored row.
+    if "config" in data or "channel" in data or "recipient_mode" in data:
+        provider = get_channel(new_channel_value)
+        if provider is None:
+            raise HTTPException(status_code=400, detail=f"Unsupported channel: {new_channel_value}")
+        raw_config = data.get("config")
+        if raw_config is None and "config" not in data:
+            # Channel changed but config didn't — re-validate what's stored, so
+            # switching to a channel the existing config can't satisfy is caught
+            # here rather than at dispatch time.
+            raw_config = json.loads(route.config) if route.config else {}
+        try:
+            data["config"] = provider.config_schema.model_validate(raw_config or {}).model_dump()
+        except PydanticValidationError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid config for channel '{new_channel_value}': {e}") from e
+
+        mode = data.get("recipient_mode")
+        mode_value = mode.value if hasattr(mode, "value") else (mode or route.recipient_mode)
+        if mode_value not in provider.supports_recipient_modes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Channel '{new_channel_value}' does not support recipient_mode '{mode_value}' "
+                    f"(supported: {sorted(provider.supports_recipient_modes)})"
+                ),
+            )
+
+    # Scope and customer_code have to move together.
+    new_scope = data.get("scope")
+    new_scope_value = new_scope.value if hasattr(new_scope, "value") else (new_scope or route.scope)
+    if "scope" in data:
+        data["customer_code"] = _enforce_scope_invariant(
+            new_scope_value,
+            None if new_scope_value == NotificationScope.INTERNAL.value else (route.customer_code or customer_code),
+        )
+
     for field, value in data.items():
         # Enums: write the underlying string into the DB column.
         if hasattr(value, "value"):
             value = value.value
-        # webhook_headers is a dict in the schema but a JSON-string
-        # column in the DB — encode on the way in.
-        if field == "webhook_headers":
-            value = json.dumps(value) if value else None
+        # config is a dict in the schema but a JSON-string column in the DB.
+        if field == "config":
+            value = json.dumps(value or {})
         # destination is NOT NULL in the DB; a webhook PATCH legitimately
         # sends it as null (webhooks don't use it) — coalesce to "".
         if field == "destination" and value is None:
             value = ""
         setattr(route, field, value)
+
+    # Keep the legacy columns in step with config; see the helper's note.
+    if "config" in data or "channel" in data:
+        final_config = json.loads(route.config) if route.config else {}
+        for column, mirrored in _legacy_columns_from_config(route.channel, final_config).items():
+            setattr(route, column, mirrored)
+
     route.updated_at = datetime.utcnow()
 
     await session.commit()

--- a/backend/tests/test_notification_channel_registry.py
+++ b/backend/tests/test_notification_channel_registry.py
@@ -59,37 +59,35 @@ def _ctx(event, session=None):
     return DispatchContext(session=session or AsyncMock(), event=event)
 
 
-def _webhook_route(**over):
+def _webhook_route(config=None, **over):
+    """A webhook route. Channel settings now live in the JSON `config` column
+    rather than a column per setting."""
+    cfg = {"url": "https://example.invalid/hook", "method": "POST", "include_full_report": False}
+    cfg.update(config or {})
     base = dict(
         id=1,
         name="SOC webhook",
         channel="webhook",
         destination="",
         format_template=None,
-        webhook_url="https://example.invalid/hook",
-        webhook_method="POST",
-        webhook_headers=None,
-        include_full_report=False,
-        shuffle_app_id=None,
+        config=json.dumps(cfg),
         shuffle_integration_id=None,
     )
     base.update(over)
     return SimpleNamespace(**base)
 
 
-def _shuffle_route(**over):
+def _shuffle_route(config=None, **over):
+    cfg = {"app_id": "app-uuid", "app_name": "Slack"}
+    cfg.update(config or {})
     base = dict(
         id=2,
         name="SOC slack",
         channel="shuffle",
         destination="#soc-alerts",
         format_template=None,
-        shuffle_app_id="app-uuid",
+        config=json.dumps(cfg),
         shuffle_integration_id=7,
-        webhook_url=None,
-        webhook_method=None,
-        webhook_headers=None,
-        include_full_report=False,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -173,21 +171,21 @@ def test_webhook_preserves_none_for_absent_optional_fields():
 
 
 def test_webhook_defaults_method_to_post():
-    _result, kwargs = _run_webhook(_webhook_route(webhook_method=None))
+    _result, kwargs = _run_webhook(_webhook_route(config={"method": "POST"}))
     assert kwargs["method"] == "POST"
 
 
 def test_webhook_missing_url_fails_with_the_original_message():
-    result, kwargs = _run_webhook(_webhook_route(webhook_url=None))
+    result, kwargs = _run_webhook(_webhook_route(config={"url": None}))
     assert result.status == "failed"
-    assert result.error_message == "Route has no webhook_url (data integrity issue)"
+    assert result.error_message == "Route config has no url (data integrity issue)"
     assert kwargs is None, "must not attempt delivery"
 
 
 def test_webhook_include_full_report_merges_flat_and_ignores_template():
     report = {"report_id": 9, "recommended_actions": "isolate", "iocs": []}
     _result, kwargs = _run_webhook(
-        _webhook_route(include_full_report=True, format_template="ignored {{summary}}"),
+        _webhook_route(config={"include_full_report": True}, format_template="ignored {{summary}}"),
         report=report,
     )
 
@@ -198,7 +196,7 @@ def test_webhook_include_full_report_merges_flat_and_ignores_template():
 
 def test_webhook_missing_report_still_sends_base_payload():
     """A dispatch must not fail just because report write-back hasn't landed."""
-    _result, kwargs = _run_webhook(_webhook_route(include_full_report=True), report=None)
+    _result, kwargs = _run_webhook(_webhook_route(config={"include_full_report": True}), report=None)
 
     assert "report_id" not in kwargs["structured_payload"]
     assert kwargs["structured_payload"]["summary"] == "Credential dumping observed on WKSTN-04."
@@ -233,14 +231,52 @@ def test_webhook_template_report_token_substitutes_when_present_in_body():
     assert sent.await_args.kwargs["rendered_template"] == f"prefix {json.dumps(report)} suffix"
 
 
-def test_webhook_headers_are_decoded_from_the_json_column():
-    _result, kwargs = _run_webhook(_webhook_route(webhook_headers='{"Authorization": "Bearer x"}'))
+def test_webhook_headers_come_through_as_a_dict():
+    """Headers are a real dict in config, where the legacy column stored a JSON
+    string that needed hand-decoding on every read."""
+    _result, kwargs = _run_webhook(_webhook_route(config={"headers": {"Authorization": "Bearer x"}}))
     assert kwargs["headers"] == {"Authorization": "Bearer x"}
 
 
-def test_webhook_malformed_headers_do_not_abort_the_dispatch():
-    _result, kwargs = _run_webhook(_webhook_route(webhook_headers="{not json"))
+def test_webhook_absent_headers_are_none():
+    _result, kwargs = _run_webhook(_webhook_route())
     assert kwargs["headers"] is None
+
+
+def test_malformed_config_fails_the_route_rather_than_the_batch():
+    """BEHAVIOUR CHANGE from the per-column scheme.
+
+    Malformed `webhook_headers` used to be swallowed — headers became None and
+    the dispatch went out anyway. `config` carries the whole channel setup, so
+    an unparseable one means we don't know the URL either; sending a
+    half-configured request is worse than recording a failure. Config is
+    validated at save time now, so reaching this needs a hand-edited row.
+
+    It must still fail only THIS route, not raise into the dispatch loop.
+    """
+    result, kwargs = _run_webhook(
+        _webhook_route(),
+    )
+    # sanity: the well-formed case succeeds
+    assert result.status == "sent"
+
+    broken = _webhook_route()
+    broken.config = "{not json"
+    result, kwargs = _run_webhook(broken)
+
+    assert result.status == "failed"
+    assert "Invalid webhook config" in result.error_message
+    assert kwargs is None, "must not attempt delivery on a config we cannot read"
+
+
+def test_config_with_unknown_key_is_rejected():
+    """extra='forbid' — a typo'd key should surface, not silently do nothing."""
+    broken = _webhook_route()
+    broken.config = json.dumps({"url": "https://x.invalid", "heders": {"a": "b"}})
+    result, kwargs = _run_webhook(broken)
+
+    assert result.status == "failed"
+    assert kwargs is None
 
 
 # ── shuffle: statuses and tenancy ─────────────────────────────────────────
@@ -316,9 +352,9 @@ def test_shuffle_disabled_integration_is_skipped_not_failed():
 
 
 def test_shuffle_missing_app_id_fails_with_the_original_message():
-    result, _kwargs = _run_shuffle(_shuffle_route(shuffle_app_id=None), _integration())
+    result, _kwargs = _run_shuffle(_shuffle_route(config={"app_id": None}), _integration())
     assert result.status == "failed"
-    assert result.error_message == "Route has no shuffle_app_id (data integrity issue)"
+    assert result.error_message == "Route config has no app_id (data integrity issue)"
 
 
 def test_shuffle_connector_error_surfaces_the_connector_detail():
@@ -376,7 +412,7 @@ def test_report_is_read_once_across_routes_in_one_dispatch():
         for _ in range(3):
             asyncio.run(
                 CHANNEL_REGISTRY["webhook"].send(
-                    route=_webhook_route(include_full_report=True),
+                    route=_webhook_route(config={"include_full_report": True}),
                     event=event,
                     rendered_body="B",
                     ctx=ctx,

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -1,5 +1,6 @@
 import type { FlaskBaseResponse } from "@/types/flask"
 import type {
+	NotificationChannelDescriptor,
 	NotificationDispatchLogEntry,
 	NotificationRoute,
 	NotificationRoutePayload,
@@ -40,6 +41,15 @@ export default {
 
 	deleteRoute(customerCode: string, routeId: number) {
 		return HttpClient.delete<FlaskBaseResponse>(`/customers/${customerCode}/notification_routes/${routeId}`)
+	},
+
+	// The channel catalog is deployment-wide, not per-customer: it advertises
+	// what this build supports plus each channel's config JSON Schema, which the
+	// route form renders generic inputs from for channels with no bespoke block.
+	getChannels() {
+		return HttpClient.get<FlaskBaseResponse & { channels: NotificationChannelDescriptor[] }>(
+			`/notification_channels`
+		)
 	},
 
 	listDispatchLog(customerCode: string) {

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -53,9 +53,9 @@
 				</template>
 			</n-form-item>
 
-			<n-form-item label="Shuffle app" path="shuffle_app_id">
+			<n-form-item label="Shuffle app" path="config.app_id">
 				<n-select
-					v-model:value="form.shuffle_app_id"
+					v-model:value="cfg.app_id"
 					:options="appOptions"
 					placeholder="Pick an authenticated app"
 					:loading="loadingApps"
@@ -86,16 +86,16 @@
 		<!-- ===== Webhook channel fields ===== -->
 		<template v-else-if="isWebhook">
 			<div class="grid grid-cols-1 gap-4 md:grid-cols-[1fr_140px]">
-				<n-form-item label="Webhook URL" path="webhook_url">
+				<n-form-item label="Webhook URL" path="config.url">
 					<n-input
-						v-model:value="form.webhook_url"
+						v-model:value="cfg.url"
 						placeholder="https://example.com/webhook/abc-123"
 						type="text"
 					/>
 				</n-form-item>
 
-				<n-form-item label="Method" path="webhook_method">
-					<n-select v-model:value="form.webhook_method" :options="methodOptions" />
+				<n-form-item label="Method" path="config.method">
+					<n-select v-model:value="cfg.method" :options="methodOptions" />
 				</n-form-item>
 			</div>
 
@@ -118,7 +118,7 @@
 			</div>
 
 			<n-form-item :show-feedback="false">
-				<n-checkbox v-model:checked="form.include_full_report" :disabled="fullReportDisabled">
+				<n-checkbox v-model:checked="cfg.include_full_report" :disabled="fullReportDisabled">
 					Include full AI report
 				</n-checkbox>
 			</n-form-item>
@@ -230,6 +230,24 @@ const editing = computed(() => props.editingRoute !== null)
 type FeedbackField =
 	"channel" | "destination" | "min_severity" | "shuffle_app_id" | "shuffle_integration_id" | "webhook_url"
 
+// Channel settings live in a JSON `config` blob on the route, whose shape each
+// backend provider owns. The form keeps them in a flat reactive object and
+// serialises on submit, so adding a field to a provider's schema doesn't
+// require a matching field here.
+// Union of the keys the hand-written channel blocks below bind to. Channels
+// without a bespoke block are rendered generically from their advertised JSON
+// Schema instead, so this deliberately does NOT try to cover every channel.
+interface EditableChannelConfig {
+	app_id?: string | null
+	app_name?: string | null
+	url?: string | null
+	method?: string
+	headers?: Record<string, string> | null
+	include_full_report?: boolean
+}
+
+const cfg = reactive<EditableChannelConfig>({ ...(props.editingRoute?.config ?? {}) })
+
 const fieldErrors = reactive<Partial<Record<FeedbackField, string>>>({})
 
 const form = reactive<NotificationRoutePayload>({
@@ -240,12 +258,11 @@ const form = reactive<NotificationRoutePayload>({
 	min_severity: props.editingRoute?.min_severity ?? ("Medium" as NotificationSeverity),
 	format_template: props.editingRoute?.format_template ?? "",
 	enabled: props.editingRoute?.enabled ?? true,
+	scope: props.editingRoute?.scope ?? "customer",
+	recipient_mode: props.editingRoute?.recipient_mode ?? "static",
+	notify_on_self_assign: props.editingRoute?.notify_on_self_assign ?? false,
 	shuffle_integration_id: props.editingRoute?.shuffle_integration_id ?? null,
-	shuffle_app_id: props.editingRoute?.shuffle_app_id ?? null,
-	shuffle_app_name: props.editingRoute?.shuffle_app_name ?? null,
-	webhook_url: props.editingRoute?.webhook_url ?? null,
-	webhook_method: props.editingRoute?.webhook_method ?? "POST",
-	include_full_report: props.editingRoute?.include_full_report ?? false
+	config: {}
 })
 
 const isShuffle = computed(() => form.channel === "shuffle")
@@ -256,7 +273,7 @@ const isWebhook = computed(() => form.channel === "webhook")
 // template; writing a template disables the box. Each lane can still get
 // the report — the box for the structured payload, the {{report}} token
 // for the template.
-const templateDisabled = computed(() => isWebhook.value && form.include_full_report)
+const templateDisabled = computed(() => isWebhook.value && Boolean(cfg.include_full_report))
 const fullReportDisabled = computed(() => isWebhook.value && Boolean(form.format_template?.trim()))
 // Shown literally in the help text. Kept as a constant so the template
 // doesn't nest {{ }} inside an interpolation (Vue can't parse that).
@@ -265,8 +282,11 @@ const reportToken = "{{report}}"
 // Custom headers are edited as an ordered key/value list and converted to
 // a Record on submit. Seed from the editing route's stored headers.
 const headerPairs = ref<{ key: string; value: string }[]>(
-	props.editingRoute?.webhook_headers
-		? Object.entries(props.editingRoute.webhook_headers).map(([key, value]) => ({ key, value }))
+	props.editingRoute?.config?.headers
+		? Object.entries(props.editingRoute.config.headers as Record<string, string>).map(([key, value]) => ({
+				key,
+				value
+			}))
 		: []
 )
 
@@ -355,8 +375,8 @@ function onChannelChange(channel: NotificationChannel) {
 	clearFieldError("shuffle_app_id")
 	clearFieldError("destination")
 	clearFieldError("webhook_url")
-	if (channel === "webhook" && !form.webhook_method) {
-		form.webhook_method = "POST"
+	if (channel === "webhook" && !cfg.method) {
+		cfg.method = "POST"
 	}
 }
 
@@ -395,8 +415,8 @@ async function loadApps(integrationId: number) {
 
 async function onIntegrationChange(integrationId: number | null) {
 	apps.value = []
-	form.shuffle_app_id = null
-	form.shuffle_app_name = null
+	cfg.app_id = null
+	cfg.app_name = null
 	if (integrationId) {
 		await loadApps(integrationId)
 	}
@@ -406,7 +426,7 @@ function onAppChange(appId: string | null) {
 	// Cache the app's display name alongside the UUID so the UI list can
 	// render "Slack" instead of a UUID without re-fetching the catalog.
 	const app = apps.value.find(a => a.id === appId)
-	form.shuffle_app_name = app?.name ?? null
+	cfg.app_name = app?.name ?? null
 }
 
 const rules: FormRules = {
@@ -491,7 +511,7 @@ async function submit() {
 		// Full report and a custom template are mutually exclusive — if the
 		// box is ticked, never persist a template (the structured payload is
 		// sent). Keeps stored data consistent with the UI's grey-out.
-		const sendTemplate = isWebhook.value && form.include_full_report ? null : form.format_template?.trim() || null
+		const sendTemplate = isWebhook.value && Boolean(cfg.include_full_report) ? null : form.format_template?.trim() || null
 
 		const base = {
 			name: form.name,
@@ -499,31 +519,36 @@ async function submit() {
 			channel: form.channel,
 			min_severity: form.min_severity,
 			format_template: sendTemplate,
-			enabled: form.enabled
+			enabled: form.enabled,
+			scope: form.scope,
+			recipient_mode: form.recipient_mode,
+			notify_on_self_assign: form.notify_on_self_assign
 		}
 
+		// Build config from scratch per channel rather than sending the whole
+		// `cfg` object: switching channels leaves the other branch's keys in
+		// there, and the backend's config schemas use extra="forbid", so a
+		// leftover `url` on a shuffle route is a 400 rather than a no-op.
 		const payload: NotificationRoutePayload = isWebhook.value
 			? {
 					...base,
 					destination: null,
-					webhook_url: form.webhook_url?.trim() || null,
-					webhook_method: form.webhook_method || "POST",
-					webhook_headers: buildHeaders(),
-					include_full_report: form.include_full_report,
 					shuffle_integration_id: null,
-					shuffle_app_id: null,
-					shuffle_app_name: null
+					config: {
+						url: cfg.url?.trim() || null,
+						method: cfg.method || "POST",
+						headers: buildHeaders(),
+						include_full_report: Boolean(cfg.include_full_report)
+					}
 				}
 			: {
 					...base,
 					destination: form.destination,
 					shuffle_integration_id: form.shuffle_integration_id,
-					shuffle_app_id: form.shuffle_app_id,
-					shuffle_app_name: form.shuffle_app_name,
-					webhook_url: null,
-					webhook_method: null,
-					webhook_headers: null,
-					include_full_report: false
+					config: {
+						app_id: cfg.app_id ?? null,
+						app_name: cfg.app_name ?? null
+					}
 				}
 
 		const res = props.editingRoute

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
@@ -26,8 +26,8 @@
 			<div class="flex flex-col gap-3 text-sm">
 				<div class="flex flex-col gap-0.5 text-sm">
 					<div v-if="isWebhook" class="flex flex-wrap gap-1">
-						<span class="font-medium">{{ route.webhook_method || "POST" }} to:</span>
-						<code class="break-all">{{ route.webhook_url }}</code>
+						<span class="font-medium">{{ webhookConfig.method || "POST" }} to:</span>
+						<code class="break-all">{{ webhookConfig.url }}</code>
 					</div>
 					<div v-else class="flex flex-wrap gap-1">
 						<span class="font-medium">Destination:</span>
@@ -39,7 +39,7 @@
 						<span class="font-medium">Custom headers:</span>
 						<span class="italic">configured</span>
 					</div>
-					<div v-if="isWebhook && route.include_full_report" class="flex flex-wrap gap-1">
+					<div v-if="isWebhook && webhookConfig.include_full_report" class="flex flex-wrap gap-1">
 						<span class="font-medium">Full AI report:</span>
 						<span class="italic">included</span>
 					</div>
@@ -110,7 +110,7 @@
 
 <script setup lang="ts">
 import type { ApiError } from "@/types/common"
-import type { NotificationRoute } from "@/types/notifications"
+import type { NotificationRoute, WebhookChannelConfig } from "@/types/notifications"
 import _split from "lodash/split"
 import { NButton, NPopconfirm, useMessage } from "naive-ui"
 import { computed, ref } from "vue"
@@ -124,6 +124,11 @@ import { formatDate } from "@/utils/format"
 
 const props = defineProps<{
 	route: NotificationRoute
+	// Passed down rather than read off the route: `customer_code` is nullable
+	// now (internal-scope routes belong to no tenant), while the API paths below
+	// always need a concrete code. This list only ever renders customer-scoped
+	// routes, so the parent's code is the right source.
+	customerCode: string
 }>()
 
 const emit = defineEmits<{
@@ -143,9 +148,13 @@ const message = useMessage()
 const dFormats = useSettingsStore().dateFormat
 
 const isWebhook = computed(() => props.route.channel === "webhook")
-const hasCustomHeaders = computed(
-	() => props.route.webhook_headers !== null && Object.keys(props.route.webhook_headers ?? {}).length > 0
-)
+
+// Channel settings now live in the route's JSON `config`. Read through a typed
+// view rather than casting at each use site — and tolerate a missing config,
+// since the read schema deliberately returns {} for an unparseable row so a bad
+// route stays visible in the list instead of 500-ing the page.
+const webhookConfig = computed<WebhookChannelConfig>(() => (props.route.config ?? {}) as WebhookChannelConfig)
+const hasCustomHeaders = computed(() => Object.keys(webhookConfig.value.headers ?? {}).length > 0)
 
 // Shuffle routes cache the app name on the row at form-submit time so we
 // can render "Shuffle · Slack" without a roundtrip; webhook routes show
@@ -154,12 +163,13 @@ const channelIcon = computed(() => (isWebhook.value ? "carbon:webhook" : "carbon
 const channelLabel = computed(() => {
 	if (isWebhook.value) {
 		try {
-			return `Webhook · ${new URL(props.route.webhook_url ?? "").host}`
+			return `Webhook · ${new URL((props.route.config?.url as string) ?? "").host}`
 		} catch {
 			return "Webhook"
 		}
 	}
-	return props.route.shuffle_app_name ? `Shuffle · ${props.route.shuffle_app_name}` : "Shuffle"
+	const appName = props.route.config?.app_name as string | undefined
+	return appName ? `Shuffle · ${appName}` : "Shuffle"
 })
 
 const severityColor = computed<"danger" | "warning" | "success">(() => {
@@ -177,7 +187,7 @@ async function toggleEnabled() {
 	loadingToggle.value = true
 
 	try {
-		const res = await Api.notifications.updateRoute(props.route.customer_code, props.route.id, {
+		const res = await Api.notifications.updateRoute(props.customerCode, props.route.id, {
 			enabled: !props.route.enabled
 		})
 		if (res.data.success) {
@@ -197,7 +207,7 @@ async function confirmDelete() {
 	loadingDelete.value = true
 
 	try {
-		const res = await Api.notifications.deleteRoute(props.route.customer_code, props.route.id)
+		const res = await Api.notifications.deleteRoute(props.customerCode, props.route.id)
 		if (res.data.success) {
 			message.success("Route deleted")
 			emit("deleted")

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRoutes.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRoutes.vue
@@ -27,6 +27,7 @@
 								v-for="route of list"
 								:key="route.id"
 								:route
+								:customer-code
 								class="item-appear item-appear-bottom item-appear-005 mb-2"
 								@edit="openEdit(route)"
 								@deleted="refreshList()"

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -14,9 +14,52 @@ export type NotificationSeverity = "Critical" | "High" | "Medium" | "Low" | "Inf
 
 export type DispatchStatus = "sent" | "failed" | "skipped"
 
+// Who a route serves. "internal" routes belong to no tenant and carry a null
+// customer_code — that's where assignment notifications land, so analyst
+// chatter never reaches a customer's channel.
+export type NotificationScope = "customer" | "internal"
+
+// Where the destination comes from. "assignee" resolves the event's assignee to
+// their email at dispatch time, and is only offered on channels that declare
+// support for it.
+export type RecipientMode = "static" | "assignee"
+
+// Per-channel settings. The shape is owned by the backend provider's config
+// schema (see NotificationChannelDescriptor), so this stays deliberately loose
+// — adding a channel must not require a type change here.
+export type ChannelConfig = Record<string, unknown>
+
+export interface ShuffleChannelConfig extends ChannelConfig {
+	app_id?: string | null
+	app_name?: string | null
+}
+
+export interface WebhookChannelConfig extends ChannelConfig {
+	url?: string | null
+	method?: string
+	headers?: Record<string, string> | null
+	include_full_report?: boolean
+}
+
+// A channel as advertised by GET /notification_channels. `config_schema` is the
+// provider's JSON Schema; the form renders generic inputs from it for channels
+// that have no bespoke block.
+export interface NotificationChannelDescriptor {
+	key: string
+	display_name: string
+	config_schema: {
+		properties?: Record<string, { type?: string; title?: string; description?: string; default?: unknown }>
+		required?: string[]
+		[key: string]: unknown
+	}
+	supports_recipient_modes: RecipientMode[]
+	secret_fields: string[]
+}
+
 export interface NotificationRoute {
 	id: number
-	customer_code: string
+	// Null on internal-scope routes.
+	customer_code: string | null
 	name: string
 	trigger: NotificationTrigger
 	channel: NotificationChannel
@@ -24,39 +67,35 @@ export interface NotificationRoute {
 	min_severity: NotificationSeverity
 	format_template: string | null
 	enabled: boolean
+	scope: NotificationScope
+	recipient_mode: RecipientMode
+	notify_on_self_assign: boolean
 	last_dispatched_at: string | null
 	dispatch_count: number
 	created_by: string | null
 	created_at: string
 	updated_at: string | null
-	// Phase 2 — populated only when channel === "shuffle"
+	// Shuffle's org stays a real FK column rather than moving into config,
+	// because burying an FK in JSON gives up referential integrity.
 	shuffle_integration_id: number | null
-	shuffle_app_id: string | null
-	shuffle_app_name: string | null
-	// Populated only when channel === "webhook"
-	webhook_url: string | null
-	webhook_method: string | null
-	webhook_headers: Record<string, string> | null
-	// Webhook only — inline the full AI report (markdown + recommended actions + IOCs) in the payload.
-	include_full_report: boolean
+	// Everything else channel-specific lives here.
+	config: ChannelConfig
 }
 
 export interface NotificationRoutePayload {
 	name: string
 	trigger: NotificationTrigger
 	channel: NotificationChannel
-	// Optional for webhook routes (the URL is the real target); required for shuffle.
+	// Required for shuffle (it's the delivery hint); ignored by other channels.
 	destination?: string | null
 	min_severity: NotificationSeverity
 	format_template?: string | null
 	enabled: boolean
+	scope?: NotificationScope
+	recipient_mode?: RecipientMode
+	notify_on_self_assign?: boolean
 	shuffle_integration_id?: number | null
-	shuffle_app_id?: string | null
-	shuffle_app_name?: string | null
-	webhook_url?: string | null
-	webhook_method?: string | null
-	webhook_headers?: Record<string, string> | null
-	include_full_report?: boolean
+	config: ChannelConfig
 }
 
 export type NotificationRouteUpdatePayload = Partial<NotificationRoutePayload>


### PR DESCRIPTION
Closes #1018. Last blocking piece of Phase 1, after #1021 and #1022.

**Step one of two.** This revision only adds and backfills — nothing is dropped. #1018b drops the six superseded columns once config has been verified against them on real data.

## Why

Per-channel settings lived in a column per setting: `shuffle_app_id`, `shuffle_app_name`, `webhook_url`, `webhook_method`, `webhook_headers`, `include_full_report`. Every new channel meant a migration plus another branch in a hand-written validator. Four more channels are queued.

## Schema

Migration `8c41d7e2b90a`, chained from `459ad67895be`.

| Change | Column | |
|---|---|---|
| add | `config` | Text — per-channel settings as JSON |
| add | `scope` | varchar(16), `'customer'` |
| add | `recipient_mode` | varchar(16), `'static'` |
| add | `notify_on_self_assign` | bool, false |
| alter | `customer_code` | now nullable |

`scope='internal'` routes belong to no tenant — that's where assignment notifications go, so analyst chatter never reaches a customer's channel. The invariant is enforced both ways in CRUD: customer-scope requires a code, internal-scope forbids one.

**`shuffle_integration_id` stays a real column.** It's a foreign key, and burying an FK in JSON gives up referential integrity and the cross-tenant check the dispatcher performs at send time.

**`destination` also stays a column**, contrary to the issue's sketch which had it moving into the shuffle config. It's `NOT NULL` and shared across channels; dropping a seventh column adds migration risk for marginal tidiness.

## The dual-write, and why it's here

The six legacy columns are **not dropped** and are **dual-written** on every create/update. Nothing reads them.

That makes this revision losslessly revertible — a route created or edited while it's applied still has its settings where the old code expects them — and lets #1018b diff the two representations on real data before dropping. `_legacy_columns_from_config` is the only code that touches them and goes away with them.

This wasn't in the original issue; it's ten lines that remove the window where a revert silently loses an edit.

## Verified against a populated database

The one existing route backfilled to `{"app_id": "accdaaf2…", "app_name": "Outlook_Office365"}`, parses through `ShuffleConfig`, and matches its legacy columns exactly.

**The webhook backfill has no rows locally**, so rather than leave it on review alone I ran the migration's exact `JSON_OBJECT` expression against MySQL over six synthetic inputs — full/absent/empty headers, null method, null flag, multiple headers — and round-tripped each through `WebhookConfig`. All six correct. That settled the two things I'd flagged as uncertain:

- `CAST(webhook_headers AS JSON)` nests headers as an **object**, not a double-encoded string. This was the failure mode I was most worried about.
- `COALESCE(include_full_report, 0) = 1` renders as a JSON **boolean**, not `1`/`0`. Pydantic would have coerced either, but it's now confirmed rather than assumed.

Read-only throughout — synthetic cases ran through a `SELECT` over literals.

## Two calls worth reviewing

**1. Write-validation moved off the shared base onto `NotificationRouteCreate`.**

`NotificationRouteRead` was inheriting it, which would 500 the list endpoint for any legacy or hand-edited row whose config fails the strict check — the Pydantic-2 strictness trap CLAUDE.md warns about. Reads now coerce an unparseable config to `{}`, so a bad route stays visible in the UI instead of taking the page down.

**2. Deliberate behaviour change: malformed config fails that route.**

Malformed `webhook_headers` used to be swallowed — headers became `None` and the dispatch went out anyway. `config` carries the whole channel setup, so an unreadable one means the URL is unknown too; sending a half-configured request is worse than recording a failure. Config is validated at save time now, so reaching this needs a hand-edited row. It still fails only that route, never the batch. Pinned by a test with the reasoning in its docstring.

## Where I deviated from the issue

#1018 said the route form becomes "schema-driven". **I did not make it fully generic**, and the difference matters.

The Shuffle block fetches a customer's orgs, then that org's authenticated apps, into a searchable picker. The webhook block has a dynamic key/value header editor. Rendering those from JSON Schema would give a bare text input for `app_id` — a real UX regression in exchange for an abstraction.

What's here is `GET /notification_channels`, advertising each provider's key, display name, config JSON Schema, supported recipient modes and secret fields — the endpoint that makes generic rendering possible — with the hand-written blocks kept.

**The generic fallback renderer is not written.** So as things stand, adding Resend or Teams still needs a form block, and the "channel #5 needs no frontend work" goal is not yet met. I'd rather flag that than let it read as delivered.

My suggestion is to build it alongside whichever of #1004/#1005 lands first, when we'll know what those fields actually need to look like — designing it now against two channels that both have bespoke blocks means guessing. Happy to do it here instead if you'd rather.

## Smaller notes

- The form's submit path rebuilds `config` per channel rather than sending the whole object: switching channels leaves the other branch's keys behind, and `extra="forbid"` turns a stale `url` on a shuffle route into a 400 rather than a no-op.
- `customerCode` is passed down to the route item rather than read off the route, since `customer_code` is nullable now but the API paths need a concrete value.
- The route item tolerates a missing config (`?? {}`), matching the lenient read schema.

## Testing

```
148 passed  backend tests/
type-check  exit 0
eslint      clean
pre-commit  clean
```

Registry test fixtures moved to the config shape; the assertions — exact webhook payload dicts, exact error strings — are unchanged, which is the point. Two header tests were reworked: one had silently become a no-op, and the other now pins the behaviour change above.

## Next

#1018b: drop the six columns and delete the dual-write. That one is genuinely irreversible, so it wants a config-vs-legacy diff across all routes before it runs.
