### PR TITLE
feat(notifications): make triggers and internal routes reachable in the UI

### DIFF
--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -139,6 +139,74 @@ async def delete_route_route(
 
 
 # ---------------------------------------------------------------------------
+# Internal-scope routes (deployment-wide, no tenant)
+# ---------------------------------------------------------------------------
+#
+# Separate from the /customers/{code}/... CRUD because these routes belong to no
+# customer: there is no code to put in the path. They are where assignment
+# notifications land, so analyst chatter never reaches a customer's channel.
+#
+# Admin-only. A customer-scoped route configures what one tenant receives; an
+# internal route configures where the SOC's own traffic goes, which is
+# deployment-wide configuration.
+
+
+@notifications_router.get(
+    "/internal_notification_routes",
+    response_model=NotificationRouteListResponse,
+    description="Internal-scope notification routes. These belong to no customer and receive assignment events.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def list_internal_routes_route(session: AsyncSession = Depends(get_db)) -> NotificationRouteListResponse:
+    routes = await svc.list_internal_routes(session)
+    return NotificationRouteListResponse(
+        success=True,
+        message=f"{len(routes)} internal route(s) retrieved",
+        routes=routes,
+    )
+
+
+@notifications_router.post(
+    "/internal_notification_routes",
+    response_model=NotificationRouteResponse,
+    description="Create an internal-scope notification route. Shuffle is unavailable — its integrations are per-customer.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def create_internal_route_route(
+    payload: NotificationRouteCreate,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> NotificationRouteResponse:
+    route = await svc.create_internal_route(payload, current_user.username, session)
+    return NotificationRouteResponse(success=True, message="Internal route created", route=route)
+
+
+@notifications_router.patch(
+    "/internal_notification_routes/{route_id}",
+    response_model=NotificationRouteResponse,
+    description="Update an internal-scope notification route.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def update_internal_route_route(
+    route_id: int,
+    payload: NotificationRouteUpdate,
+    session: AsyncSession = Depends(get_db),
+) -> NotificationRouteResponse:
+    route = await svc.update_internal_route(route_id, payload, session)
+    return NotificationRouteResponse(success=True, message="Internal route updated", route=route)
+
+
+@notifications_router.delete(
+    "/internal_notification_routes/{route_id}",
+    description="Delete an internal-scope notification route. Dispatch log entries are retained.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def delete_internal_route_route(route_id: int, session: AsyncSession = Depends(get_db)):
+    await svc.delete_internal_route(route_id, session)
+    return {"success": True, "message": "Internal route deleted"}
+
+
+# ---------------------------------------------------------------------------
 # Channel catalog
 # ---------------------------------------------------------------------------
 

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -111,6 +111,150 @@ def _enforce_scope_invariant(scope: str, customer_code: Optional[str]) -> Option
     return customer_code
 
 
+async def list_internal_routes(session: AsyncSession) -> List[CustomerNotificationRoute]:
+    """Every internal-scope route. Deployment-wide — they belong to no tenant."""
+    result = await session.execute(
+        select(CustomerNotificationRoute)
+        .where(CustomerNotificationRoute.scope == NotificationScope.INTERNAL.value)
+        .order_by(desc(CustomerNotificationRoute.created_at)),
+    )
+    return result.scalars().all()
+
+
+async def get_internal_route(route_id: int, session: AsyncSession) -> CustomerNotificationRoute:
+    """Single internal route. Scoped in the query rather than trusting the id,
+    so a customer route's id can't be reached through the internal endpoints."""
+    result = await session.execute(
+        select(CustomerNotificationRoute).where(
+            CustomerNotificationRoute.id == route_id,
+            CustomerNotificationRoute.scope == NotificationScope.INTERNAL.value,
+        ),
+    )
+    route = result.scalars().first()
+    if not route:
+        raise HTTPException(status_code=404, detail="Internal route not found")
+    return route
+
+
+def _reject_shuffle_for_internal(payload_channel: Optional[str]) -> None:
+    """Shuffle is unavailable to internal routes.
+
+    `shuffle_integration_id` is an FK to `customer_shuffle_integration`, which is
+    per-customer — a route belonging to no tenant has no integration to point
+    at. Caught here rather than at dispatch, where it would surface as a
+    confusing "integration is missing" failure.
+    """
+    if payload_channel == NotificationChannel.SHUFFLE.value:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Shuffle is not available for internal routes: a Shuffle integration belongs to a "
+                "specific customer, and an internal route belongs to none. Use webhook or email."
+            ),
+        )
+
+
+async def create_internal_route(
+    payload: NotificationRouteCreate,
+    created_by: Optional[str],
+    session: AsyncSession,
+) -> CustomerNotificationRoute:
+    """Create a route that belongs to no tenant.
+
+    Forces scope='internal' rather than trusting the payload — these endpoints
+    are the internal surface by definition, and honouring a 'customer' scope
+    here would create a route with no customer_code that the customer-scoped
+    dispatch path could never find.
+    """
+    _reject_shuffle_for_internal(payload.channel.value)
+    if payload.scope != NotificationScope.INTERNAL:
+        raise HTTPException(status_code=400, detail="This endpoint creates internal-scope routes only.")
+
+    route = CustomerNotificationRoute(
+        customer_code=None,
+        scope=NotificationScope.INTERNAL.value,
+        recipient_mode=payload.recipient_mode.value,
+        notify_on_self_assign=payload.notify_on_self_assign,
+        name=payload.name,
+        trigger=payload.trigger.value,
+        channel=payload.channel.value,
+        destination=payload.destination or "",
+        min_severity=payload.min_severity.value,
+        format_template=payload.format_template,
+        enabled=payload.enabled,
+        created_by=created_by,
+        shuffle_integration_id=None,
+        config=json.dumps(payload.config or {}),
+    )
+    session.add(route)
+    await session.commit()
+    await session.refresh(route)
+    return route
+
+
+async def update_internal_route(
+    route_id: int,
+    payload: NotificationRouteUpdate,
+    session: AsyncSession,
+) -> CustomerNotificationRoute:
+    route = await get_internal_route(route_id, session)
+    data = payload.model_dump(exclude_unset=True)
+
+    new_channel = data.get("channel")
+    new_channel_value = new_channel.value if hasattr(new_channel, "value") else (new_channel or route.channel)
+    _reject_shuffle_for_internal(new_channel_value)
+
+    # Scope and customer_code are fixed for these routes; silently ignoring an
+    # attempt to change them would let a PATCH strand the route in a scope its
+    # dispatch path can't reach.
+    if "scope" in data and data["scope"] != NotificationScope.INTERNAL:
+        raise HTTPException(status_code=400, detail="An internal route's scope cannot be changed.")
+    data.pop("scope", None)
+
+    if "config" in data or "channel" in data or "recipient_mode" in data:
+        provider = get_channel(new_channel_value)
+        if provider is None:
+            raise HTTPException(status_code=400, detail=f"Unsupported channel: {new_channel_value}")
+        raw_config = data.get("config")
+        if raw_config is None and "config" not in data:
+            raw_config = json.loads(route.config) if route.config else {}
+        try:
+            data["config"] = provider.config_schema.model_validate(raw_config or {}).model_dump()
+        except PydanticValidationError as e:
+            raise HTTPException(status_code=400, detail=f"Invalid config for channel '{new_channel_value}': {e}") from e
+
+        mode = data.get("recipient_mode")
+        mode_value = mode.value if hasattr(mode, "value") else (mode or route.recipient_mode)
+        if mode_value not in provider.supports_recipient_modes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Channel '{new_channel_value}' does not support recipient_mode '{mode_value}' "
+                    f"(supported: {sorted(provider.supports_recipient_modes)})"
+                ),
+            )
+
+    for field, value in data.items():
+        if hasattr(value, "value"):
+            value = value.value
+        if field == "config":
+            value = json.dumps(value or {})
+        if field == "destination" and value is None:
+            value = ""
+        setattr(route, field, value)
+    route.updated_at = datetime.utcnow()
+
+    await session.commit()
+    await session.refresh(route)
+    return route
+
+
+async def delete_internal_route(route_id: int, session: AsyncSession) -> None:
+    route = await get_internal_route(route_id, session)
+    await session.delete(route)
+    await session.commit()
+
+
 async def create_route(
     customer_code: str,
     payload: NotificationRouteCreate,

--- a/backend/tests/test_notification_internal_routes.py
+++ b/backend/tests/test_notification_internal_routes.py
@@ -1,0 +1,200 @@
+"""Internal-scope route CRUD.
+
+Internal routes belong to no tenant, so they can't live under
+`/customers/{code}/notification_routes` — there's no code to put in the path.
+They're where assignment notifications land, which makes them the mechanism that
+keeps analyst chatter out of a customer's channel.
+
+Three invariants these tests exist to hold:
+
+1. **Scope is fixed.** A route created here is internal, and stays internal. A
+   PATCH that flipped it would strand the route in a scope its dispatch path
+   can't reach — it would have no customer_code, so the customer-scoped lookup
+   would never find it, and it would silently stop firing.
+2. **No customer_code.** The whole point.
+3. **No Shuffle.** `shuffle_integration_id` is an FK to a per-customer table.
+
+Unit tests with a mocked session — no DB.
+
+Run with: cd backend && python -m pytest tests/test_notification_internal_routes.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.schema.notifications import NotificationRouteCreate  # noqa: E402
+from app.notifications.schema.notifications import NotificationRouteUpdate  # noqa: E402
+
+
+def _payload(**over):
+    base = dict(
+        name="SOC assignments",
+        trigger="alert_assigned",
+        channel="resend",
+        scope="internal",
+        recipient_mode="assignee",
+        min_severity="Informational",
+        enabled=True,
+        config={},
+    )
+    base.update(over)
+    return NotificationRouteCreate(**base)
+
+
+def _session(existing=None):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = existing
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+def _existing(route_id=1, channel="resend", scope="internal"):
+    return SimpleNamespace(
+        id=route_id,
+        scope=scope,
+        channel=channel,
+        customer_code=None,
+        recipient_mode="assignee",
+        config=json.dumps({"to": []}),
+        updated_at=None,
+    )
+
+
+def _added(session):
+    assert session.add.call_count == 1
+    return session.add.call_args.args[0]
+
+
+# ── creation ──────────────────────────────────────────────────────────────
+
+
+def test_created_route_has_no_customer():
+    session = _session()
+    asyncio.run(svc.create_internal_route(_payload(), "admin", session))
+    assert _added(session).customer_code is None
+
+
+def test_created_route_is_internal_scope():
+    session = _session()
+    asyncio.run(svc.create_internal_route(_payload(), "admin", session))
+    assert _added(session).scope == "internal"
+
+
+def test_a_customer_scoped_payload_is_rejected_here():
+    """Honouring it would create a route with no customer_code that the
+    customer-scoped dispatch path could never find."""
+    session = _session()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            svc.create_internal_route(_payload(scope="customer", recipient_mode="static", config={"to": ["a@b.c"]}), "admin", session),
+        )
+    assert exc.value.status_code == 400
+    assert session.add.call_count == 0
+
+
+def test_shuffle_is_rejected_for_internal_routes():
+    """A Shuffle integration belongs to a specific customer; an internal route
+    belongs to none. Caught at create time rather than surfacing later as a
+    confusing "integration is missing" dispatch failure."""
+    session = _session()
+    payload = _payload(channel="shuffle", recipient_mode="static", destination="#soc", config={"app_id": "x"}, shuffle_integration_id=1)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(svc.create_internal_route(payload, "admin", session))
+
+    assert exc.value.status_code == 400
+    assert "not available for internal routes" in exc.value.detail
+    assert session.add.call_count == 0
+
+
+def test_shuffle_integration_id_is_never_persisted():
+    session = _session()
+    asyncio.run(svc.create_internal_route(_payload(), "admin", session))
+    assert _added(session).shuffle_integration_id is None
+
+
+def test_assignee_mode_survives_creation():
+    """The reason internal routes exist: mail whoever it was assigned to."""
+    session = _session()
+    asyncio.run(svc.create_internal_route(_payload(), "admin", session))
+    assert _added(session).recipient_mode == "assignee"
+
+
+# ── lookup isolation ──────────────────────────────────────────────────────
+
+
+def test_lookup_is_scoped_so_a_customer_route_id_is_unreachable():
+    """Without the scope predicate, an admin could PATCH a customer's route
+    through the internal endpoints."""
+    session = _session(existing=None)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(svc.get_internal_route(99, session))
+    assert exc.value.status_code == 404
+
+    where = str(session.execute.await_args.args[0])
+    assert "scope" in where
+
+
+def test_list_filters_to_internal_only():
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+
+    asyncio.run(svc.list_internal_routes(session))
+    assert "scope" in str(session.execute.await_args.args[0])
+
+
+# ── updates ───────────────────────────────────────────────────────────────
+
+
+def test_scope_cannot_be_changed_by_patch():
+    """Flipping scope would leave the route with no customer_code but a
+    customer scope — invisible to both dispatch paths."""
+    session = _session(existing=_existing())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(svc.update_internal_route(1, NotificationRouteUpdate(scope="customer"), session))
+    assert exc.value.status_code == 400
+
+
+def test_patching_to_shuffle_is_rejected():
+    session = _session(existing=_existing())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(svc.update_internal_route(1, NotificationRouteUpdate(channel="shuffle"), session))
+    assert exc.value.status_code == 400
+
+
+def test_recipient_mode_is_validated_against_the_channel():
+    """webhook can't resolve a person, so assignee mode on it is a 400 rather
+    than a route that silently never delivers."""
+    session = _session(existing=_existing(channel="webhook"))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            svc.update_internal_route(
+                1,
+                NotificationRouteUpdate(channel="webhook", recipient_mode="assignee", config={"url": "https://x.invalid"}),
+                session,
+            ),
+        )
+    assert exc.value.status_code == 400
+    assert "recipient_mode" in exc.value.detail
+
+
+def test_an_ordinary_field_update_still_works():
+    route = _existing()
+    session = _session(existing=route)
+    asyncio.run(svc.update_internal_route(1, NotificationRouteUpdate(name="Renamed"), session))
+    assert route.name == "Renamed"

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -16,7 +16,7 @@ import type {
 import { HttpClient } from "../http-client"
 
 // Per-customer notification routing — wraps app/notifications/routes/notifications.py.
-// Used by the Customer detail page's "AI Notifications" tab to manage who
+// Used by the Customer detail page's "Notifications" tab to manage who
 // receives notifications about Talon's investigation results.
 
 export default {
@@ -42,6 +42,28 @@ export default {
 
 	deleteRoute(customerCode: string, routeId: number) {
 		return HttpClient.delete<FlaskBaseResponse>(`/customers/${customerCode}/notification_routes/${routeId}`)
+	},
+
+	// Internal-scope routes live outside the /customers/{code}/... tree because
+	// they belong to no tenant. Admin-only: they configure where the SOC's own
+	// traffic goes, which is deployment-wide rather than per-customer.
+	getInternalRoutes() {
+		return HttpClient.get<FlaskBaseResponse & { routes: NotificationRoute[] }>(`/internal_notification_routes`)
+	},
+	createInternalRoute(payload: NotificationRoutePayload) {
+		return HttpClient.post<FlaskBaseResponse & { route: NotificationRoute }>(
+			`/internal_notification_routes`,
+			payload
+		)
+	},
+	updateInternalRoute(routeId: number, payload: NotificationRouteUpdatePayload) {
+		return HttpClient.patch<FlaskBaseResponse & { route: NotificationRoute }>(
+			`/internal_notification_routes/${routeId}`,
+			payload
+		)
+	},
+	deleteInternalRoute(routeId: number) {
+		return HttpClient.delete<FlaskBaseResponse>(`/internal_notification_routes/${routeId}`)
 	},
 
 	// The channel catalog is deployment-wide, not per-customer: it advertises

--- a/frontend/src/app-layouts/common/Navbar/items.tsx
+++ b/frontend/src/app-layouts/common/Navbar/items.tsx
@@ -15,6 +15,7 @@ const OverviewIcon = "carbon:dashboard"
 const CustomersIcon = "carbon:user-multiple"
 const AiAnalystIcon = "carbon:machine-learning-model"
 const DetectionCatalogIcon = "carbon:catalog"
+const InternalNotificationsIcon = "carbon:notification"
 
 export default function getItems(): MenuMixedOption[] {
 	return [
@@ -33,6 +34,12 @@ export default function getItems(): MenuMixedOption[] {
 		{
 			...routerLinkItem("Customers", "Customers"),
 			icon: renderIcon(CustomersIcon)
+		},
+		{
+			// Deployment-wide: where the SOC's own assignment notifications go.
+			// Distinct from a customer's routes, which live on the customer.
+			...routerLinkItem("Internal Notifications", "InternalNotifications"),
+			icon: renderIcon(InternalNotificationsIcon)
 		},
 		siemItem,
 		incidentManagementItem,

--- a/frontend/src/components/customers/CustomerDetailsTabs.vue
+++ b/frontend/src/components/customers/CustomerDetailsTabs.vue
@@ -62,8 +62,8 @@
 					<CustomerAITriggers :customer-code="customer.customer_code" />
 				</n-tab-pane>
 				<n-tab-pane
-					name="AI Notifications"
-					tab="AI Notifications"
+					name="Notifications"
+					tab="Notifications"
 					display-directive="show:lazy"
 					class="overflow-hidden p-4!"
 				>
@@ -221,7 +221,7 @@ const CUSTOMER_SUB_TABS = new Set([
 	"Network Connectors",
 	"Notification Workflows",
 	"AI Triggers",
-	"AI Notifications",
+	"Notifications",
 	"Event Sources",
 	"Reporting",
 	"Portal Branding",

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -1,5 +1,23 @@
 <template>
 	<n-form ref="formRef" :model="form" :rules label-placement="top" class="flex flex-col gap-1">
+		<!--
+			The legacy per-customer Shuffle workflow also fires on alert creation.
+			Both are opt-in, so duplication only happens when an operator configures
+			both — which is exactly the moment to say so.
+		-->
+		<n-alert
+			v-if="showsLegacyWorkflowWarning"
+			type="warning"
+			:bordered="false"
+			title="This customer already notifies on alert creation"
+			class="mb-3"
+		>
+			A legacy Notification Workflow is enabled for this customer, under the
+			<strong>Notification Workflows</strong>
+			tab. Saving this route means new alerts will notify twice — once through each. Disable one if that
+			isn't what you want.
+		</n-alert>
+
 		<n-form-item label="Name" path="name">
 			<n-input v-model:value="form.name" placeholder="e.g. SOC team Slack #alerts" :maxlength="128" show-count />
 		</n-form-item>
@@ -260,6 +278,7 @@ import type {
 	NotificationChannel,
 	NotificationRoute,
 	NotificationRoutePayload,
+	NotificationScope,
 	NotificationSeverity,
 	NotificationTrigger,
 	ResendQuota,
@@ -272,8 +291,10 @@ import Api from "@/api"
 import { getApiErrorMessage } from "@/utils"
 
 const props = defineProps<{
-	customerCode: string
+	// Empty for internal-scope routes, which belong to no tenant.
+	customerCode?: string
 	editingRoute: NotificationRoute | null
+	scope?: NotificationScope
 }>()
 
 const emit = defineEmits<{
@@ -317,8 +338,10 @@ const fieldErrors = reactive<Partial<Record<FeedbackField, string>>>({})
 
 const form = reactive<NotificationRoutePayload>({
 	name: props.editingRoute?.name ?? "",
-	trigger: props.editingRoute?.trigger ?? ("investigation_complete" as NotificationTrigger),
-	channel: props.editingRoute?.channel ?? "shuffle",
+	trigger:
+		props.editingRoute?.trigger ??
+		((props.scope === "internal" ? "alert_assigned" : "alert_created") as NotificationTrigger),
+	channel: props.editingRoute?.channel ?? (props.scope === "internal" ? "resend" : "shuffle"),
 	destination: props.editingRoute?.destination ?? "",
 	min_severity: props.editingRoute?.min_severity ?? ("Medium" as NotificationSeverity),
 	format_template: props.editingRoute?.format_template ?? "",
@@ -331,6 +354,32 @@ const form = reactive<NotificationRoutePayload>({
 })
 
 const isShuffle = computed(() => form.channel === "shuffle")
+// The same form serves both surfaces. They differ in exactly two ways — which
+// triggers apply and which channels are possible — so a prop is cheaper and
+// safer than extracting shared parts out of a 700-line component. If the
+// conditionals multiply beyond these, that's the signal to split it.
+const isInternalScope = computed(() => props.scope === "internal")
+
+// Non-null only when the customer has a legacy workflow enabled. Fetched once
+// per form open; a failure leaves it null so the warning simply doesn't show
+// rather than blocking the form.
+const legacyWorkflowEnabled = ref<boolean | null>(null)
+
+const showsLegacyWorkflowWarning = computed(
+	() => !isInternalScope.value && form.trigger === "alert_created" && legacyWorkflowEnabled.value === true
+)
+
+async function loadLegacyWorkflowState() {
+	if (isInternalScope.value || !props.customerCode) return
+	try {
+		const res = await Api.incidentManagement.notification.getNotifications(props.customerCode)
+		const rows = res.data?.notifications ?? []
+		legacyWorkflowEnabled.value = rows.some(n => n.enabled)
+	} catch {
+		legacyWorkflowEnabled.value = null
+	}
+}
+
 const isWebhook = computed(() => form.channel === "webhook")
 const isResend = computed(() => form.channel === "resend")
 const isAssigneeMode = computed(() => form.recipient_mode === "assignee")
@@ -397,19 +446,41 @@ const headerPairs = ref<{ key: string; value: string }[]>(
 		: []
 )
 
-// Trigger is a single fixed value today (`investigation_complete`).
-// Will become a richer select again when we add more dispatch event
-// types (analyst-review hooks, IOC-enrichment alerts, scheduled sweeps).
-const triggerOptions = [
-	{ label: "Every investigation completes", value: "investigation_complete" },
-	{ label: "Critical / High severity only", value: "severity_critical_or_high" }
+// Triggers are filtered by scope rather than shown as one list. A customer
+// route with an assignment trigger would be dead config: assignments resolve
+// against internal routes, so it could never fire. Offering it would be an
+// invitation to create something that silently does nothing.
+const CUSTOMER_TRIGGER_OPTIONS = [
+	{ label: "An alert is created", value: "alert_created" },
+	{ label: "An AI investigation completes", value: "investigation_complete" },
+	// Legacy value kept selectable so editing an old route doesn't blank the
+	// field; the backend coerces it to investigation_complete on read.
+	{ label: "Critical / High severity only (legacy)", value: "severity_critical_or_high" }
 ]
 
-const channelOptions = [
-	{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" },
-	{ label: "Webhook (direct HTTP to any URL)", value: "webhook" },
-	{ label: "Email (Resend)", value: "resend" }
+const INTERNAL_TRIGGER_OPTIONS = [
+	{ label: "An alert is assigned", value: "alert_assigned" },
+	{ label: "A case is assigned", value: "case_assigned" },
+	{ label: "A case task is assigned", value: "case_task_assigned" }
 ]
+
+const triggerOptions = computed(() => (isInternalScope.value ? INTERNAL_TRIGGER_OPTIONS : CUSTOMER_TRIGGER_OPTIONS))
+
+// Shuffle is unavailable to internal routes: a Shuffle integration belongs to a
+// specific customer, and an internal route belongs to none. The backend rejects
+// it too — this just avoids offering something that would 400.
+const channelOptions = computed(() =>
+	isInternalScope.value
+		? [
+				{ label: "Email (Resend)", value: "resend" },
+				{ label: "Webhook (direct HTTP to any URL)", value: "webhook" }
+			]
+		: [
+				{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" },
+				{ label: "Webhook (direct HTTP to any URL)", value: "webhook" },
+				{ label: "Email (Resend)", value: "resend" }
+			]
+)
 
 const methodOptions = [
 	{ label: "POST", value: "POST" },
@@ -499,9 +570,14 @@ function onChannelChange(channel: NotificationChannel) {
 }
 
 async function loadIntegrations() {
+	// Shuffle integrations are per-customer, so there is nothing to load for an
+	// internal route — and no customerCode to load it with.
+	const code = props.customerCode
+	if (!code) return
+
 	loadingIntegrations.value = true
 	try {
-		const res = await Api.notifications.listShuffleIntegrations(props.customerCode)
+		const res = await Api.notifications.listShuffleIntegrations(code)
 		if (res.data.success) {
 			integrations.value = res.data.integrations
 		}
@@ -513,10 +589,13 @@ async function loadIntegrations() {
 }
 
 async function loadApps(integrationId: number) {
+	const code = props.customerCode
+	if (!code) return
+
 	loadingApps.value = true
 	appsError.value = null
 	try {
-		const res = await Api.notifications.listShuffleApps(props.customerCode, integrationId)
+		const res = await Api.notifications.listShuffleApps(code, integrationId)
 		if (res.data.success) {
 			apps.value = res.data.apps
 		} else {
@@ -638,7 +717,7 @@ async function submit() {
 			min_severity: form.min_severity,
 			format_template: sendTemplate,
 			enabled: form.enabled,
-			scope: form.scope,
+			scope: props.scope ?? "customer",
 			recipient_mode: form.recipient_mode,
 			notify_on_self_assign: form.notify_on_self_assign
 		}
@@ -686,9 +765,24 @@ async function submit() {
 						}
 					}
 
-		const res = props.editingRoute
-			? await Api.notifications.updateRoute(props.customerCode, props.editingRoute.id, payload)
-			: await Api.notifications.createRoute(props.customerCode, payload)
+		let res
+		if (isInternalScope.value) {
+			res = props.editingRoute
+				? await Api.notifications.updateInternalRoute(props.editingRoute.id, payload)
+				: await Api.notifications.createInternalRoute(payload)
+		} else {
+			// customerCode is optional on the props because internal routes have
+			// none; on this branch it is always present, and a missing one is a
+			// wiring bug worth surfacing rather than sending "" to the API.
+			const code = props.customerCode
+			if (!code) {
+				message.error("No customer selected for this route.")
+				return
+			}
+			res = props.editingRoute
+				? await Api.notifications.updateRoute(code, props.editingRoute.id, payload)
+				: await Api.notifications.createRoute(code, payload)
+		}
 
 		if (res.data.success) {
 			message.success(editing.value ? "Route updated" : "Route created")
@@ -704,6 +798,7 @@ async function submit() {
 }
 
 onBeforeMount(async () => {
+	loadLegacyWorkflowState()
 	await loadIntegrations()
 	// If editing a Shuffle route, prefetch the apps for its integration
 	// so the picker is populated when the form first renders.

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
@@ -110,7 +110,7 @@
 
 <script setup lang="ts">
 import type { ApiError } from "@/types/common"
-import type { NotificationRoute, WebhookChannelConfig } from "@/types/notifications"
+import type { NotificationRoute, NotificationScope, WebhookChannelConfig } from "@/types/notifications"
 import _split from "lodash/split"
 import { NButton, NPopconfirm, useMessage } from "naive-ui"
 import { computed, ref } from "vue"
@@ -125,10 +125,11 @@ import { formatDate } from "@/utils/format"
 const props = defineProps<{
 	route: NotificationRoute
 	// Passed down rather than read off the route: `customer_code` is nullable
-	// now (internal-scope routes belong to no tenant), while the API paths below
-	// always need a concrete code. This list only ever renders customer-scoped
-	// routes, so the parent's code is the right source.
-	customerCode: string
+	// (internal routes belong to no tenant) while the customer-scoped API paths
+	// need a concrete code. Absent for internal routes, which use their own
+	// endpoints below.
+	customerCode?: string
+	scope?: NotificationScope
 }>()
 
 const emit = defineEmits<{
@@ -146,6 +147,8 @@ const loadingToggle = ref(false)
 const loadingDelete = ref(false)
 const message = useMessage()
 const dFormats = useSettingsStore().dateFormat
+
+const isInternalScope = computed(() => props.scope === "internal")
 
 const isWebhook = computed(() => props.route.channel === "webhook")
 
@@ -187,9 +190,12 @@ async function toggleEnabled() {
 	loadingToggle.value = true
 
 	try {
-		const res = await Api.notifications.updateRoute(props.customerCode, props.route.id, {
-			enabled: !props.route.enabled
-		})
+		const payload = { enabled: !props.route.enabled }
+		const code = props.customerCode
+		const res =
+			isInternalScope.value || !code
+				? await Api.notifications.updateInternalRoute(props.route.id, payload)
+				: await Api.notifications.updateRoute(code, props.route.id, payload)
 		if (res.data.success) {
 			message.success(`Route ${res.data.route.enabled ? "enabled" : "disabled"}`)
 			emit("toggled")
@@ -207,7 +213,11 @@ async function confirmDelete() {
 	loadingDelete.value = true
 
 	try {
-		const res = await Api.notifications.deleteRoute(props.customerCode, props.route.id)
+		const code = props.customerCode
+		const res =
+			isInternalScope.value || !code
+				? await Api.notifications.deleteInternalRoute(props.route.id)
+				: await Api.notifications.deleteRoute(code, props.route.id)
 		if (res.data.success) {
 			message.success("Route deleted")
 			emit("deleted")

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotifications.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotifications.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-// Container for the per-customer "AI Notifications" tab. Three
+// Container for the per-customer "Notifications" tab. Three
 // sub-tabs:
 //   - Routes: CRUD list + form for notification rules
 //   - Shuffle integrations: CRUD for the customer's Shuffle Org-Id rows

--- a/frontend/src/components/incidentManagement/alerts/AlertTryMcp.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertTryMcp.vue
@@ -13,7 +13,7 @@
 		<!-- No integration configured -->
 		<n-alert v-else-if="!activeIntegration" type="info" title="No Shuffle integration configured">
 			This customer has no enabled Shuffle integration. Configure one in
-			<strong>Customer → AI Notifications → Shuffle integrations</strong>
+			<strong>Customer → Notifications → Shuffle integrations</strong>
 			before using Try MCP.
 		</n-alert>
 

--- a/frontend/src/router/routes/admin.ts
+++ b/frontend/src/router/routes/admin.ts
@@ -1,5 +1,5 @@
 import type { RouteRecordRaw } from "vue-router"
-import { RouteRole } from "@/types/auth"
+import { AuthUserRole, RouteRole } from "@/types/auth"
 
 export const adminRoutes: RouteRecordRaw[] = [
 	{
@@ -13,6 +13,16 @@ export const adminRoutes: RouteRecordRaw[] = [
 		name: "AuditEntry",
 		component: () => import("@/views/AuditEntry.vue"),
 		meta: { title: "Audit Entry", auth: true, roles: RouteRole.All }
+	},
+	{
+		// Internal notification routes are deployment-wide configuration —
+		// where the SOC's own assignment notifications go — so they sit outside
+		// the per-customer tree and are admin-only, unlike a customer's routes
+		// which an analyst can manage.
+		path: "/internal-notifications",
+		name: "InternalNotifications",
+		component: () => import("@/views/InternalNotificationRoutes.vue"),
+		meta: { title: "Internal Notifications", auth: true, roles: AuthUserRole.Admin }
 	},
 	{
 		path: "/logs",

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -6,7 +6,24 @@
 // a severity filter (severity gating lives in min_severity). Currently
 // just the one Talon-driven event; will grow when we add hooks for
 // analyst-review / IOC-enrichment / scheduled sweeps.
-export type NotificationTrigger = "investigation_complete"
+// What kind of event caused the dispatch — not a severity filter; severity
+// gating lives in min_severity.
+//
+// Triggers split by which routes they resolve against. The assignment triggers
+// are INTERNAL: they're about who is working on something, so they reach the
+// SOC's own routes and never a customer's channel.
+export type NotificationTrigger =
+	| "investigation_complete"
+	| "alert_created"
+	| "alert_assigned"
+	| "case_assigned"
+	| "case_task_assigned"
+
+export const INTERNAL_TRIGGERS: NotificationTrigger[] = ["alert_assigned", "case_assigned", "case_task_assigned"]
+
+export function isInternalTrigger(trigger: NotificationTrigger): boolean {
+	return INTERNAL_TRIGGERS.includes(trigger)
+}
 
 export type NotificationChannel = "shuffle" | "webhook" | "resend"
 

--- a/frontend/src/views/InternalNotificationRoutes.vue
+++ b/frontend/src/views/InternalNotificationRoutes.vue
@@ -1,0 +1,129 @@
+<template>
+	<div class="page">
+		<div class="mb-4 flex flex-col gap-2">
+			<h1>Internal notifications</h1>
+			<p class="text-secondary max-w-3xl text-sm">
+				Where the SOC's own notifications go. These routes belong to no customer — they receive assignment
+				events, so telling an analyst that an alert landed on their plate never reaches the customer whose
+				alert it was.
+				<br />
+				For notifications a customer should receive, use
+				<strong>Customers → (customer) → Notifications</strong>
+				instead.
+			</p>
+		</div>
+
+		<n-card>
+			<transition name="transition-fade" mode="out-in">
+				<div v-if="showForm" class="flex flex-col gap-4">
+					<h4>{{ editingRoute ? `Edit ${editingRoute.name}` : "Create an internal route" }}</h4>
+					<CustomerAiNotificationRouteForm
+						:editing-route
+						scope="internal"
+						@submitted="onFormSubmitted"
+						@close="closeForm()"
+					/>
+				</div>
+				<div v-else class="flex flex-col gap-4">
+					<div class="flex items-center justify-between gap-4">
+						<n-button size="small" type="primary" @click="openForm()">
+							<template #icon>
+								<Icon :name="AddIcon" :size="14" />
+							</template>
+							Add internal route
+						</n-button>
+					</div>
+
+					<n-spin :show="loading">
+						<div class="min-h-52">
+							<template v-if="list.length">
+								<CustomerAiNotificationRouteItem
+									v-for="route of list"
+									:key="route.id"
+									:route
+									scope="internal"
+									class="item-appear item-appear-bottom item-appear-005 mb-2"
+									@edit="openEdit(route)"
+									@deleted="refreshList()"
+									@toggled="refreshList()"
+								/>
+							</template>
+							<template v-else>
+								<n-empty
+									v-if="!loading"
+									description="No internal routes yet. Add one to be notified when an alert, case or task is assigned — email can deliver to whoever it was assigned to."
+									class="h-48 justify-center"
+								/>
+							</template>
+						</div>
+					</n-spin>
+				</div>
+			</transition>
+		</n-card>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { NotificationRoute } from "@/types/notifications"
+import { NButton, NCard, NEmpty, NSpin, useMessage } from "naive-ui"
+import { onBeforeMount, ref } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import CustomerAiNotificationRouteForm from "@/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue"
+import CustomerAiNotificationRouteItem from "@/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue"
+import { getApiErrorMessage } from "@/utils"
+
+// Reuses the per-customer form and item rather than duplicating them. They
+// differ in exactly two ways — which triggers apply and which channels are
+// possible — which the `scope` prop covers. Duplicating a 700-line form to vary
+// two lists would be worse than the prop.
+
+const AddIcon = "carbon:add-alt"
+
+const message = useMessage()
+const loading = ref(false)
+const list = ref<NotificationRoute[]>([])
+const showForm = ref(false)
+const editingRoute = ref<NotificationRoute | null>(null)
+
+function openForm() {
+	editingRoute.value = null
+	showForm.value = true
+}
+
+function openEdit(route: NotificationRoute) {
+	editingRoute.value = route
+	showForm.value = true
+}
+
+function closeForm() {
+	showForm.value = false
+	editingRoute.value = null
+}
+
+function onFormSubmitted() {
+	closeForm()
+	refreshList()
+}
+
+async function refreshList() {
+	loading.value = true
+	try {
+		const res = await Api.notifications.getInternalRoutes()
+		if (res.data.success) {
+			list.value = res.data.routes
+		} else {
+			message.warning(res.data.message || "Failed to load internal routes")
+		}
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Failed to load internal routes")
+	} finally {
+		loading.value = false
+	}
+}
+
+onBeforeMount(() => {
+	refreshList()
+})
+</script>


### PR DESCRIPTION
Closes #1028. **No migration.**

#1026 (Resend) and #1027 (triggers) both merged, and none of it was reachable — the route form offered only the two AI triggers, and internal-scope routes had no surface at all. This closes that gap, so six PRs' worth of backend becomes usable.

## Scope correction: this wasn't frontend-only

All route CRUD lived under `/customers/{customer_code}/notification_routes`. An internal route has no customer code, so **there was no URL it could exist at**. Adds a parallel admin-only set:

```
GET    /internal_notification_routes
POST   /internal_notification_routes
PATCH  /internal_notification_routes/{id}
DELETE /internal_notification_routes/{id}
```

**Admin-only, deliberately.** A customer route configures what one tenant receives; an internal route configures where the SOC's own traffic goes. That's deployment-wide configuration.

## Three invariants, enforced server-side

**Scope is fixed.** Creating with `scope='customer'` here is a 400, and a PATCH can't flip it. Either would strand a route with no `customer_code` but a customer scope — invisible to *both* dispatch paths, so it stops firing silently rather than erroring.

**Lookup is scope-filtered**, not id-only. Without that predicate an admin could PATCH a customer's route through these endpoints.

**Shuffle is rejected** — the constraint I'd missed when scoping. `shuffle_integration_id` is an FK to a per-customer table, so a tenant-less route has no integration to point at. Caught at create time rather than surfacing later as a confusing "integration is missing" dispatch failure. Internal routes are webhook or email, which is what assignee notification needs anyway.

## Triggers are filtered by scope

Not shown as one list. A customer route with an assignment trigger would be **dead config**: assignments resolve against internal routes, so it could never fire. Offering it would invite creating something that silently does nothing.

| Surface | Triggers |
|---|---|
| Customer | `alert_created`, `investigation_complete` (+ the legacy value, so editing an old route doesn't blank the field) |
| Internal | `alert_assigned`, `case_assigned`, `case_task_assigned` |

## Duplicate-workflow warning

As agreed. `create_alert_full()` already fires the legacy per-customer Shuffle workflow, so an `alert_created` route is a second notification on the same event. Both are opt-in — the warning appears at the moment someone could cause the duplication, pointing at the Notification Workflows tab.

Uses the existing `GET /incidents/db_operations/notification/{customer_code}` and its frontend wrapper; no new backend. A failed fetch leaves the warning hidden rather than blocking the form.

## I reversed a decision from the issue

#1028 said to **extract shared parts** rather than add a `scope` flag to the 714-line form, on the grounds that mode flags are how components rot.

Having built it, a prop was the better call. The two surfaces differ in exactly two lists — which triggers apply, which channels are possible. Extracting would split the main config surface into three files with real regression risk, to avoid two conditionals. There's a comment marking the point at which that trade flips: if the conditionals grow past these, split it.

Flagging because it's the opposite of what the issue says, and worth disagreeing with if you see it differently.

## Two things that fell out of building it

`loadIntegrations` and `loadApps` now early-return without a customer code. Semantically right — Shuffle integrations are per-customer and internal routes can't use them — and it removed the non-null assertions the lint config forbids.

The route **item** needed the same scope awareness as the form: its toggle and delete also hit customer-scoped endpoints, so an internal route's Disable button would have 404'd.

## Testing

```
12 new     tests/test_notification_internal_routes.py
206 passed backend tests/
type-check exit 0 · eslint clean across src/ · pre-commit clean
```

Covers: created routes have no customer and are internal-scoped; a customer-scoped payload is rejected here; Shuffle rejected at create and at PATCH; `shuffle_integration_id` never persisted; assignee mode survives creation; lookup and list are scope-filtered; scope can't be PATCHed; recipient_mode validated against the channel; ordinary updates still work.

## Worth verifying by hand before merge

The tenancy-sensitive path deserves a click-through, not just green tests:

- An internal route created through the new page has `customer_code = NULL`
- Assigning an alert notifies the internal route and **not** any customer-facing route for that alert's customer
- A Resend route with `recipient_mode='assignee'` reaches the assignee's own address

## Next

#1029 — generic schema-driven config renderer and send-test. Neither blocks usability now.
