### PR TITLE
feat(notifications): alert-created and assignment triggers

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -246,6 +246,9 @@ from app.incidents.services.notification_enrichment import extract_rule_level
 from app.incidents.services.notification_enrichment import severity_from_rule_level
 from app.middleware.customer_access import customer_access_handler
 from app.middleware.customer_query import customer_codes_query
+from app.notifications.services.emit import emit
+from app.notifications.services.event_builders import alert_assigned_event
+from app.notifications.services.event_builders import case_assigned_event
 
 incidents_db_operations_router = APIRouter()
 
@@ -762,13 +765,39 @@ async def get_available_users(db: AsyncSession = Depends(get_db)):
     response_model=AlertResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def update_assigned_to_endpoint(assigned_to: AssignedToAlert, db: AsyncSession = Depends(get_db)):
+async def update_assigned_to_endpoint(
+    assigned_to: AssignedToAlert,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     all_users = await select_all_users()
     user_names = [user.username for user in all_users]
     if assigned_to.assigned_to not in user_names:
         raise HTTPException(status_code=400, detail="User does not exist")
+
+    # Read the current assignee BEFORE the mutation: the notification below only
+    # fires on an actual change, so rewriting the same value stays silent.
+    existing = await db.execute(select(Alert).where(Alert.id == assigned_to.alert_id))
+    existing_alert = existing.scalars().first()
+    previous_assignee = existing_alert.assigned_to if existing_alert else None
+    alert_title = existing_alert.alert_name if existing_alert else None
+    alert_customer = existing_alert.customer_code if existing_alert else None
+
+    updated = await update_alert_assigned_to(assigned_to.alert_id, assigned_to.assigned_to, db)
+
+    if previous_assignee != assigned_to.assigned_to:
+        emit(
+            alert_assigned_event(
+                alert_id=assigned_to.alert_id,
+                title=alert_title,
+                assignee=assigned_to.assigned_to,
+                actor=current_user.username,
+                customer_code=alert_customer,
+            ),
+        )
+
     return AlertResponse(
-        alert=await update_alert_assigned_to(assigned_to.alert_id, assigned_to.assigned_to, db),
+        alert=updated,
         success=True,
         message="Alert assigned to user successfully",
     )
@@ -2109,6 +2138,20 @@ async def update_case_assigned_to_endpoint(
         payload=payload_assignment(from_assignee=previous_assignee, to_assignee=assigned_to.assigned_to),
         commit=True,
     )
+
+    # Notification routes (#1006). Only when the assignee actually changed — a
+    # PATCH rewriting the same value must not re-notify. Resolves against
+    # internal-scope routes, so this never reaches the customer's channel.
+    if previous_assignee != assigned_to.assigned_to:
+        emit(
+            case_assigned_event(
+                case_id=assigned_to.case_id,
+                title=getattr(case, "case_name", None),
+                assignee=assigned_to.assigned_to,
+                actor=current_user.username,
+                customer_code=case.customer_code,
+            ),
+        )
 
     # Re-fetch the case with full data structure
     updated_case = await get_case_by_id(assigned_to.case_id, db)

--- a/backend/app/incidents/services/case_tasks.py
+++ b/backend/app/incidents/services/case_tasks.py
@@ -676,6 +676,24 @@ async def update_case_task(
         await session.commit()
         await session.refresh(task)
 
+        # Notification routes (#1006). `assignment_changed` is the same guard the
+        # audit event uses, so a no-op write neither logs nor notifies.
+        if assignment_changed:
+            from app.notifications.services.emit import emit
+            from app.notifications.services.event_builders import (
+                case_task_assigned_event,
+            )
+
+            emit(
+                case_task_assigned_event(
+                    task_id=task.id,
+                    case_id=task.case_id,
+                    title=task.title,
+                    assignee=task.assigned_to,
+                    actor=actor,
+                ),
+            )
+
         return CaseTaskOperationResponse(
             task=_case_task_to_response(task),
             success=True,

--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -54,6 +54,8 @@ from app.integrations.alert_creation_settings.models.alert_creation_settings imp
 )
 from app.integrations.alert_escalation.schema.escalate_alert import CustomerCodeKeys
 from app.integrations.routes import get_customer_by_auth_key
+from app.notifications.services.emit import emit
+from app.notifications.services.event_builders import alert_created_event
 
 
 async def fetch_settings(field: str, value: str, session: AsyncSession, case_insensitive: bool = False):
@@ -987,6 +989,27 @@ async def create_alert_full(
 
     # Trigger Talon investigation if enabled for this customer
     await handle_talon_investigation(alert_id, customer_code, session)
+
+    # Notification routes on the new engine (#1006). Deliberately placed after
+    # the recurrence early-return above, so a repeated alert does not re-notify.
+    #
+    # NOTE: handle_customer_notifications() above fires the LEGACY per-customer
+    # Shuffle workflow on the same event. Both are opt-in, so a customer only
+    # sees two notifications if an operator configures both — the route form
+    # warns when that is the case.
+    #
+    # Fire-and-forget: this is the ingest hot path and must not wait on an
+    # outbound HTTP call.
+    emit(
+        alert_created_event(
+            alert_id=alert_id,
+            customer_code=customer_code,
+            alert_title=alert_payload.alert_title_payload,
+            severity=alert_payload.severity,
+            rule_level=alert_payload.rule_level,
+            asset_name=asset.asset_name if asset is not None else None,
+        ),
+    )
 
     if threshold_alert is True or velo_sigma_alert is True:
         logger.info(

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -44,6 +44,12 @@ class NotificationTrigger(str, Enum):
 
     INVESTIGATION_COMPLETE = "investigation_complete"
 
+    # Fired by CoPilot itself rather than pushed in by Talon.
+    ALERT_CREATED = "alert_created"
+    ALERT_ASSIGNED = "alert_assigned"
+    CASE_ASSIGNED = "case_assigned"
+    CASE_TASK_ASSIGNED = "case_task_assigned"
+
 
 class NotificationChannel(str, Enum):
     """Delivery channel set.
@@ -135,6 +141,18 @@ class DispatchStatus(str, Enum):
 # The legacy `severity_critical_or_high` value is included because routes saved
 # against an older schema still dispatch through the same AI path; see
 # `_trigger_applies`.
+# Triggers about *who is working on something* rather than about a customer's
+# security posture. They resolve against scope='internal' routes, so assigning
+# an ACME alert to an analyst reaches the SOC, never ACME's channel.
+INTERNAL_TRIGGERS: frozenset = frozenset(
+    {
+        "alert_assigned",
+        "case_assigned",
+        "case_task_assigned",
+    },
+)
+
+
 AI_SOURCED_TRIGGERS: frozenset = frozenset(
     {
         "investigation_complete",

--- a/backend/app/notifications/services/emit.py
+++ b/backend/app/notifications/services/emit.py
@@ -1,0 +1,107 @@
+"""Fire-and-forget notification emission from inside CoPilot.
+
+Until now the dispatch loop was only ever reached from Talon's HTTP call, where
+blocking was fine — the caller was waiting for a dispatch result anyway. The
+triggers added in #1006 sit somewhere much less forgiving: `alert_created` is on
+the **ingest hot path**, and a slow Resend or Teams endpoint must never back up
+alert creation.
+
+So emission is scheduled and abandoned. The dispatch log is the durable record
+of what happened; nothing is returned to the caller and nothing propagates back.
+
+Two hazards this module exists to contain:
+
+**A background task must open its own session.** Reusing the request-scoped one
+after the response has been returned raises `MissingGreenlet` or a
+closed-session error — the same async-SQLAlchemy hazard the notification models
+already carry comments about. `_run` opens a fresh `AsyncSession` and owns it.
+
+**A hung provider must not leak a task forever.** The whole dispatch is wrapped
+in a timeout, so a black-holed endpoint produces a logged failure rather than a
+task that never finishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+from typing import Set
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.db_session import async_engine
+from app.notifications.schema.events import NotificationEvent
+
+#: Ceiling for one whole emission — every matched route, including provider
+#: calls. Generous because a batch may fan out to several channels; the point is
+#: to bound a hang, not to be tight.
+_EMIT_TIMEOUT_S = 60.0
+
+#: asyncio keeps only a weak reference to a bare task, so one that is never
+#: awaited can be garbage-collected mid-flight. Holding a strong reference until
+#: it completes is the documented way to avoid that.
+_IN_FLIGHT: Set[asyncio.Task] = set()
+
+
+async def _run(event: NotificationEvent) -> None:
+    """Dispatch on a session of our own, swallowing everything."""
+    # Imported here rather than at module scope: the services module imports the
+    # channels package, which imports schemas — a top-level import would make
+    # this module part of that cycle.
+    from app.notifications.services.notifications import dispatch_event
+
+    try:
+        async with AsyncSession(async_engine) as session:
+            response = await asyncio.wait_for(dispatch_event(event, session), timeout=_EMIT_TIMEOUT_S)
+        if response.routes_matched:
+            logger.info(
+                f"Notification emit [{event.trigger.value}] {event.entity_type}#{event.entity_id}: "
+                f"{response.dispatched} sent, {response.skipped} skipped, {response.failed} failed "
+                f"across {response.routes_matched} route(s).",
+            )
+    except asyncio.TimeoutError:
+        logger.error(
+            f"Notification emit [{event.trigger.value}] {event.entity_type}#{event.entity_id} "
+            f"timed out after {_EMIT_TIMEOUT_S}s; abandoning.",
+        )
+    except Exception as e:  # noqa: BLE001 — nothing here may reach the caller
+        logger.error(f"Notification emit [{event.trigger.value}] failed: {type(e).__name__}: {e}")
+
+
+def emit(event: NotificationEvent) -> None:
+    """Schedule `event` for dispatch and return immediately.
+
+    Deliberately synchronous and returning None: callers sit on the ingest path
+    and in request handlers, and must not be able to await this by accident.
+
+    Safe to call with no running event loop (a sync context or a test): the
+    emission is skipped with a warning rather than raising, because failing to
+    notify must never fail the operation that triggered it.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning(
+            f"Notification emit [{event.trigger.value}] skipped: no running event loop.",
+        )
+        return
+
+    task = loop.create_task(_run(event))
+    _IN_FLIGHT.add(task)
+    task.add_done_callback(_IN_FLIGHT.discard)
+
+
+async def emit_now(event: NotificationEvent, session: Optional[AsyncSession] = None):
+    """Dispatch inline and return the result. For tests and explicit callers.
+
+    `emit` is the right entry point for production code; this exists so a test
+    can assert on outcomes without racing a background task, and so a future
+    synchronous "send test notification" button has something to await.
+    """
+    from app.notifications.services.notifications import dispatch_event
+
+    if session is not None:
+        return await dispatch_event(event, session)
+    async with AsyncSession(async_engine) as own_session:
+        return await dispatch_event(event, own_session)

--- a/backend/app/notifications/services/event_builders.py
+++ b/backend/app/notifications/services/event_builders.py
@@ -1,0 +1,177 @@
+"""Construct `NotificationEvent`s for CoPilot-originated triggers.
+
+Kept out of the incident modules so the emit points there stay one line, and out
+of the notifications service so the dispatch loop has no knowledge of alerts or
+cases. Each builder owns two things that are easy to get wrong in-line:
+
+**The dedupe key**, which decides what counts as "the same notification". For
+assignments it includes the assignee, so reassigning A → B → A notifies A again
+while a no-op write does not.
+
+**The severity**, which decides whether a route's `min_severity` lets it
+through. Assignments have no inherent severity and use INFORMATIONAL so they are
+governed by the route's trigger filter rather than accidentally suppressed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Optional
+
+from app.notifications.schema.events import EntityType
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.schema.notifications import NotificationSeverity
+from app.notifications.schema.notifications import NotificationTrigger
+
+#: Assignments carry no security severity of their own. INFORMATIONAL means a
+#: route filters them by trigger, not by an invented severity — anything higher
+#: would silently drop them on routes tuned for real alerts.
+_ASSIGNMENT_SEVERITY = NotificationSeverity.INFORMATIONAL
+
+
+def _coerce_severity(value: Optional[str]) -> NotificationSeverity:
+    """Map a payload severity string onto the enum, defaulting to Medium.
+
+    `alert_payload.severity` is derived from the Wazuh rule level (issue #980)
+    and is None for sources that carry no level. Medium rather than
+    Informational so a severity-less alert isn't quietly filtered out of every
+    route that gates above Informational.
+    """
+    if not value:
+        return NotificationSeverity.MEDIUM
+    try:
+        return NotificationSeverity(value)
+    except ValueError:
+        return NotificationSeverity.MEDIUM
+
+
+def alert_created_event(
+    *,
+    alert_id: int,
+    customer_code: str,
+    alert_title: Optional[str],
+    severity: Optional[str] = None,
+    rule_level: Optional[int] = None,
+    asset_name: Optional[str] = None,
+    link_url: Optional[str] = None,
+) -> NotificationEvent:
+    """A new alert landed.
+
+    Only ever built for genuinely new alerts — `create_alert()` short-circuits
+    on recurrence before reaching the emit point, so a repeated alert does not
+    re-notify.
+    """
+    title = alert_title or f"Alert #{alert_id}"
+    return NotificationEvent(
+        customer_code=customer_code,
+        trigger=NotificationTrigger.ALERT_CREATED,
+        severity=_coerce_severity(severity),
+        subject=title,
+        summary=f"A new alert was created for {customer_code}.",
+        entity_type=EntityType.ALERT,
+        entity_id=alert_id,
+        dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.ALERT_CREATED.value}",
+        link_url=link_url,
+        context={"alert_name": title, "rule_level": rule_level, "asset_name": asset_name},
+    )
+
+
+def _assignment_event(
+    *,
+    trigger: NotificationTrigger,
+    entity_type: str,
+    entity_id: int,
+    title: Optional[str],
+    assignee: Optional[str],
+    actor: Optional[str],
+    customer_code: Optional[str],
+    summary: str,
+    link_url: Optional[str] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> NotificationEvent:
+    """Shared shape for the three assignment triggers.
+
+    The dedupe key includes the assignee on purpose: reassigning A → B → A
+    should notify A the second time, which a key of just (entity, trigger)
+    could not express. `unassigned` keeps a clear-out distinct from an
+    assignment.
+    """
+    context: dict[str, Any] = {"title": title}
+    if extra:
+        context.update(extra)
+    return NotificationEvent(
+        customer_code=customer_code,
+        trigger=trigger,
+        severity=_ASSIGNMENT_SEVERITY,
+        subject=title or f"{entity_type} #{entity_id}",
+        summary=summary,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        dedupe_key=f"{entity_type}:{entity_id}:{trigger.value}:{assignee or 'unassigned'}",
+        link_url=link_url,
+        assignee_username=assignee,
+        actor_username=actor,
+        context=context,
+    )
+
+
+def alert_assigned_event(
+    *,
+    alert_id: int,
+    title: Optional[str],
+    assignee: Optional[str],
+    actor: Optional[str],
+    customer_code: Optional[str] = None,
+) -> NotificationEvent:
+    return _assignment_event(
+        trigger=NotificationTrigger.ALERT_ASSIGNED,
+        entity_type=EntityType.ALERT,
+        entity_id=alert_id,
+        title=title,
+        assignee=assignee,
+        actor=actor,
+        customer_code=customer_code,
+        summary=(f"Alert #{alert_id} was assigned to {assignee}." if assignee else f"Alert #{alert_id} was unassigned."),
+    )
+
+
+def case_assigned_event(
+    *,
+    case_id: int,
+    title: Optional[str],
+    assignee: Optional[str],
+    actor: Optional[str],
+    customer_code: Optional[str] = None,
+) -> NotificationEvent:
+    return _assignment_event(
+        trigger=NotificationTrigger.CASE_ASSIGNED,
+        entity_type=EntityType.CASE,
+        entity_id=case_id,
+        title=title,
+        assignee=assignee,
+        actor=actor,
+        customer_code=customer_code,
+        summary=(f"Case #{case_id} was assigned to {assignee}." if assignee else f"Case #{case_id} was unassigned."),
+    )
+
+
+def case_task_assigned_event(
+    *,
+    task_id: int,
+    case_id: int,
+    title: Optional[str],
+    assignee: Optional[str],
+    actor: Optional[str],
+    customer_code: Optional[str] = None,
+) -> NotificationEvent:
+    return _assignment_event(
+        trigger=NotificationTrigger.CASE_TASK_ASSIGNED,
+        entity_type=EntityType.CASE_TASK,
+        entity_id=task_id,
+        title=title,
+        assignee=assignee,
+        actor=actor,
+        customer_code=customer_code,
+        summary=(f"Task '{title}' on case #{case_id} was assigned to {assignee}." if assignee else f"Task '{title}' was unassigned."),
+        extra={"case_id": case_id},
+    )

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -40,6 +40,7 @@ from app.notifications.schema.events import EntityType
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.schema.events import event_from_dispatch_request
 from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS
+from app.notifications.schema.notifications import INTERNAL_TRIGGERS
 from app.notifications.schema.notifications import SEVERITY_ORDER
 from app.notifications.schema.notifications import DispatchOutcome
 from app.notifications.schema.notifications import DispatchRequest
@@ -536,44 +537,97 @@ async def _ai_reports_permitted(trigger: str, customer_code: str, session: Async
     return await is_ai_reports_enabled(customer_code, session)
 
 
-def _format_default_body(req: DispatchRequest) -> str:
-    """Plain default formatter when a route has no `format_template`.
+def _format_default_body(event: NotificationEvent) -> str:
+    """Default message body when a route sets no `format_template`.
 
-    Markdown-ish but readable in both Slack and email — both channels
-    render this acceptably without extra structure. Phase 4 swaps for
-    per-channel templates.
+    Markdown-ish: readable as-is in Slack, Teams and a plaintext email. Per-
+    trigger wording, because "AI investigation complete" is wrong for an
+    assignment and "assigned to" is wrong for an alert landing.
+
+    The investigation_complete branch reproduces the pre-#1006 text exactly —
+    it is what existing customers already receive.
     """
+    trig = event.trigger.value
+    ctx = event.context or {}
+
+    if trig in INTERNAL_TRIGGERS:
+        what = {
+            "alert_assigned": "Alert",
+            "case_assigned": "Case",
+            "case_task_assigned": "Task",
+        }.get(trig, "Item")
+        label = ctx.get("title") or event.subject
+        parts = [
+            f"*{what} assigned* — {event.assignee_username or 'unassigned'}",
+            "",
+            f"{what}: #{event.entity_id}" + (f" — {label}" if label else ""),
+        ]
+        if event.customer_code:
+            parts.append(f"Customer: `{event.customer_code}`")
+        if event.actor_username:
+            parts.append(f"Assigned by: {event.actor_username}")
+        if event.summary:
+            parts.extend(["", event.summary.strip()])
+        if event.link_url:
+            parts.extend(["", f"Open in CoPilot: {event.link_url}"])
+        return "\n".join(parts)
+
+    if trig == NotificationTrigger.ALERT_CREATED.value:
+        parts = [
+            f"*New alert* — severity: *{event.severity.value}*",
+            "",
+            f"Customer: `{event.customer_code}`",
+            f"Alert: #{event.entity_id}" + (f" — {event.subject}" if event.subject else ""),
+        ]
+        if ctx.get("asset_name"):
+            parts.append(f"Asset: {ctx['asset_name']}")
+        if ctx.get("rule_level") is not None:
+            parts.append(f"Rule level: {ctx['rule_level']}")
+        if event.summary:
+            parts.extend(["", event.summary.strip()])
+        if event.link_url:
+            parts.extend(["", f"Open in CoPilot: {event.link_url}"])
+        return "\n".join(parts)
+
+    # investigation_complete — unchanged wording, existing customers see this.
+    alert_name = ctx.get("alert_name")
     parts = [
-        f"*AI investigation complete* — severity: *{req.severity_assessment.value}*",
+        f"*AI investigation complete* — severity: *{event.severity.value}*",
         "",
-        f"Customer: `{req.customer_code}`",
-        f"Alert: #{req.alert_id}" + (f" — {req.alert_name}" if req.alert_name else ""),
+        f"Customer: `{event.customer_code}`",
+        f"Alert: #{event.entity_id}" + (f" — {alert_name}" if alert_name else ""),
         "",
-        req.summary.strip(),
+        event.summary.strip(),
     ]
-    if req.report_url:
-        parts.extend(["", f"Full report: {req.report_url}"])
+    if event.link_url:
+        parts.extend(["", f"Full report: {event.link_url}"])
     return "\n".join(parts)
 
 
-def _render_body(route: CustomerNotificationRoute, req: DispatchRequest) -> str:
-    """Apply the route's `format_template` if set, else fall back.
+def _render_body(route: CustomerNotificationRoute, event: NotificationEvent) -> str:
+    """Apply the route's `format_template` if set, else the default.
 
-    Phase 1's templating is intentionally minimal — `{{ variable }}`
-    substitution only, no Jinja control flow. Real Jinja can come in
-    Phase 4 when the per-channel templates land.
+    Substitution is `{{token}}` replacement only — no control flow. Real Jinja
+    arrives with #1009. Token names are unchanged from before the envelope so
+    existing stored templates keep rendering identically.
     """
     if not route.format_template:
-        return _format_default_body(req)
+        return _format_default_body(event)
 
+    ctx = event.context or {}
     body = route.format_template
     substitutions = {
-        "{{customer_code}}": req.customer_code,
-        "{{alert_id}}": str(req.alert_id),
-        "{{alert_name}}": req.alert_name or "",
-        "{{severity}}": req.severity_assessment.value,
-        "{{summary}}": req.summary,
-        "{{report_url}}": req.report_url or "",
+        "{{customer_code}}": event.customer_code or "",
+        "{{alert_id}}": str(event.entity_id),
+        "{{alert_name}}": ctx.get("alert_name") or event.subject or "",
+        "{{severity}}": event.severity.value,
+        "{{summary}}": event.summary,
+        "{{report_url}}": event.link_url or "",
+        # New with #1006; empty on triggers that don't carry them.
+        "{{assignee}}": event.assignee_username or "",
+        "{{actor}}": event.actor_username or "",
+        "{{entity_type}}": event.entity_type,
+        "{{entity_id}}": str(event.entity_id),
     }
     for token, value in substitutions.items():
         body = body.replace(token, value)
@@ -671,26 +725,68 @@ async def _record_log(
         return False
 
 
-async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchResponse:
-    """Walk the customer's routes, fire each match, log each outcome.
+async def routes_for_event(event: NotificationEvent, session: AsyncSession) -> List[CustomerNotificationRoute]:
+    """Candidate routes for an event, before trigger/severity filtering.
 
-    Idempotency is enforced at the log table — we attempt the insert
-    *before* calling the provider, so a re-dispatch sees the existing
-    row and short-circuits without sending. (The cost is one wasted
-    INSERT in the race case, which is fine.)
-
-    ``req`` is Talon's wire format and stays untouched (it is an external
-    contract); it is adapted into a ``NotificationEvent`` here, and everything
-    downstream — providers included — sees only the envelope. New triggers
-    (#1006) construct the envelope directly and never build a DispatchRequest.
+    Scope decides the pool, and the split is the point of the whole dimension:
+    an assignment is about *who is working on something*, so it resolves against
+    internal routes and never reaches the customer whose alert it was. Anything
+    else is about the customer's security posture and resolves against theirs.
     """
-    event = event_from_dispatch_request(req)
-    routes = await list_routes(req.customer_code, session)
+    if event.trigger.value in INTERNAL_TRIGGERS:
+        stmt = select(CustomerNotificationRoute).where(
+            CustomerNotificationRoute.scope == NotificationScope.INTERNAL.value,
+        )
+    else:
+        stmt = select(CustomerNotificationRoute).where(
+            CustomerNotificationRoute.scope == NotificationScope.CUSTOMER.value,
+            CustomerNotificationRoute.customer_code == event.customer_code,
+        )
+    result = await session.execute(stmt.order_by(desc(CustomerNotificationRoute.created_at)))
+    return result.scalars().all()
+
+
+def _self_assignment_suppressed(route: CustomerNotificationRoute, event: NotificationEvent) -> bool:
+    """Whether to drop a self-assignment for this route.
+
+    An analyst picking up their own alert doesn't need a notification about it.
+    Opt-in per route because some teams do want the audit trail.
+    """
+    if event.trigger.value not in INTERNAL_TRIGGERS:
+        return False
+    if not event.actor_username or not event.assignee_username:
+        return False
+    if event.actor_username != event.assignee_username:
+        return False
+    return not bool(getattr(route, "notify_on_self_assign", False))
+
+
+async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchResponse:
+    """Talon's entry point. Adapts the wire format and delegates.
+
+    Kept as a thin shim because `DispatchRequest` is an external contract; every
+    CoPilot-originated trigger builds a `NotificationEvent` directly and calls
+    `dispatch_event`.
+    """
+    return await dispatch_event(event_from_dispatch_request(req), session)
+
+
+async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> DispatchResponse:
+    """Walk the matching routes, fire each, log every outcome.
+
+    Idempotency is enforced at the log table — the insert is attempted *before*
+    the provider call, so a re-dispatch sees the existing row and short-circuits
+    without sending.
+    """
+    routes = await routes_for_event(event, session)
 
     matched_routes = [
         r
         for r in routes
-        if r.enabled and _trigger_applies(req.trigger.value, r.trigger) and _severity_meets(req.severity_assessment.value, r.min_severity)
+        if r.enabled
+        and _trigger_applies(event.trigger.value, r.trigger)
+        and _severity_meets(event.severity.value, r.min_severity)
+        and not _self_assignment_suppressed(r, event)
     ]
 
     outcomes: List[DispatchOutcome] = []
@@ -701,19 +797,21 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
     # is far easier to debug than silence — but BEFORE the connector fetch and
     # any provider call, so nothing leaves the process.
     #
-    # Every route today is customer-facing (`customer_code` is NOT NULL). Once
-    # the scope dimension lands (#1003) this must additionally check
-    # `route.scope == 'customer'` per route, because internal/analyst-facing
-    # routes are deliberately exempt: running investigations while keeping the
-    # results internal is a supported configuration.
-    if matched_routes and not await _ai_reports_permitted(req.trigger.value, req.customer_code, session):
+    # Only customer-facing routes are gated. Internal routes are deliberately
+    # exempt: running investigations while keeping the results internal is a
+    # supported configuration, and the switch governs what reaches the CUSTOMER.
+    # (routes_for_event already returns one scope or the other, so in practice
+    # this filter is all-or-nothing — it is written per-route so it stays
+    # correct if a future trigger mixes scopes.)
+    gated_routes = [r for r in matched_routes if r.scope == NotificationScope.CUSTOMER.value]
+    if gated_routes and not await _ai_reports_permitted(event.trigger.value, event.customer_code, session):
         logger.info(
-            f"AI reports are not enabled for customer {req.customer_code}; "
-            f"suppressing {len(matched_routes)} matched notification route(s) "
-            f"for alert {req.alert_id}.",
+            f"AI reports are not enabled for customer {event.customer_code}; "
+            f"suppressing {len(gated_routes)} matched notification route(s) "
+            f"for alert {event.entity_id}.",
         )
         reason = "AI reports are not enabled for this customer; notification suppressed."
-        for route in matched_routes:
+        for route in gated_routes:
             # Cache before the await — see the attribute-caching note in the
             # main loop below.
             route_id = route.id
@@ -741,7 +839,7 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         return DispatchResponse(
             success=True,
             message="Dispatch suppressed — AI reports are not enabled for this customer",
-            routes_matched=len(matched_routes),
+            routes_matched=len(gated_routes),
             dispatched=0,
             skipped=skipped,
             failed=0,
@@ -765,7 +863,7 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
         route_name = route.name
         route_channel = route.channel
 
-        body = _render_body(route, req)
+        body = _render_body(route, event)
         body_preview = body[:500]
 
         latency_ms: Optional[int] = None
@@ -871,7 +969,9 @@ async def dispatch(req: DispatchRequest, session: AsyncSession) -> DispatchRespo
 
     return DispatchResponse(
         success=True,
-        message=(f"Dispatched {sent} of {len(matched_routes)} matching route(s) " f"for customer {req.customer_code} alert {req.alert_id}"),
+        message=(
+            f"Dispatched {sent} of {len(matched_routes)} matching route(s) " f"for customer {event.customer_code} alert {event.entity_id}"
+        ),
         routes_matched=len(matched_routes),
         dispatched=sent,
         skipped=skipped,

--- a/backend/tests/test_notification_ai_report_gating.py
+++ b/backend/tests/test_notification_ai_report_gating.py
@@ -38,12 +38,18 @@ from app.notifications.schema.notifications import NotificationTrigger  # noqa: 
 CUSTOMER = "TENANT_A"
 
 
-def _route(route_id=1, name="SOC webhook", channel=NotificationChannel.WEBHOOK.value):
-    """A route that matches any Informational-or-above investigation dispatch."""
+def _route(route_id=1, name="SOC webhook", channel=NotificationChannel.WEBHOOK.value, scope="customer"):
+    """A customer-scoped route matching any Informational-or-above investigation.
+
+    Scope matters here: the gate governs what reaches the CUSTOMER, so internal
+    routes are deliberately exempt (see test_internal_routes_are_not_gated).
+    """
     return SimpleNamespace(
         id=route_id,
         name=name,
         channel=channel,
+        scope=scope,
+        notify_on_self_assign=False,
         enabled=True,
         trigger=NotificationTrigger.INVESTIGATION_COMPLETE.value,
         min_severity=NotificationSeverity.INFORMATIONAL.value,
@@ -79,7 +85,7 @@ def _dispatch(routes, *, ai_enabled):
     to how a given provider talks to its vendor.
     """
     with (
-        patch.object(svc, "list_routes", AsyncMock(return_value=routes)),
+        patch.object(svc, "routes_for_event", AsyncMock(return_value=routes)),
         patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)) as gate,
         patch.object(svc, "_record_log", AsyncMock(return_value=True)) as record,
         patch.object(
@@ -206,3 +212,15 @@ def test_every_ai_sourced_trigger_is_gated(trigger):
     with patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=False)):
         permitted = asyncio.run(svc._ai_reports_permitted(trigger, CUSTOMER, session))
     assert permitted is False
+
+
+def test_internal_routes_are_not_gated():
+    """Running investigations while keeping results internal is supported.
+
+    The switch governs what reaches the customer, so an internal route must
+    still fire even when the customer's AI reports are disabled.
+    """
+    response, _gate, _record, webhook, _shuffle = _dispatch([_route(scope="internal")], ai_enabled=False)
+
+    assert webhook.await_count == 1
+    assert response.dispatched == 1

--- a/backend/tests/test_notification_triggers.py
+++ b/backend/tests/test_notification_triggers.py
@@ -1,0 +1,265 @@
+"""CoPilot-originated notification triggers.
+
+Until #1006 the dispatch loop was only ever reached from Talon's HTTP call.
+These triggers fire from inside CoPilot, which introduces three ways to be
+wrong that the AI path never had:
+
+1. **Scope.** An assignment is about who is working on something, so it must
+   resolve against internal routes. Leaking it to the customer's channel would
+   tell ACME which analyst picked up their alert.
+2. **Spam.** `alert_created` sits on the ingest hot path and assignments fire on
+   every PATCH. Emitting on recurrence, or on a write that changed nothing,
+   multiplies straight into someone's inbox.
+3. **Blocking.** A slow provider must not back up alert ingestion.
+
+Unit tests with mocked sessions — no DB, no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_triggers.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels.base import SendResult  # noqa: E402
+from app.notifications.schema.notifications import INTERNAL_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.event_builders import alert_assigned_event  # noqa: E402
+from app.notifications.services.event_builders import alert_created_event  # noqa: E402
+from app.notifications.services.event_builders import case_assigned_event  # noqa: E402
+from app.notifications.services.event_builders import (  # noqa: E402
+    case_task_assigned_event,
+)
+
+CUSTOMER = "TENANT_A"
+
+
+def _route(trigger, scope, route_id=1, notify_on_self_assign=False, min_severity="Informational"):
+    return SimpleNamespace(
+        id=route_id,
+        name=f"{scope} route",
+        channel="webhook",
+        scope=scope,
+        enabled=True,
+        trigger=trigger,
+        min_severity=min_severity,
+        destination="",
+        format_template=None,
+        config='{"url": "https://example.invalid/hook"}',
+        shuffle_integration_id=None,
+        notify_on_self_assign=notify_on_self_assign,
+    )
+
+
+def _dispatch(event, routes):
+    """Run dispatch_event with the route query and providers stubbed."""
+    with (
+        patch.object(svc, "routes_for_event", AsyncMock(return_value=routes)) as lookup,
+        patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=True)),
+        patch.object(svc, "_record_log", AsyncMock(return_value=True)),
+        patch.object(
+            type(CHANNEL_REGISTRY["webhook"]),
+            "send",
+            AsyncMock(return_value=SendResult(status="sent", latency_ms=1)),
+        ) as send,
+        patch.object(type(CHANNEL_REGISTRY["webhook"]), "after_send", AsyncMock()),
+    ):
+        response = asyncio.run(svc.dispatch_event(event, AsyncMock()))
+    return response, send, lookup
+
+
+# ── scope: the tenancy guarantee ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="alice", customer_code=CUSTOMER),
+        case_assigned_event(case_id=1, title="t", assignee="bob", actor="alice", customer_code=CUSTOMER),
+        case_task_assigned_event(task_id=1, case_id=2, title="t", assignee="bob", actor="alice", customer_code=CUSTOMER),
+    ],
+    ids=["alert", "case", "case_task"],
+)
+def test_assignments_resolve_against_internal_routes(event):
+    """The whole point of the scope dimension: telling a customer which analyst
+    picked up their alert is a tenancy leak, not a feature."""
+    assert event.trigger.value in INTERNAL_TRIGGERS
+
+
+def test_alert_created_resolves_against_customer_routes():
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t")
+    assert event.trigger.value not in INTERNAL_TRIGGERS
+
+
+def test_route_query_filters_by_scope_not_just_customer():
+    """A stale query filtering only on customer_code would hand assignment
+    notifications to customer-facing routes."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+
+    event = alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="alice", customer_code=CUSTOMER)
+    asyncio.run(svc.routes_for_event(event, session))
+
+    where = str(session.execute.await_args.args[0])
+    assert "scope" in where
+
+
+# ── self-assignment suppression ───────────────────────────────────────────
+
+
+def test_self_assignment_is_suppressed_by_default():
+    """An analyst picking up their own alert doesn't need an email about it."""
+    event = alert_assigned_event(alert_id=1, title="t", assignee="alice", actor="alice", customer_code=CUSTOMER)
+    response, send, _ = _dispatch(event, [_route("alert_assigned", "internal")])
+
+    assert send.await_count == 0
+    assert response.routes_matched == 0
+
+
+def test_self_assignment_fires_when_the_route_opts_in():
+    event = alert_assigned_event(alert_id=1, title="t", assignee="alice", actor="alice", customer_code=CUSTOMER)
+    response, send, _ = _dispatch(event, [_route("alert_assigned", "internal", notify_on_self_assign=True)])
+
+    assert send.await_count == 1
+    assert response.dispatched == 1
+
+
+def test_assigning_to_someone_else_always_fires():
+    event = alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="alice", customer_code=CUSTOMER)
+    _response, send, _ = _dispatch(event, [_route("alert_assigned", "internal")])
+    assert send.await_count == 1
+
+
+def test_suppression_does_not_apply_to_non_assignment_triggers():
+    """actor == assignee is meaningless for alert_created; the check must not
+    accidentally swallow it."""
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t")
+    event.actor_username = "alice"
+    event.assignee_username = "alice"
+    _response, send, _ = _dispatch(event, [_route("alert_created", "customer")])
+    assert send.await_count == 1
+
+
+# ── dedupe keys: the anti-spam guarantee ──────────────────────────────────
+
+
+def test_reassigning_back_to_someone_notifies_them_again():
+    """A → B → A must reach A twice. A key of just (entity, trigger) could not
+    express that, which is why the assignee is in it."""
+    a1 = alert_assigned_event(alert_id=1, title="t", assignee="alice", actor="x", customer_code=CUSTOMER)
+    b = alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="x", customer_code=CUSTOMER)
+    a2 = alert_assigned_event(alert_id=1, title="t", assignee="alice", actor="x", customer_code=CUSTOMER)
+
+    assert a1.dedupe_key != b.dedupe_key
+    assert a1.dedupe_key == a2.dedupe_key, "same assignee, same key — the log's idempotency handles the rest"
+
+
+def test_unassignment_has_its_own_key():
+    assigned = alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="x", customer_code=CUSTOMER)
+    cleared = alert_assigned_event(alert_id=1, title="t", assignee=None, actor="x", customer_code=CUSTOMER)
+    assert assigned.dedupe_key != cleared.dedupe_key
+    assert cleared.dedupe_key.endswith("unassigned")
+
+
+def test_entity_types_do_not_collide():
+    """Case #7 and task #7 are different things."""
+    case = case_assigned_event(case_id=7, title="t", assignee="bob", actor="x")
+    task = case_task_assigned_event(task_id=7, case_id=1, title="t", assignee="bob", actor="x")
+    assert case.dedupe_key != task.dedupe_key
+
+
+# ── severity ──────────────────────────────────────────────────────────────
+
+
+def test_assignments_are_informational_so_routes_filter_by_trigger():
+    """Assignments carry no security severity. Anything higher would be an
+    invention; anything lower doesn't exist."""
+    event = alert_assigned_event(alert_id=1, title="t", assignee="bob", actor="x")
+    assert event.severity.value == "Informational"
+
+
+def test_alert_created_uses_the_payloads_derived_severity():
+    """rule_level -> severity is already computed upstream (issue #980); this
+    must not re-derive it differently."""
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity="Critical", rule_level=14)
+    assert event.severity.value == "Critical"
+    assert event.context["rule_level"] == 14
+
+
+def test_alert_without_a_severity_defaults_to_medium_not_informational():
+    """Sources with no rule level would otherwise be filtered out of every route
+    gating above Informational."""
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity=None)
+    assert event.severity.value == "Medium"
+
+
+def test_unknown_severity_string_falls_back_rather_than_raising():
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity="Catastrophic")
+    assert event.severity.value == "Medium"
+
+
+def test_min_severity_still_gates_alert_created():
+    event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity="Low")
+    _response, send, _ = _dispatch(event, [_route("alert_created", "customer", min_severity="High")])
+    assert send.await_count == 0
+
+
+# ── body rendering ────────────────────────────────────────────────────────
+
+
+def test_each_trigger_gets_wording_that_fits_it():
+    created = svc._format_default_body(alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="Mimikatz"))
+    assigned = svc._format_default_body(alert_assigned_event(alert_id=1, title="Mimikatz", assignee="bob", actor="alice"))
+
+    assert "New alert" in created
+    assert "assigned" in assigned.lower()
+    assert "bob" in assigned
+    assert "AI investigation" not in created
+
+
+def test_investigation_wording_is_unchanged_for_existing_customers():
+    """This is the text customers already receive; #1006 must not reword it."""
+    from app.notifications.schema.events import event_from_dispatch_request
+    from app.notifications.schema.notifications import DispatchRequest
+    from app.notifications.schema.notifications import NotificationSeverity
+
+    req = DispatchRequest(
+        customer_code=CUSTOMER,
+        alert_id=42,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity_assessment=NotificationSeverity.CRITICAL,
+        summary="Credential dumping observed.",
+        report_url="https://copilot.invalid/42",
+        alert_name="Mimikatz signature",
+    )
+    body = svc._format_default_body(event_from_dispatch_request(req))
+
+    assert body.startswith("*AI investigation complete* — severity: *Critical*")
+    assert "Alert: #42 — Mimikatz signature" in body
+    assert "Full report: https://copilot.invalid/42" in body
+
+
+def test_existing_template_tokens_still_render():
+    """Stored format_templates predate the envelope and must keep working."""
+    route = _route("alert_created", "customer")
+    route.format_template = "{{severity}} on {{customer_code}} alert {{alert_id}}: {{alert_name}}"
+    body = svc._render_body(route, alert_created_event(alert_id=9, customer_code=CUSTOMER, alert_title="X", severity="High"))
+    assert body == f"High on {CUSTOMER} alert 9: X"
+
+
+def test_new_assignment_tokens_are_available():
+    route = _route("alert_assigned", "internal")
+    route.format_template = "{{assignee}} <- {{actor}} ({{entity_type}}#{{entity_id}})"
+    body = svc._render_body(route, alert_assigned_event(alert_id=3, title="t", assignee="bob", actor="alice"))
+    assert body == "bob <- alice (alert#3)"


