### PR TITLE
feat(notifications): add Resend as an email delivery channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,16 @@ PORTAINER_ENDPOINT_ID=2
 TALON_URL=http://127.1.1.1:3100
 TALON_API_KEY=REPLACE_ME
 
+# RESEND : transactional email for notification routes (https://resend.com)
+# Deployment-wide, like SHUFFLER_API_KEY — the per-customer differentiator is the
+# to/from addresses on each notification route. Free tier is 1,000 emails/month
+# across ALL customers, so gate email routes on severity and watch the quota
+# counter in the UI.
+RESEND_URL=https://api.resend.com
+RESEND_API_KEY=REPLACE_ME
+# Must be on a domain verified in Resend, or sends are rejected.
+RESEND_FROM_ADDRESS=alerts@example.com
+
 # ! CoPilot MCP
 
 # OpenAI Configuration

--- a/backend/app/db/db_populate.py
+++ b/backend/app/db/db_populate.py
@@ -158,6 +158,17 @@ def get_connectors_list():
             "Connection to Graylog. If you only have one Graylog instance, set this to the same as Graylog.",
         ),
         (
+            "Resend",
+            "1",
+            "api_key",
+            (
+                "Connection to Resend for transactional email notifications. Requires an API key and a verified "
+                "sending domain. The default From address is read from RESEND_FROM_ADDRESS and can be overridden "
+                "per notification route."
+            ),
+            "RESEND_FROM_ADDRESS",
+        ),
+        (
             "Talon",
             "3",
             "api_key",

--- a/backend/app/notifications/channels/__init__.py
+++ b/backend/app/notifications/channels/__init__.py
@@ -19,12 +19,14 @@ from typing import Optional
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
 from app.notifications.channels.base import SendResult
+from app.notifications.channels.resend import ResendChannel
 from app.notifications.channels.shuffle import ShuffleChannel
 from app.notifications.channels.webhook import WebhookChannel
 
 _PROVIDERS: List[ChannelProvider] = [
     ShuffleChannel(),
     WebhookChannel(),
+    ResendChannel(),
 ]
 
 CHANNEL_REGISTRY: Dict[str, ChannelProvider] = {p.key: p for p in _PROVIDERS}

--- a/backend/app/notifications/channels/resend.py
+++ b/backend/app/notifications/channels/resend.py
@@ -1,0 +1,232 @@
+"""Resend email delivery.
+
+The first channel that can address a *person* rather than a fixed endpoint: a
+webhook targets a URL and Shuffle targets an app, but email can resolve the
+event's assignee at dispatch time. That's what makes "notify whoever this alert
+was assigned to" expressible (#1006).
+
+Credentials are deployment-wide, following the Shuffle precedent — one Resend
+account in the `connectors` table, with the per-customer differentiator being
+the to/from addresses on each route.
+
+**Quota is the operational constraint here.** Resend's free tier is 1,000
+emails/month across the whole deployment — roughly 33/day for every customer
+combined. `max_per_hour` on the route and the monthly counter in
+`services/resend_quota.py` exist so that ceiling is visible and enforceable
+rather than something you discover when delivery stops.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from fastapi import HTTPException
+from loguru import logger
+from pydantic import field_validator
+
+from app.connectors.utils import get_connector_info_from_db
+from app.notifications.channels.base import ChannelConfig
+from app.notifications.channels.base import ChannelProvider
+from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import SendResult
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.services.dispatchers import dispatch_resend
+
+_CREDS_MEMO_KEY = "resend_creds"
+
+RESEND_CONNECTOR_NAME = "Resend"
+
+#: Resend's free tier, for the UI's quota indicator. Not enforced here — Resend
+#: itself rejects over-quota sends, and a paid plan raises it.
+FREE_TIER_MONTHLY_LIMIT = 1000
+
+
+async def get_resend_connector(session) -> Tuple[str, str, Optional[str]]:
+    """Fetch (base_url, api_key, default_from) for the Resend connector.
+
+    Raises HTTPException when unconfigured, which the provider converts into a
+    per-route failure rather than letting it abort a whole dispatch batch.
+    """
+    info = await get_connector_info_from_db(RESEND_CONNECTOR_NAME, session)
+    if not info:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Resend connector is not configured in CoPilot. Add the Resend connector "
+                "with a valid API key before creating email notification routes."
+            ),
+        )
+    api_key = info.get("connector_api_key") or ""
+    base_url = info.get("connector_url") or "https://api.resend.com"
+    default_from = info.get("connector_extra_data") or None
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Resend connector is configured but has no API key set.")
+    return (base_url, api_key, default_from)
+
+
+class ResendConfig(ChannelConfig):
+    """`customer_notification_route.config` when channel='resend'.
+
+    `to` is required for recipient_mode='static' and ignored for 'assignee',
+    where the address is resolved from the event instead. Enforced at save time
+    in the route schema, which knows the mode.
+
+    No secret_fields: the API key lives on the deployment's connector row, not
+    in per-route config, so nothing here needs encrypting in #1020.
+    """
+
+    to: List[str] = []
+    cc: List[str] = []
+    #: Overrides the connector's RESEND_FROM_ADDRESS. Must be on a domain
+    #: verified in Resend or the send is rejected.
+    from_address: Optional[str] = None
+    reply_to: Optional[str] = None
+    subject_prefix: str = "[CoPilot]"
+    #: Per-route throttle, checked before the provider call. Guards the shared
+    #: monthly quota from one noisy route — an alert_created route on a busy
+    #: customer could exhaust the free tier for everyone in a morning.
+    max_per_hour: Optional[int] = 20
+
+    @field_validator("to", "cc", mode="before")
+    @classmethod
+    def _coerce_single_address(cls, v):
+        """Accept a bare string as a one-element list.
+
+        The form sends a list, but hand-written config and API callers commonly
+        send a single address; rejecting that is needless friction.
+        """
+        if v is None:
+            return []
+        if isinstance(v, str):
+            return [v] if v.strip() else []
+        return v
+
+    @field_validator("max_per_hour")
+    @classmethod
+    def _positive_limit(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v < 1:
+            raise ValueError("max_per_hour must be at least 1, or null to disable the throttle")
+        return v
+
+
+class ResendChannel(ChannelProvider):
+    key = "resend"
+    display_name = "Email (Resend)"
+    config_schema = ResendConfig
+    # The first channel that can resolve a person. `assignee` looks up the
+    # event's assignee and mails them directly.
+    supports_recipient_modes = {"static", "assignee"}
+    # Empty: the API key is on the connector row, not in route config.
+    secret_fields = set()
+
+    async def send(
+        self,
+        *,
+        route: Any,
+        event: NotificationEvent,
+        rendered_body: str,
+        ctx: DispatchContext,
+    ) -> SendResult:
+        # Read every attribute before the first await — an expired ORM object
+        # would otherwise trigger a synchronous refresh and MissingGreenlet.
+        route_id = route.id
+        recipient_mode = route.recipient_mode
+        try:
+            cfg = self.parse_config(route)
+        except ValueError as e:
+            return SendResult.failed(f"Invalid resend config: {e}")
+
+        try:
+            creds = await ctx.memoize(_CREDS_MEMO_KEY, lambda: get_resend_connector(ctx.session))
+        except HTTPException as e:
+            logger.warning(f"Resend connector unavailable: {e.detail}")
+            return SendResult.failed(str(e.detail) or "Resend connector unavailable")
+
+        base_url, api_key, default_from = creds
+
+        from_address = cfg.from_address or default_from
+        if not from_address:
+            return SendResult.failed(
+                "No From address: set RESEND_FROM_ADDRESS on the connector or from_address on the route.",
+            )
+
+        recipients, problem = await self._resolve_recipients(recipient_mode, cfg, event)
+        if problem is not None:
+            return problem
+        if not recipients:
+            return SendResult.failed("No recipients resolved for this route.")
+
+        # Throttle before the provider call, so a skipped send costs nothing and
+        # is visible in the dispatch log rather than silently dropped.
+        if cfg.max_per_hour:
+            from app.notifications.services.resend_quota import sends_in_last_hour
+
+            recent = await sends_in_last_hour(route_id, ctx.session)
+            if recent >= cfg.max_per_hour:
+                return SendResult.skipped(
+                    f"Rate limit reached for this route ({recent}/{cfg.max_per_hour} in the last hour).",
+                )
+
+        subject = self._subject(cfg, event)
+
+        status, error_message, latency_ms, message_id = await dispatch_resend(
+            base_url=base_url,
+            api_key=api_key,
+            from_address=from_address,
+            to=recipients,
+            cc=cfg.cc or None,
+            reply_to=cfg.reply_to,
+            subject=subject,
+            text_body=rendered_body,
+        )
+        return SendResult(
+            status=status,
+            error_message=error_message,
+            latency_ms=latency_ms,
+            provider_reference=message_id,
+        )
+
+    async def _resolve_recipients(
+        self,
+        recipient_mode: str,
+        cfg: ResendConfig,
+        event: NotificationEvent,
+    ) -> Tuple[List[str], Optional[SendResult]]:
+        """Return (addresses, failure). Exactly one is meaningful.
+
+        Every failure path is a logged outcome rather than an exception: a route
+        pointed at a departed user should record why it didn't send, not take
+        down the batch.
+        """
+        if recipient_mode != "assignee":
+            return (list(cfg.to), None)
+
+        username = event.assignee_username
+        if not username:
+            # e.g. an investigation_complete event reaching an assignee-mode
+            # route. Skipped rather than failed: nothing is misconfigured, this
+            # event simply has no one to address.
+            return ([], SendResult.skipped("Route delivers to the assignee, but this event has no assignee."))
+
+        from app.auth.services.universal import find_user
+
+        user = await find_user(username)
+        if user is None:
+            return ([], SendResult.failed(f"Assignee '{username}' not found; cannot resolve an email address."))
+        email = getattr(user, "email", None)
+        if not email:
+            return ([], SendResult.failed(f"Assignee '{username}' has no email address on their account."))
+        return ([str(email)], None)
+
+    def _subject(self, cfg: ResendConfig, event: NotificationEvent) -> str:
+        """Prefix + the event's one-line subject, with severity for scanability.
+
+        Kept here rather than in the body renderer because a subject line is an
+        email-specific concern — no other channel has one.
+        """
+        prefix = (cfg.subject_prefix or "").strip()
+        core = f"{event.severity.value}: {event.subject}".strip()
+        return f"{prefix} {core}".strip() if prefix else core

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -18,8 +18,11 @@ Two surfaces:
 
 from __future__ import annotations
 
+from typing import Optional
+
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import HTTPException
 from fastapi import Security
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,6 +41,7 @@ from app.notifications.schema.notifications import NotificationRouteListResponse
 from app.notifications.schema.notifications import NotificationRouteRead
 from app.notifications.schema.notifications import NotificationRouteResponse
 from app.notifications.schema.notifications import NotificationRouteUpdate
+from app.notifications.schema.notifications import ResendQuotaResponse
 from app.notifications.schema.notifications import ShuffleAppListResponse
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
 from app.notifications.schema.notifications import ShuffleIntegrationListResponse
@@ -161,6 +165,45 @@ async def list_channels_route() -> ChannelListResponse:
         for provider in CHANNEL_REGISTRY.values()
     ]
     return ChannelListResponse(success=True, message=f"{len(channels)} channel(s) retrieved", channels=channels)
+
+
+@notifications_router.get(
+    "/notification_channels/resend/quota",
+    response_model=ResendQuotaResponse,
+    description=(
+        "Resend emails sent this calendar month against the plan limit. Deployment-wide — "
+        "the API key is shared, so every customer's routes draw from one allowance. "
+        "Pass customer_code for a display-only breakdown."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def resend_quota_route(
+    customer_code: Optional[str] = None,
+    session: AsyncSession = Depends(get_db),
+) -> ResendQuotaResponse:
+    from app.notifications.channels.resend import FREE_TIER_MONTHLY_LIMIT
+    from app.notifications.channels.resend import get_resend_connector
+    from app.notifications.services.resend_quota import sends_this_month
+
+    total = await sends_this_month(session)
+    scoped = await sends_this_month(session, customer_code) if customer_code else None
+
+    # "Is Resend usable at all" drives whether the UI offers the channel; an
+    # unconfigured connector is a normal state, not an error.
+    try:
+        await get_resend_connector(session)
+        configured = True
+    except HTTPException:
+        configured = False
+
+    return ResendQuotaResponse(
+        success=True,
+        message=f"{total} email(s) sent this month",
+        sent_this_month=total,
+        limit=FREE_TIER_MONTHLY_LIMIT,
+        customer_sent=scoped,
+        configured=configured,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -69,6 +69,7 @@ class NotificationChannel(str, Enum):
 
     SHUFFLE = "shuffle"
     WEBHOOK = "webhook"
+    RESEND = "resend"
 
 
 class NotificationSeverity(str, Enum):
@@ -310,6 +311,12 @@ class NotificationRouteCreate(NotificationRouteBase):
                 raise ValueError("config.url is required when channel='webhook'")
             if not str(url).lower().startswith(("http://", "https://")):
                 raise ValueError("config.url must start with http:// or https://")
+        elif self.channel == NotificationChannel.RESEND:
+            # `to` is only meaningful for static delivery — in assignee mode the
+            # address comes from the event, and requiring both would imply the
+            # static list is a fallback, which it is not.
+            if self.recipient_mode == RecipientMode.STATIC and not self.config.get("to"):
+                raise ValueError("config.to is required when channel='resend' and recipient_mode='static'")
         return self
 
 
@@ -472,6 +479,22 @@ class ChannelDescriptor(BaseModel):
     config_schema: Dict[str, Any]
     supports_recipient_modes: List[str]
     secret_fields: List[str]
+
+
+class ResendQuotaResponse(BaseModel):
+    """Monthly email usage against Resend's plan limit.
+
+    Deployment-wide by construction: the API key is deployment-wide, so every
+    customer's routes draw from the same allowance. `customer_sent` is a
+    breakdown for display, never a separate budget.
+    """
+
+    success: bool = True
+    message: str = "Quota retrieved"
+    sent_this_month: int
+    limit: int
+    customer_sent: Optional[int] = None
+    configured: bool = Field(description="Whether the Resend connector has an API key set.")
 
 
 class ChannelListResponse(BaseModel):

--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -29,6 +29,7 @@ import json
 import time
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Tuple
 
@@ -56,6 +57,8 @@ _WEBHOOK_TIMEOUT_S = 15.0
 # uniform call site, but the 4th slot (a provider execution id) is always
 # None for webhooks — there's no async run to correlate to.
 WebhookDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
+# (status, error_message, latency_ms, provider_reference)
+ResendDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +144,77 @@ async def dispatch_webhook(
     except Exception as e:  # noqa: BLE001
         latency_ms = int((time.monotonic() - started) * 1000)
         logger.warning(f"Webhook dispatch failed: {e!r}")
+        return ("failed", f"{type(e).__name__}: {e}", latency_ms, None)
+
+
+# ---------------------------------------------------------------------------
+# Resend dispatcher
+# ---------------------------------------------------------------------------
+
+_RESEND_TIMEOUT_S = 15.0
+
+
+async def dispatch_resend(
+    *,
+    base_url: str,
+    api_key: str,
+    from_address: str,
+    to: List[str],
+    subject: str,
+    text_body: str,
+    cc: Optional[List[str]] = None,
+    reply_to: Optional[str] = None,
+) -> ResendDispatchResult:
+    """Send one email via Resend's REST API.
+
+    Returns (status, error_message, latency_ms, message_id). Never raises —
+    the provider turns the result into a dispatch-log row.
+
+    Body is plain text only for now. Resend accepts `html` too, but the message
+    body CoPilot renders today is markdown-ish plain text; sending it as HTML
+    would show the markup. Real HTML arrives with templates (#1009).
+    """
+    payload: Dict[str, Any] = {
+        "from": from_address,
+        "to": to,
+        "subject": subject,
+        "text": text_body,
+    }
+    if cc:
+        payload["cc"] = cc
+    if reply_to:
+        payload["reply_to"] = reply_to
+
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=_RESEND_TIMEOUT_S) as client:
+            response = await client.post(
+                f"{base_url.rstrip('/')}/emails",
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                json=payload,
+            )
+        latency_ms = int((time.monotonic() - started) * 1000)
+
+        if response.status_code >= 400:
+            # Resend returns a JSON body with `message` on errors; surface it so
+            # the operator sees "domain not verified" rather than a bare 403.
+            detail = response.text[:200]
+            try:
+                parsed = response.json()
+                detail = parsed.get("message") or parsed.get("error") or detail
+            except ValueError:
+                pass
+            return ("failed", f"Resend returned {response.status_code}: {detail}", latency_ms, None)
+
+        message_id = None
+        try:
+            message_id = response.json().get("id")
+        except ValueError:
+            pass
+        return ("sent", None, latency_ms, message_id)
+    except Exception as e:  # noqa: BLE001
+        latency_ms = int((time.monotonic() - started) * 1000)
+        logger.warning(f"Resend dispatch failed: {e!r}")
         return ("failed", f"{type(e).__name__}: {e}", latency_ms, None)
 
 

--- a/backend/app/notifications/services/resend_quota.py
+++ b/backend/app/notifications/services/resend_quota.py
@@ -1,0 +1,76 @@
+"""Resend send counting — per-route throttle and deployment-wide monthly usage.
+
+Resend's free tier is 1,000 emails/month across the **whole deployment**, not
+per customer or per route, because the API key is deployment-wide. That makes it
+a shared resource one noisy route can exhaust for everyone.
+
+Both counts are derived from `notification_dispatch_log` rather than kept in a
+counter column: the log is already the record of what was sent, and a separate
+counter would be one more thing to keep in step.
+
+Only `sent` rows count. A `failed` send never reached Resend, and a `skipped`
+one never left the process.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timedelta
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.universal_models import CustomerNotificationRoute
+from app.db.universal_models import NotificationDispatchLog
+
+RESEND_CHANNEL_KEY = "resend"
+
+
+async def sends_in_last_hour(route_id: int, session: AsyncSession) -> int:
+    """Successful sends for one route in the trailing hour.
+
+    Backs the per-route `max_per_hour` throttle. Trailing window rather than a
+    clock hour, so a burst can't straddle the boundary and send twice the limit.
+    """
+    since = datetime.utcnow() - timedelta(hours=1)
+    result = await session.execute(
+        select(func.count())
+        .select_from(NotificationDispatchLog)
+        .where(
+            NotificationDispatchLog.route_id == route_id,
+            NotificationDispatchLog.status == "sent",
+            NotificationDispatchLog.dispatched_at >= since,
+        ),
+    )
+    return int(result.scalar() or 0)
+
+
+async def sends_this_month(session: AsyncSession, customer_code: Optional[str] = None) -> int:
+    """Successful email sends this calendar month, deployment-wide by default.
+
+    Calendar month, not trailing 30 days, because that's how Resend bills and
+    resets — a trailing window would disagree with their dashboard.
+
+    `customer_code` narrows it for display purposes only. The quota itself is
+    never per-customer: every customer draws from the same account.
+    """
+    now = datetime.utcnow()
+    month_start = datetime(now.year, now.month, 1)
+
+    stmt = (
+        select(func.count())
+        .select_from(NotificationDispatchLog)
+        .join(CustomerNotificationRoute, CustomerNotificationRoute.id == NotificationDispatchLog.route_id)
+        .where(
+            CustomerNotificationRoute.channel == RESEND_CHANNEL_KEY,
+            NotificationDispatchLog.status == "sent",
+            NotificationDispatchLog.dispatched_at >= month_start,
+        )
+    )
+    if customer_code:
+        stmt = stmt.where(CustomerNotificationRoute.customer_code == customer_code)
+
+    result = await session.execute(stmt)
+    return int(result.scalar() or 0)

--- a/backend/tests/test_notification_channel_registry.py
+++ b/backend/tests/test_notification_channel_registry.py
@@ -97,10 +97,10 @@ def _shuffle_route(config=None, **over):
 
 
 def test_registry_contains_the_shipped_channels():
-    assert sorted(channel_keys()) == ["shuffle", "webhook"]
+    assert sorted(channel_keys()) == ["resend", "shuffle", "webhook"]
 
 
-@pytest.mark.parametrize("key", ["shuffle", "webhook"])
+@pytest.mark.parametrize("key", ["resend", "shuffle", "webhook"])
 def test_every_provider_declares_the_required_classvars(key):
     provider = CHANNEL_REGISTRY[key]
     assert isinstance(provider, ChannelProvider)

--- a/backend/tests/test_notification_resend_channel.py
+++ b/backend/tests/test_notification_resend_channel.py
@@ -1,0 +1,291 @@
+"""The Resend email channel.
+
+Two things make this channel different from the two before it, and both are what
+these tests are mostly about:
+
+1. It can address a **person**. `recipient_mode='assignee'` resolves the event's
+   assignee to their email at dispatch time — the first channel that can, and
+   what makes "notify whoever this was assigned to" (#1006) expressible.
+
+2. Its quota is a **shared, finite deployment resource**. The free tier is 1,000
+   emails/month across every customer, because the API key is deployment-wide.
+   One noisy route can exhaust it for everyone, so the throttle matters.
+
+Every failure path must produce a logged outcome rather than an exception: a
+route pointed at a departed user should record why it didn't send, not take down
+the dispatch batch.
+
+Unit tests with mocked sessions and stubbed HTTP — no DB, no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_resend_channel.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+
+import app.notifications.channels.resend as resend_mod  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.channels.resend import ResendConfig  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+
+CUSTOMER = "TENANT_A"
+CREDS = ("https://api.resend.com", "re_key", "alerts@socfortress.co")
+
+
+def _event(assignee=None, subject="Mimikatz signature", severity=NotificationSeverity.CRITICAL):
+    return NotificationEvent(
+        customer_code=CUSTOMER,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity=severity,
+        subject=subject,
+        summary="Credential dumping observed on WKSTN-04.",
+        entity_type="alert",
+        entity_id=42,
+        dedupe_key="alert:42:investigation_complete",
+        assignee_username=assignee,
+    )
+
+
+def _route(config=None, recipient_mode="static", **over):
+    cfg = {"to": ["soc@acme.example"]}
+    cfg.update(config or {})
+    base = dict(id=1, name="SOC email", channel="resend", recipient_mode=recipient_mode, config=json.dumps(cfg))
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _send(route, event=None, creds=CREDS, recent_sends=0, user=...):
+    """Invoke the provider with HTTP, connector and DB lookups stubbed.
+
+    Returns (result, kwargs-the-dispatcher-was-called-with-or-None).
+    """
+    ev = event or _event()
+    sent = AsyncMock(return_value=("sent", None, 12, "msg-1"))
+    creds_mock = AsyncMock(side_effect=creds) if isinstance(creds, Exception) else AsyncMock(return_value=creds)
+
+    patches = [
+        patch.object(resend_mod, "dispatch_resend", sent),
+        patch.object(resend_mod, "get_resend_connector", creds_mock),
+        patch("app.notifications.services.resend_quota.sends_in_last_hour", AsyncMock(return_value=recent_sends)),
+    ]
+    if user is not ...:
+        patches.append(patch("app.auth.services.universal.find_user", AsyncMock(return_value=user)))
+
+    for p in patches:
+        p.start()
+    try:
+        result = asyncio.run(
+            CHANNEL_REGISTRY["resend"].send(
+                route=route,
+                event=ev,
+                rendered_body="RENDERED BODY",
+                ctx=DispatchContext(session=AsyncMock(), event=ev),
+            ),
+        )
+    finally:
+        for p in patches:
+            p.stop()
+    return result, (sent.await_args.kwargs if sent.await_args else None)
+
+
+# ── the provider contract ─────────────────────────────────────────────────
+
+
+def test_resend_is_the_first_channel_that_can_address_a_person():
+    provider = CHANNEL_REGISTRY["resend"]
+    assert "assignee" in provider.supports_recipient_modes
+    assert "static" in provider.supports_recipient_modes
+
+
+def test_api_key_is_not_route_config_so_nothing_here_needs_encrypting():
+    """The key lives on the deployment's connector row. If that ever changes,
+    #1020's encryption has to cover it."""
+    assert CHANNEL_REGISTRY["resend"].secret_fields == set()
+
+
+# ── static delivery ───────────────────────────────────────────────────────
+
+
+def test_static_mode_sends_to_the_configured_addresses():
+    _result, kwargs = _send(_route(config={"to": ["a@x.example", "b@x.example"]}))
+    assert kwargs["to"] == ["a@x.example", "b@x.example"]
+
+
+def test_from_address_falls_back_to_the_connector_default():
+    _result, kwargs = _send(_route())
+    assert kwargs["from_address"] == "alerts@socfortress.co"
+
+
+def test_route_can_override_the_from_address():
+    _result, kwargs = _send(_route(config={"from_address": "ir@acme.example"}))
+    assert kwargs["from_address"] == "ir@acme.example"
+
+
+def test_missing_from_address_everywhere_is_a_clear_failure():
+    """Neither the connector nor the route supplies one — Resend would reject
+    the send, so fail with something actionable instead."""
+    result, kwargs = _send(_route(), creds=("https://api.resend.com", "re_key", None))
+
+    assert result.status == "failed"
+    assert "From address" in result.error_message
+    assert kwargs is None
+
+
+def test_subject_carries_severity_for_scanability():
+    _result, kwargs = _send(_route())
+    assert kwargs["subject"] == "[CoPilot] Critical: Mimikatz signature"
+
+
+def test_subject_prefix_is_configurable_and_optional():
+    _result, kwargs = _send(_route(config={"subject_prefix": ""}))
+    assert kwargs["subject"] == "Critical: Mimikatz signature"
+
+
+def test_message_id_becomes_the_provider_reference():
+    result, _kwargs = _send(_route())
+    assert result.status == "sent"
+    assert result.provider_reference == "msg-1"
+
+
+# ── assignee resolution: the point of the channel ─────────────────────────
+
+
+def test_assignee_mode_resolves_the_users_email():
+    user = SimpleNamespace(username="analyst_one", email="analyst_one@socfortress.co")
+    _result, kwargs = _send(
+        _route(recipient_mode="assignee", config={"to": []}),
+        event=_event(assignee="analyst_one"),
+        user=user,
+    )
+    assert kwargs["to"] == ["analyst_one@socfortress.co"]
+
+
+def test_assignee_mode_ignores_the_static_recipient_list():
+    """`to` is not a fallback in assignee mode — treating it as one would mail
+    the SOC list every time a lookup failed."""
+    user = SimpleNamespace(username="analyst_one", email="analyst_one@socfortress.co")
+    _result, kwargs = _send(
+        _route(recipient_mode="assignee", config={"to": ["everyone@acme.example"]}),
+        event=_event(assignee="analyst_one"),
+        user=user,
+    )
+    assert kwargs["to"] == ["analyst_one@socfortress.co"]
+
+
+def test_event_without_an_assignee_is_skipped_not_failed():
+    """An investigation_complete event reaching an assignee-mode route isn't a
+    misconfiguration — there is simply nobody to address."""
+    result, kwargs = _send(_route(recipient_mode="assignee", config={"to": []}), event=_event(assignee=None))
+
+    assert result.status == "skipped"
+    assert "no assignee" in result.error_message
+    assert kwargs is None
+
+
+def test_unknown_assignee_fails_with_the_username():
+    result, kwargs = _send(
+        _route(recipient_mode="assignee", config={"to": []}),
+        event=_event(assignee="departed_user"),
+        user=None,
+    )
+    assert result.status == "failed"
+    assert "departed_user" in result.error_message
+    assert kwargs is None
+
+
+def test_assignee_without_an_email_fails_clearly():
+    user = SimpleNamespace(username="analyst_one", email=None)
+    result, kwargs = _send(
+        _route(recipient_mode="assignee", config={"to": []}),
+        event=_event(assignee="analyst_one"),
+        user=user,
+    )
+    assert result.status == "failed"
+    assert "no email address" in result.error_message
+    assert kwargs is None
+
+
+# ── the shared quota ──────────────────────────────────────────────────────
+
+
+def test_throttle_skips_before_reaching_the_provider():
+    """A throttled send must cost nothing. The quota is a shared deployment
+    resource, so the check happens before the network call, not after."""
+    result, kwargs = _send(_route(config={"max_per_hour": 5}), recent_sends=5)
+
+    assert result.status == "skipped"
+    assert "Rate limit" in result.error_message
+    assert kwargs is None, "throttled send must not hit Resend"
+
+
+def test_under_the_throttle_still_sends():
+    result, kwargs = _send(_route(config={"max_per_hour": 5}), recent_sends=4)
+    assert result.status == "sent"
+    assert kwargs is not None
+
+
+def test_throttle_can_be_disabled_with_null():
+    result, _kwargs = _send(_route(config={"max_per_hour": None}), recent_sends=9999)
+    assert result.status == "sent"
+
+
+def test_throttle_must_be_a_positive_number():
+    with pytest.raises(ValueError):
+        ResendConfig(to=["a@b.c"], max_per_hour=0)
+
+
+# ── config shape ──────────────────────────────────────────────────────────
+
+
+def test_a_bare_string_recipient_is_accepted_as_one_address():
+    """The form sends a list, but hand-written config and API callers commonly
+    send a single address; rejecting that is needless friction."""
+    cfg = ResendConfig.model_validate({"to": "one@x.example"})
+    assert cfg.to == ["one@x.example"]
+
+
+def test_unknown_config_key_is_rejected():
+    with pytest.raises(ValueError):
+        ResendConfig.model_validate({"to": ["a@b.c"], "subjectprefix": "oops"})
+
+
+def test_defaults_are_sane_for_a_shared_quota():
+    cfg = ResendConfig()
+    assert cfg.max_per_hour == 20, "an unthrottled default would let one route drain the tier"
+    assert cfg.subject_prefix == "[CoPilot]"
+
+
+# ── connector failures ────────────────────────────────────────────────────
+
+
+def test_unconfigured_connector_surfaces_its_own_message():
+    """The operator needs "no API key set", not a generic dispatcher error."""
+    exc = HTTPException(status_code=503, detail="Resend connector is configured but has no API key set.")
+    result, kwargs = _send(_route(), creds=exc)
+
+    assert result.status == "failed"
+    assert result.error_message == "Resend connector is configured but has no API key set."
+    assert kwargs is None
+
+
+def test_malformed_config_fails_only_this_route():
+    broken = _route()
+    broken.config = "{not json"
+    result, kwargs = _send(broken)
+
+    assert result.status == "failed"
+    assert "Invalid resend config" in result.error_message
+    assert kwargs is None

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -5,6 +5,7 @@ import type {
 	NotificationRoute,
 	NotificationRoutePayload,
 	NotificationRouteUpdatePayload,
+	ResendQuota,
 	ShuffleApp,
 	ShuffleIntegration,
 	ShuffleIntegrationPayload,
@@ -50,6 +51,14 @@ export default {
 		return HttpClient.get<FlaskBaseResponse & { channels: NotificationChannelDescriptor[] }>(
 			`/notification_channels`
 		)
+	},
+
+	// Resend's quota is deployment-wide — one API key, one allowance shared by
+	// every customer's routes. customerCode only narrows the display breakdown.
+	getResendQuota(customerCode?: string) {
+		return HttpClient.get<FlaskBaseResponse & ResendQuota>(`/notification_channels/resend/quota`, {
+			params: customerCode ? { customer_code: customerCode } : undefined
+		})
 	},
 
 	listDispatchLog(customerCode: string) {

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -137,6 +137,64 @@
 			</div>
 		</template>
 
+		<!-- ===== Resend (email) channel fields ===== -->
+		<template v-else-if="isResend">
+			<n-form-item label="Deliver to" path="recipient_mode">
+				<n-select v-model:value="form.recipient_mode" :options="recipientModeOptions" />
+				<template #feedback>
+					<span v-if="isAssigneeMode">
+						Sent to whoever the alert or task is assigned to, resolved from their CoPilot account
+						at delivery time. Events with no assignee are skipped.
+					</span>
+					<span v-else>Sent to a fixed list of addresses.</span>
+				</template>
+			</n-form-item>
+
+			<n-form-item v-if="!isAssigneeMode" label="To" path="config.to">
+				<n-dynamic-input
+					v-model:value="toAddresses"
+					:on-create="() => ''"
+					placeholder="soc@example.com"
+					class="w-full"
+				/>
+			</n-form-item>
+
+			<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<n-form-item label="From (optional)" path="config.from_address">
+					<n-input v-model:value="cfg.from_address" placeholder="alerts@yourdomain.com" />
+					<template #feedback>
+						Must be on a domain verified in Resend. Leave empty to use the deployment default.
+					</template>
+				</n-form-item>
+
+				<n-form-item label="Reply-to (optional)" path="config.reply_to">
+					<n-input v-model:value="cfg.reply_to" placeholder="soc@yourdomain.com" />
+				</n-form-item>
+			</div>
+
+			<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<n-form-item label="Subject prefix" path="config.subject_prefix">
+					<n-input v-model:value="cfg.subject_prefix" placeholder="[CoPilot]" />
+				</n-form-item>
+
+				<n-form-item label="Max emails per hour" path="config.max_per_hour">
+					<n-input-number v-model:value="cfg.max_per_hour" :min="1" clearable class="w-full" />
+					<template #feedback>Clear to disable the throttle.</template>
+				</n-form-item>
+			</div>
+
+			<n-alert v-if="quota" :type="quotaTone" :bordered="false" class="mb-3">
+				<template v-if="!quota.configured">
+					The Resend connector has no API key set — routes on this channel will fail until it is
+					configured.
+				</template>
+				<template v-else>
+					{{ quota.sent_this_month }} of {{ quota.limit }} emails sent this month, across all
+					customers. Resend's allowance is deployment-wide, so every route draws from the same pool.
+				</template>
+			</n-alert>
+		</template>
+
 		<n-form-item label="Custom message template (optional)" path="format_template" :show-feedback="false">
 			<n-input
 				v-model:value="form.format_template"
@@ -204,10 +262,11 @@ import type {
 	NotificationRoutePayload,
 	NotificationSeverity,
 	NotificationTrigger,
+	ResendQuota,
 	ShuffleApp,
 	ShuffleIntegration
 } from "@/types/notifications"
-import { NButton, NCheckbox, NDynamicInput, NForm, NFormItem, NInput, NSelect, useMessage } from "naive-ui"
+import { NAlert, NButton, NCheckbox, NDynamicInput, NForm, NFormItem, NInput, NInputNumber, NSelect, useMessage } from "naive-ui"
 import { computed, onBeforeMount, reactive, ref } from "vue"
 import Api from "@/api"
 import { getApiErrorMessage } from "@/utils"
@@ -244,6 +303,12 @@ interface EditableChannelConfig {
 	method?: string
 	headers?: Record<string, string> | null
 	include_full_report?: boolean
+	to?: string[]
+	cc?: string[]
+	from_address?: string | null
+	reply_to?: string | null
+	subject_prefix?: string
+	max_per_hour?: number | null
 }
 
 const cfg = reactive<EditableChannelConfig>({ ...(props.editingRoute?.config ?? {}) })
@@ -267,6 +332,48 @@ const form = reactive<NotificationRoutePayload>({
 
 const isShuffle = computed(() => form.channel === "shuffle")
 const isWebhook = computed(() => form.channel === "webhook")
+const isResend = computed(() => form.channel === "resend")
+const isAssigneeMode = computed(() => form.recipient_mode === "assignee")
+
+// n-dynamic-input binds an array of strings; cfg.to is the source of truth.
+const toAddresses = computed({
+	get: () => cfg.to ?? [],
+	set: (v: string[]) => {
+		cfg.to = v
+	}
+})
+
+const recipientModeOptions = [
+	{ label: "A fixed list of addresses", value: "static" },
+	{ label: "Whoever it's assigned to", value: "assignee" }
+]
+
+// Deployment-wide, not per-customer: one API key, one allowance. Fetched only
+// when the channel is actually Resend so other routes don't pay for it.
+const quota = ref<ResendQuota | null>(null)
+const quotaTone = computed(() => {
+	if (!quota.value?.configured) return "warning"
+	const used = quota.value.sent_this_month / Math.max(quota.value.limit, 1)
+	return used >= 0.9 ? "error" : used >= 0.7 ? "warning" : "info"
+})
+
+async function loadQuota() {
+	if (!isResend.value || quota.value) return
+	try {
+		const res = await Api.notifications.getResendQuota(props.customerCode)
+		if (res.data.success) {
+			quota.value = {
+				sent_this_month: res.data.sent_this_month,
+				limit: res.data.limit,
+				customer_sent: res.data.customer_sent,
+				configured: res.data.configured
+			}
+		}
+	} catch {
+		// Non-fatal: the indicator is informational, and a failure here must not
+		// block someone from saving a route.
+	}
+}
 
 // Mutual exclusivity (webhook only): "include full report" and a custom
 // template are two alternative body modes. Ticking the box disables the
@@ -300,7 +407,8 @@ const triggerOptions = [
 
 const channelOptions = [
 	{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" },
-	{ label: "Webhook (direct HTTP to any URL)", value: "webhook" }
+	{ label: "Webhook (direct HTTP to any URL)", value: "webhook" },
+	{ label: "Email (Resend)", value: "resend" }
 ]
 
 const methodOptions = [
@@ -375,6 +483,16 @@ function onChannelChange(channel: NotificationChannel) {
 	clearFieldError("shuffle_app_id")
 	clearFieldError("destination")
 	clearFieldError("webhook_url")
+	if (channel !== "resend" && form.recipient_mode === "assignee") {
+		// Only email can resolve a person; leaving the mode set would fail the
+		// provider's supports_recipient_modes check on save.
+		form.recipient_mode = "static"
+	}
+	if (channel === "resend") {
+		if (!cfg.subject_prefix) cfg.subject_prefix = "[CoPilot]"
+		if (cfg.max_per_hour === undefined) cfg.max_per_hour = 20
+		loadQuota()
+	}
 	if (channel === "webhook" && !cfg.method) {
 		cfg.method = "POST"
 	}
@@ -541,15 +659,32 @@ async function submit() {
 						include_full_report: Boolean(cfg.include_full_report)
 					}
 				}
-			: {
-					...base,
-					destination: form.destination,
-					shuffle_integration_id: form.shuffle_integration_id,
-					config: {
-						app_id: cfg.app_id ?? null,
-						app_name: cfg.app_name ?? null
+			: isResend.value
+				? {
+						...base,
+						destination: null,
+						shuffle_integration_id: null,
+						config: {
+							// Assignee mode resolves the address from the event, so an
+							// unused `to` list is dropped rather than persisted as a
+							// fallback it would never act as.
+							to: isAssigneeMode.value ? [] : (cfg.to ?? []).filter(a => a.trim().length > 0),
+							cc: (cfg.cc ?? []).filter(a => a.trim().length > 0),
+							from_address: cfg.from_address?.trim() || null,
+							reply_to: cfg.reply_to?.trim() || null,
+							subject_prefix: cfg.subject_prefix ?? "[CoPilot]",
+							max_per_hour: cfg.max_per_hour ?? null
+						}
 					}
-				}
+				: {
+						...base,
+						destination: form.destination,
+						shuffle_integration_id: form.shuffle_integration_id,
+						config: {
+							app_id: cfg.app_id ?? null,
+							app_name: cfg.app_name ?? null
+						}
+					}
 
 		const res = props.editingRoute
 			? await Api.notifications.updateRoute(props.customerCode, props.editingRoute.id, payload)

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -8,7 +8,7 @@
 // analyst-review / IOC-enrichment / scheduled sweeps.
 export type NotificationTrigger = "investigation_complete"
 
-export type NotificationChannel = "shuffle" | "webhook"
+export type NotificationChannel = "shuffle" | "webhook" | "resend"
 
 export type NotificationSeverity = "Critical" | "High" | "Medium" | "Low" | "Informational"
 
@@ -32,6 +32,24 @@ export type ChannelConfig = Record<string, unknown>
 export interface ShuffleChannelConfig extends ChannelConfig {
 	app_id?: string | null
 	app_name?: string | null
+}
+
+export interface ResendChannelConfig extends ChannelConfig {
+	to?: string[]
+	cc?: string[]
+	from_address?: string | null
+	reply_to?: string | null
+	subject_prefix?: string
+	// Per-route throttle. Resend's free tier is 1,000/month across the WHOLE
+	// deployment, so this guards a shared resource, not just this route.
+	max_per_hour?: number | null
+}
+
+export interface ResendQuota {
+	sent_this_month: number
+	limit: number
+	customer_sent: number | null
+	configured: boolean
 }
 
 export interface WebhookChannelConfig extends ChannelConfig {


### PR DESCRIPTION
Closes #1004. First channel added since Phase 1 landed.

## No migration

A provider module, a registry line, a connector tuple. Nothing else. `route.config` already carries whatever a channel needs, so this is the first real proof of the claim Phase 1 was built on — and it held.

## First channel that can address a person

A webhook targets a URL; Shuffle targets an app. Email can resolve the *event's assignee* at dispatch time, so `recipient_mode='assignee'` becomes usable for the first time.

That's what makes **"notify whoever this alert was assigned to"** expressible in #1006. Until now assignment notifications could only post to a fixed channel — half the original ask.

Every resolution failure is a **logged outcome, never an exception**:

| Situation | Result | Why |
|---|---|---|
| Event has no assignee | `skipped` | Nothing is misconfigured — there's simply nobody to address. An `investigation_complete` event hitting an assignee route is normal. |
| Username not found | `failed` | Names the username, so a departed analyst is obvious |
| User has no email | `failed` | Distinct from "not found" — different fix |
| Connector unset / config malformed | `failed` | Fails that route only, never the batch |

`to` is deliberately **not** a fallback in assignee mode. Treating it as one would quietly mail the SOC list every time a lookup failed.

## Quota is the operational constraint

The free tier is 1,000 emails/month across the **whole deployment** — the API key is shared, so every customer's routes draw from one allowance, and one noisy route can drain it for everyone.

I tried to measure real alert volume before building, as #1004 asked. **That was inconclusive**: the dev database holds 34 alerts spanning two years, one in the last 30 days. Reading that as headroom would be exactly the wrong conclusion — production could be three orders of magnitude higher.

So rather than guess, this ships the instruments:

- **Per-route trailing-hour throttle** (`max_per_hour`, default 20), checked *before* the network call so a throttled send costs nothing and appears in the dispatch log with a reason
- **Deployment-wide calendar-month counter**, surfaced in the route form, shifting info → warning → error as the month fills

Both derive from `notification_dispatch_log` rather than a counter column — the log already records what was sent, and a separate counter is one more thing to keep in step. Only `sent` rows count; a `failed` send never reached Resend, a `skipped` one never left the process. Calendar month, not trailing 30 days, because that's how Resend bills and resets.

If production volume makes the free tier untenable, the counter says so **with data**, and digest batching becomes urgent on evidence rather than on my guess.

## Verified against the live API

Through our own dispatcher, not raw HTTP:

```
success  -> sent, 390ms, message id captured as provider_reference
failure  -> "You can only send testing emails to your own email address…
             verify a domain at resend.com/domains"
```

The failure case was the more valuable one: it proves the error extraction works. An operator sees Resend's own message instead of `Resend returned 403`, which is the difference between a five-minute fix and a support ticket.

Test credentials live in `.env` only — confirmed gitignored before writing, and the staged diff contains zero occurrences of the key. `.env.example` keeps `REPLACE_ME`.

Incidental finding: the test key is **send-only restricted**, so `GET /domains` 401s. Nothing we call uses that endpoint, but a future "verify connector" button couldn't work with a key of that shape.

## Three calls worth pushing back on

**Plaintext only.** Resend accepts `html`, but the rendered body is markdown-ish today — sending it as HTML would display the markup. Real HTML arrives with templates (#1009).

**`max_per_hour` lives in `ResendConfig`**, not as a channel-agnostic route column. No schema change needed, but a future rate-limited channel will duplicate the field.

**I wrote a hand-written form block rather than the generic schema renderer.** I'd said I'd build that "when the real field shapes are known" — and now that they are, Resend turns out to be a poor first case: `to` is required in static mode and meaningless in assignee mode, which is form logic JSON Schema can't express. **Teams (#1005) is the better candidate**, its config being a single URL. So the renderer remains outstanding, and #1005 should carry it.

## Testing

```
23 new     tests/test_notification_resend_channel.py
172 passed backend tests/
type-check exit 0 · eslint clean · pre-commit clean
```

Covers assignee resolution and all four failure modes, the throttle skipping before the provider call, quota defaults (an unthrottled default would let one route drain the tier), single-string recipient coercion, unknown-key rejection, and connector-failure message surfacing.

## Next

#1006 — alert-created and assignment triggers — now lands with assignee email working on day one, which was the point of doing this first.
