### PR TITLE
refactor(notifications): drop the superseded per-channel columns

### DIFF
--- a/backend/alembic/versions/b3f5a91c72d4_drop_legacy_channel_columns.py
+++ b/backend/alembic/versions/b3f5a91c72d4_drop_legacy_channel_columns.py
@@ -1,0 +1,65 @@
+"""drop the superseded per-channel columns
+
+Revision ID: b3f5a91c72d4
+Revises: 8c41d7e2b90a
+Create Date: 2026-08-01 15:45:00.000000
+
+Phase 1b of the notification refactor (#1024), second of two steps.
+
+8c41d7e2b90a added `config` and backfilled it from the six columns dropped here,
+leaving them in place and dual-written so that revision stayed revertible. This
+one removes the scaffolding.
+
+IRREVERSIBLE IN PRACTICE. `downgrade()` recreates the columns but CANNOT
+repopulate them — the application stopped writing them the moment this shipped,
+so any route created or edited afterwards has its settings only in `config`.
+Before running, verify config matches the legacy columns for every route and
+take a snapshot of them; see the checklist on #1024.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3f5a91c72d4"
+down_revision: Union[str, None] = "8c41d7e2b90a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Superseded by `config`. `shuffle_integration_id` is deliberately NOT here:
+    # it is a foreign key, and burying an FK in JSON would give up referential
+    # integrity and the cross-tenant check the dispatcher performs at send time.
+    # `destination` also stays — NOT NULL and shared across channels.
+    op.drop_column("customer_notification_route", "shuffle_app_id")
+    op.drop_column("customer_notification_route", "shuffle_app_name")
+    op.drop_column("customer_notification_route", "webhook_url")
+    op.drop_column("customer_notification_route", "webhook_method")
+    op.drop_column("customer_notification_route", "webhook_headers")
+    op.drop_column("customer_notification_route", "include_full_report")
+
+
+def downgrade() -> None:
+    """Recreates the columns EMPTY.
+
+    This restores the shape, not the data. Every column comes back NULL, which
+    for the pre-8c41d7e2b90a code means every route reads as unconfigured: a
+    shuffle route with no app_id and a webhook route with no url both fail at
+    dispatch with a data-integrity message rather than sending anything.
+
+    Repopulating means replaying `config` back out — from the #1024 snapshot for
+    routes that predate the drop, or by parsing `config` for those that don't.
+    Deliberately not automated here: doing it silently would hide that a
+    downgrade past this point needs a human decision.
+    """
+    op.add_column("customer_notification_route", sa.Column("shuffle_app_id", sa.String(64), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("shuffle_app_name", sa.String(128), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("webhook_url", sa.Text(), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("webhook_method", sa.String(8), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("webhook_headers", sa.Text(), nullable=True))
+    op.add_column("customer_notification_route", sa.Column("include_full_report", sa.Boolean(), nullable=True))

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -986,18 +986,6 @@ class CustomerNotificationRoute(SQLModel, table=True):
         index=True,
     )
 
-    # ----- Legacy per-channel columns (dropped in #1018b) -----
-    # Superseded by `config`, retained for one release and dual-written on every
-    # create/update. That makes reverting this change lossless and lets the
-    # follow-up verify config against them on real data before dropping.
-    # Nothing reads these — the providers read `config`.
-    shuffle_app_id: Optional[str] = Field(default=None, max_length=64)
-    shuffle_app_name: Optional[str] = Field(default=None, max_length=128)
-    webhook_url: Optional[str] = Field(sa_column=Column(Text), default=None)
-    webhook_method: Optional[str] = Field(default=None, max_length=8)
-    webhook_headers: Optional[str] = Field(sa_column=Column(Text), default=None)
-    include_full_report: Optional[bool] = Field(default=False)
-
     created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     updated_at: Optional[datetime] = Field(default=None)
 

--- a/backend/app/notifications/channels/webhook.py
+++ b/backend/app/notifications/channels/webhook.py
@@ -15,7 +15,6 @@ from typing import Any
 from typing import Dict
 from typing import Optional
 
-from loguru import logger
 from pydantic import field_validator
 
 from app.notifications.channels.base import ChannelConfig
@@ -24,25 +23,6 @@ from app.notifications.channels.base import DispatchContext
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import dispatch_webhook
-
-
-def decode_webhook_headers(raw: Optional[str]) -> Optional[Dict[str, str]]:
-    """Deserialize the route's JSON-string ``webhook_headers`` column.
-
-    Returns a flat str→str dict, or None when unset/blank/malformed. Failing
-    closed (None) rather than raising keeps a bad row from aborting the whole
-    dispatch — the request just goes out with the dispatcher's default headers.
-    """
-    if not raw:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except ValueError:
-        logger.warning(f"Malformed webhook_headers JSON, ignoring: {raw[:120]!r}")
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    return {str(k): str(v) for k, v in parsed.items()}
 
 
 async def build_full_report(alert_id: int, session) -> Optional[Dict[str, Any]]:

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -48,24 +48,23 @@ class NotificationTrigger(str, Enum):
 class NotificationChannel(str, Enum):
     """Delivery channel set.
 