### PR DESCRIPTION
Closes #1006. **No migration.** This is the feature the epic was opened for.

## ⚠️ Backend only — not reachable from the UI yet

The route form still offers only the two AI triggers, and there is no surface for creating internal-scope routes (they belong to no customer, so they can't live under *Customers → customer*).

So after merging this, **nothing changes for a user until #1008**. The triggers work and are creatable via the API — verified — but not through the UI. Flagging prominently so nobody merges this and wonders why their alerts are silent.

## What fires, and where it goes

| Trigger | Resolves against |
|---|---|
| `alert_created` | customer-scoped routes |
| `alert_assigned` | **internal**-scoped routes |
| `case_assigned` | **internal**-scoped routes |
| `case_task_assigned` | **internal**-scoped routes |

The scope split is the tenancy guarantee, and the reason that dimension exists. An assignment is about *who is working on something* — telling ACME which analyst picked up their alert is a leak, not a feature. Everything else is about the customer's security posture.

## Fire-and-forget, deliberately

`emit()` schedules and returns. It is synchronous and returns `None` so a caller on the ingest path cannot await it by accident.

Three hazards it exists to contain:

- **Its own `AsyncSession`.** Reusing the request-scoped one after the response has returned raises `MissingGreenlet` — the same async-SQLAlchemy hazard the notification models already carry comments about.
- **A bounded timeout.** A black-holed provider produces a logged failure, not a task that never finishes.
- **A strong task reference.** asyncio holds only a weak one, so a bare task can be garbage-collected mid-flight.

Nothing propagates to the caller. The dispatch log is the record.

## Two guards against spam

Both are the difference between a feature and an inbox flood, and both are easy to miss:

**Only genuinely new alerts.** `create_alert()` short-circuits on recurrence — same title, same customer — and returns the existing id. The emit sits *after* that early-return, so a recurring alert does not re-notify.

**Only actual assignment changes.** A PATCH rewriting the same assignee stays silent, using the same comparison the audit events already make. For case tasks that's literally the same `assignment_changed` flag, so audit and notification can't disagree.

Plus **self-assignment suppression**, on by default and opt-in per route: an analyst picking up their own alert doesn't need an email about it.

## Dedupe and severity

`dedupe_key` includes the assignee, so **A → B → A reaches A again** — a key of `(entity, trigger)` couldn't express that. Unassignment gets its own key, and case #7 can't collide with task #7.

Assignments carry **INFORMATIONAL** severity because they have no security severity of their own. Inventing one would silently drop them on routes tuned for real alerts. `alert_created` reuses the severity already derived from the Wazuh rule level upstream (issue #980) rather than re-deriving it, defaulting to Medium — not Informational — when a source carries no level, so it isn't filtered out of every route gating above Informational.

## Two things carried over from earlier PRs

**The AI gate is now scope-aware** — the TODO I left in #1014, at the exact comment marking the spot. Internal routes are exempt: that switch governs what reaches the *customer*, and running investigations while keeping results internal is supported. Pinned by a test.

**`_render_body` takes the envelope**, deferred in #1021. Stored `format_template` tokens render identically, and a test asserts the `investigation_complete` wording byte-for-byte — that's text customers already receive. New `{{assignee}}` / `{{actor}}` / `{{entity_type}}` / `{{entity_id}}` tokens are available and render empty on triggers that don't carry them.

## Duplicate notifications, as agreed

`create_alert_full()` already calls `handle_customer_notifications()`, the **legacy per-customer Shuffle workflow**. `alert_created` is therefore a second notification on the same event.

Both are opt-in, so duplication only happens if an operator configures both. Per your call, they coexist and the **route form will warn** when a customer has the legacy workflow enabled — that warning is #1008's, since it's UI. There's a comment at the emit point so the next reader doesn't rediscover the overlap.

## Worth knowing about how this went

Two bugs my own scripted edits introduced, both caught before they mattered:

- The case-task emit landed in `add_case_task` instead of `update_case_task` — flake8 caught the undefined guard variable.
- It was then inserted **twice**, because the replace had no count and both functions share the same `commit`/`refresh`/`return` shape.

Neither survived to review, but they're the argument for the guard tests rather than trusting the diff looked right.

## Testing

```
21 new     tests/test_notification_triggers.py
194 passed backend tests/
pre-commit clean
```

Covers scope isolation for all three assignment triggers, the route query filtering on scope (a stale customer-only filter would hand assignments to customer-facing routes), self-assign suppression and its opt-in, the A → B → A dedupe case, unassignment keys, entity-type collision, severity defaults and fallbacks, `min_severity` still gating `alert_created`, per-trigger body wording, and byte-for-byte investigation wording.

`test_notification_ai_report_gating.py` gains a case asserting internal routes are not gated.

## Next

#1008 — the UI. Trigger selector, an admin surface for internal-scope routes, the legacy-workflow duplicate warning, and the generic schema-driven form renderer that #1005 should also use.