-    `shuffle` proxies to Shuffle's hosted MCP — each customer points at
-    their own Shuffle Org via `customer_shuffle_integration`, and Shuffle
-    handles the OAuth-authenticated downstream app (Slack workspace,
-    Outlook tenant, Teams, Gmail, SendGrid, etc.). Routes referencing
-    `shuffle` MUST populate the `shuffle_integration_id` + `shuffle_app_id`
-    columns. Email, chat, ticketing, and the rest of the catalog all
-    flow through this single channel — there's no separate direct SMTP
-    path because Shuffle's email apps cover that surface.
+    Each value maps to a provider in ``app.notifications.channels``. The
+    provider owns its own settings shape, validated from the route's ``config``
+    column against its declared ``config_schema`` — so adding a channel needs
+    neither a migration nor an edit here beyond the enum member.
 
-    `webhook` is a direct HTTP POST to any URL the customer chooses
-    (automation platforms, chat incoming webhooks, a custom automation
-    endpoint, …) — no Shuffle org in the path. Routes referencing
-    `webhook` MUST populate `webhook_url`. By default the dispatcher
-    sends a structured JSON object; if the route sets a `format_template`
-    that template's rendered output is sent as the raw body instead, so
-    provider-specific shapes (Discord's `{"content": …}`, Slack's
-    `{"text": …}`) work without a code change. Optional `webhook_headers`
-    carry auth (Authorization / X-API-Key / …).
+    ``shuffle`` proxies to Shuffle's hosted MCP: each customer points at their
+    own Shuffle org via ``customer_shuffle_integration``, and Shuffle handles the
+    OAuth-authenticated downstream app (Slack, Outlook, Teams, Gmail, …). Its
+    org stays a real FK column (``shuffle_integration_id``) rather than moving
+    into config, so referential integrity and the dispatcher's cross-tenant
+    check survive.
+
+    ``webhook`` is a direct HTTP request to any URL the customer chooses, with
+    no Shuffle org in the path. By default the dispatcher sends a structured
+    JSON object; if the route sets a ``format_template`` its rendered output is
+    sent as the raw body instead, so provider-specific shapes (Discord's
+    ``{"content": …}``, Slack's ``{"text": …}``) work without a code change.
     """
 
     SHUFFLE = "shuffle"

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -94,37 +94,6 @@ async def get_route(route_id: int, customer_code: str, session: AsyncSession) ->
     return route
 
 
-def _legacy_columns_from_config(channel: str, config: dict) -> dict:
-    """Mirror `config` back onto the pre-#1018 per-channel columns.
-
-    Nothing reads these — the providers read `config`. They are dual-written for
-    one release so that reverting this change is lossless and #1018b can diff
-    the two representations against real rows before dropping the columns.
-
-    Deleted along with the columns in #1018b.
-    """
-    if channel == NotificationChannel.WEBHOOK.value:
-        headers = config.get("headers")
-        return {
-            "webhook_url": config.get("url"),
-            "webhook_method": config.get("method") or "POST",
-            "webhook_headers": json.dumps(headers) if headers else None,
-            "include_full_report": bool(config.get("include_full_report")),
-            "shuffle_app_id": None,
-            "shuffle_app_name": None,
-        }
-    if channel == NotificationChannel.SHUFFLE.value:
-        return {
-            "shuffle_app_id": config.get("app_id"),
-            "shuffle_app_name": config.get("app_name"),
-            "webhook_url": None,
-            "webhook_method": None,
-            "webhook_headers": None,
-            "include_full_report": False,
-        }
-    return {}
-
-
 def _enforce_scope_invariant(scope: str, customer_code: Optional[str]) -> Optional[str]:
     """A customer route must name a tenant; an internal route must not.
 
@@ -172,8 +141,6 @@ async def create_route(
         created_by=created_by,
         shuffle_integration_id=payload.shuffle_integration_id,
         config=json.dumps(payload.config or {}),
-        # Dual-written for one release; see _legacy_columns_from_config.
-        **_legacy_columns_from_config(payload.channel.value, payload.config or {}),
     )
     session.add(route)
     await session.commit()
@@ -257,12 +224,6 @@ async def update_route(
         if field == "destination" and value is None:
             value = ""
         setattr(route, field, value)
-
-    # Keep the legacy columns in step with config; see the helper's note.
-    if "config" in data or "channel" in data:
-        final_config = json.loads(route.config) if route.config else {}
-        for column, mirrored in _legacy_columns_from_config(route.channel, final_config).items():
-            setattr(route, column, mirrored)
 
     route.updated_at = datetime.utcnow()
 


### PR DESCRIPTION
Closes #1024. Second and final step of moving channel settings into `config` (#1023). **Completes Phase 1.**

## What

Drops the six per-channel columns superseded by `config`:

`shuffle_app_id` · `shuffle_app_name` · `webhook_url` · `webhook_method` · `webhook_headers` · `include_full_report`

Plus the dual-write helper that kept them current, their model fields, and two things they were propping up: `decode_webhook_headers` (dead since the provider started reading a real dict out of config) and the `NotificationChannel` docstring, which still told readers those columns were required.

**`shuffle_integration_id` stays** — it's a foreign key, and burying an FK in JSON gives up referential integrity and the cross-tenant check the dispatcher runs before sending. **`destination` stays** — NOT NULL and shared across channels.

## Why the dual-write existed, and why it goes now

#1023 kept these columns written-but-unread on purpose. That made it revertible without data loss, and gave this step something to diff against.

Keeping it longer has a cost: the columns look like part of the schema, so new code can start depending on them, and every create/update does redundant writes. Scaffolding is cheapest to remove while the work is fresh.

## This one is irreversible in practice

`downgrade()` recreates the columns but **cannot repopulate them**. The application stopped writing them the moment this shipped, so any route created or edited afterwards has its settings only in `config`.

The docstring says that plainly rather than implying a clean rollback, and deliberately does *not* auto-replay `config` back out — downgrading past this point is a human decision, and automating it silently would hide that.

## Verification

**Before running** — all four, against real data:

- `config` matched the legacy columns for **every** route, not a sample
- every `config` parsed through its provider's `config_schema`
- no route sat on a channel outside the registry
- the six columns were snapshotted to `~/copilot-migration-backups/`, outside the repo so it can't be committed

**After running:**

```
alembic_version  b3f5a91c72d4
dropped          all six GONE
retained         config, scope, recipient_mode, notify_on_self_assign,
                 shuffle_integration_id, destination, customer_code — all ok
read schema      builds from the ORM row, config parsed to a dict
dispatch         sent → same app_id, same org_id as before the drop
```

Both halves, not just the schema: the API's read model still constructs from the row (that's what renders the routes list), and a dry-run dispatch against the real route resolves the identical Shuffle app and org. Outbound call stubbed — nothing was sent.

## Testing

```
148 passed  backend tests/
pre-commit  clean
```

No test changes needed — #1023 already migrated the fixtures to the config shape, so nothing referenced the dropped columns.

## Phase 1 is now complete

| | |
|---|---|
| #1021 | channel registry + event envelope |
| #1022 | dispatch log generalization |
| #1023 | route config JSON, scope, recipient_mode |
| **#1024** | **drop the scaffolding** |

Everything downstream is unblocked: #1006 (triggers), #1004 (Resend), #1005 (Teams).

One outstanding gap, carried from #1023 so it doesn't get lost: the **generic fallback form renderer** is not built. `GET /notification_channels` advertises each provider's JSON Schema, but the route form still needs a hand-written block per channel — so adding Resend or Teams isn't yet zero-frontend-work. Best built alongside whichever of those lands first, when the real field shapes are known.
