### PR TITLE
feat(notifications): generic channel config renderer and send-test

### DIFF
--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -34,6 +34,7 @@ from app.notifications.channels import CHANNEL_REGISTRY
 from app.notifications.schema.notifications import ChannelDescriptor
 from app.notifications.schema.notifications import ChannelListResponse
 from app.notifications.schema.notifications import DispatchLogListResponse
+from app.notifications.schema.notifications import DispatchOutcome
 from app.notifications.schema.notifications import DispatchRequest
 from app.notifications.schema.notifications import DispatchResponse
 from app.notifications.schema.notifications import NotificationRouteCreate
@@ -136,6 +137,35 @@ async def delete_route_route(
 ) -> dict:
     await svc.delete_route(route_id, customer_code, session)
     return {"success": True, "message": "Route deleted"}
+
+
+@notifications_router.post(
+    "/customers/{customer_code}/notification_routes/{route_id}/test",
+    response_model=DispatchOutcome,
+    description=(
+        "Send a real test notification through this route. Consumes provider quota and is "
+        "recorded in the dispatch log, exactly like a live notification."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def test_route(
+    customer_code: str,
+    route_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> DispatchOutcome:
+    route = await svc.get_route(route_id, customer_code, session)
+    return await svc.send_test_notification(route, session)
+
+
+@notifications_router.post(
+    "/internal_notification_routes/{route_id}/test",
+    response_model=DispatchOutcome,
+    description="Send a real test notification through this internal route.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def test_internal_route(route_id: int, session: AsyncSession = Depends(get_db)) -> DispatchOutcome:
+    route = await svc.get_internal_route(route_id, session)
+    return await svc.send_test_notification(route, session)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -18,6 +18,7 @@ import json
 from datetime import datetime
 from typing import List
 from typing import Optional
+from uuid import uuid4
 
 from fastapi import HTTPException
 from loguru import logger
@@ -50,6 +51,7 @@ from app.notifications.schema.notifications import NotificationChannel
 from app.notifications.schema.notifications import NotificationRouteCreate
 from app.notifications.schema.notifications import NotificationRouteUpdate
 from app.notifications.schema.notifications import NotificationScope
+from app.notifications.schema.notifications import NotificationSeverity
 from app.notifications.schema.notifications import NotificationTrigger
 from app.notifications.schema.notifications import ShuffleApp
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
@@ -867,6 +869,101 @@ async def _record_log(
         # into locals so this is safe.
         await session.rollback()
         return False
+
+
+def _sample_event_for(route: CustomerNotificationRoute) -> NotificationEvent:
+    """A realistic-looking event for a test send.
+
+    Deliberately built from the route's own trigger so the operator sees the
+    body they'll actually get, not a generic "hello". The dedupe key carries a
+    uuid so repeated tests always send — a test that silently no-ops the second
+    time would be worse than useless.
+    """
+    trigger = (
+        NotificationTrigger(route.trigger)
+        if route.trigger in {t.value for t in NotificationTrigger}
+        else NotificationTrigger.INVESTIGATION_COMPLETE
+    )
+
+    is_assignment = trigger.value in INTERNAL_TRIGGERS
+    entity_type = EntityType.ALERT
+    if trigger == NotificationTrigger.CASE_ASSIGNED:
+        entity_type = EntityType.CASE
+    elif trigger == NotificationTrigger.CASE_TASK_ASSIGNED:
+        entity_type = EntityType.CASE_TASK
+
+    return NotificationEvent(
+        customer_code=route.customer_code,
+        trigger=trigger,
+        severity=NotificationSeverity.HIGH,
+        subject="Test notification from CoPilot",
+        summary=(
+            "This is a test notification triggered from the CoPilot route form. "
+            "If you are reading it, this route is configured correctly."
+        ),
+        entity_type=entity_type,
+        entity_id=0,
+        dedupe_key=f"test:{route.id}:{uuid4()}",
+        link_url=None,
+        assignee_username=route.created_by if is_assignment else None,
+        actor_username=route.created_by,
+        context={"alert_name": "Test notification from CoPilot", "title": "Test notification from CoPilot"},
+    )
+
+
+async def send_test_notification(route: CustomerNotificationRoute, session: AsyncSession) -> DispatchOutcome:
+    """Deliver one test message through the route's real provider.
+
+    Uses the normal send path rather than a bespoke per-provider probe, because
+    a probe tests the wrong thing: the Resend key in use here is send-only
+    restricted, so an account-state check 401s while sending works fine. What an
+    operator wants to know is "will a real notification arrive", and only a real
+    send answers that.
+
+    The outcome IS logged. A test send consumes provider quota exactly like a
+    real one — leaving it out of the dispatch log would make the Resend monthly
+    counter under-report, and hide test traffic from the audit trail.
+    """
+    provider = get_channel(route.channel)
+    if provider is None:
+        return DispatchOutcome(
+            route_id=route.id,
+            route_name=route.name,
+            channel=route.channel,
+            status=DispatchStatus.FAILED,
+            error_message=f"Unsupported channel: {route.channel}",
+        )
+
+    event = _sample_event_for(route)
+    ctx = DispatchContext(session=session, event=event)
+    body = _render_body(route, event)
+
+    try:
+        result = await provider.send(route=route, event=event, rendered_body=body, ctx=ctx)
+    except Exception as e:  # noqa: BLE001 — a test must report, never 500
+        logger.exception(f"Test dispatch raised for route {route.id}: {e!r}")
+        result = SendResult.failed(f"Dispatcher exception: {type(e).__name__}: {e}")
+
+    await _record_log(
+        session,
+        event=event,
+        route_id=route.id,
+        status=result.status,
+        error_message=result.error_message,
+        latency_ms=result.latency_ms,
+        payload_preview=body[:500],
+        provider_reference=result.provider_reference,
+    )
+
+    return DispatchOutcome(
+        route_id=route.id,
+        route_name=route.name,
+        channel=route.channel,
+        status=DispatchStatus(result.status),
+        error_message=result.error_message,
+        latency_ms=result.latency_ms,
+        provider_reference=result.provider_reference,
+    )
 
 
 async def routes_for_event(event: NotificationEvent, session: AsyncSession) -> List[CustomerNotificationRoute]:

--- a/backend/tests/test_notification_test_send.py
+++ b/backend/tests/test_notification_test_send.py
@@ -1,0 +1,162 @@
+"""Test-send: deliver one real notification through a route on demand.
+
+Uses the normal send path rather than a per-provider probe. A probe tests the
+wrong thing — the Resend key in use is send-only restricted, so an account-state
+check 401s while sending works fine. What an operator wants to know is "will a
+real notification arrive", and only a real send answers that.
+
+The outcome IS logged. A test send consumes provider quota exactly like a live
+one; leaving it out would make the Resend monthly counter under-report and hide
+test traffic from the audit trail.
+
+Two of these tests exist because the live run caught bugs the rest of the suite
+missed: an unimported name in the sample-event builder, and a field name left
+behind by #1022's rename. Both survived a green suite because nothing exercised
+this path.
+
+Run with: cd backend && python -m pytest tests/test_notification_test_send.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels.base import SendResult  # noqa: E402
+from app.notifications.schema.notifications import DispatchStatus  # noqa: E402
+
+
+def _route(trigger="investigation_complete", channel="webhook", scope="customer", customer_code="TENANT_A"):
+    return SimpleNamespace(
+        id=7,
+        name="SOC webhook",
+        channel=channel,
+        scope=scope,
+        customer_code=customer_code,
+        trigger=trigger,
+        min_severity="Informational",
+        destination="",
+        format_template=None,
+        created_by="analyst_one",
+        config=json.dumps({"url": "https://example.invalid/hook"}),
+        recipient_mode="static",
+        shuffle_integration_id=None,
+        notify_on_self_assign=False,
+    )
+
+
+def _run(route, send_result=None, record=None):
+    send = AsyncMock(return_value=send_result or SendResult(status="sent", latency_ms=12, provider_reference="ref-1"))
+    rec = record or AsyncMock(return_value=True)
+    with (
+        patch.object(type(CHANNEL_REGISTRY["webhook"]), "send", send),
+        patch.object(svc, "_record_log", rec),
+    ):
+        outcome = asyncio.run(svc.send_test_notification(route, AsyncMock()))
+    return outcome, send, rec
+
+
+# ── the two bugs the live run caught ──────────────────────────────────────
+
+
+def test_sample_event_builds_for_every_trigger():
+    """Regression: NotificationSeverity was unimported, so this raised NameError
+    for every trigger — invisible because nothing exercised the builder."""
+    for trigger in ["investigation_complete", "alert_created", "alert_assigned", "case_assigned", "case_task_assigned"]:
+        event = svc._sample_event_for(_route(trigger=trigger))
+        assert event.severity is not None
+        assert event.trigger.value == trigger
+
+
+def test_outcome_uses_the_current_field_name():
+    """Regression: this passed `shuffle_execution_id`, renamed to
+    `provider_reference` in #1022. Pydantic accepted the construction and failed
+    on read — rename residue that survives a green suite."""
+    outcome, _send, _rec = _run(_route())
+    assert outcome.provider_reference == "ref-1"
+    assert not hasattr(outcome, "shuffle_execution_id")
+
+
+# ── the sample event ──────────────────────────────────────────────────────
+
+
+def test_dedupe_key_is_unique_per_test_so_repeats_always_send():
+    """A test that silently no-ops the second time would be worse than useless."""
+    first = svc._sample_event_for(_route()).dedupe_key
+    second = svc._sample_event_for(_route()).dedupe_key
+    assert first != second
+    assert first.startswith("test:7:")
+
+
+def test_entity_type_follows_the_trigger():
+    assert svc._sample_event_for(_route(trigger="case_assigned")).entity_type == "case"
+    assert svc._sample_event_for(_route(trigger="case_task_assigned")).entity_type == "case_task"
+    assert svc._sample_event_for(_route(trigger="alert_created")).entity_type == "alert"
+
+
+def test_assignment_triggers_get_an_assignee_so_assignee_mode_can_resolve():
+    """Without one, testing an assignee-mode route would always skip with
+    'this event has no assignee' and tell the operator nothing."""
+    event = svc._sample_event_for(_route(trigger="alert_assigned"))
+    assert event.assignee_username == "analyst_one"
+
+
+def test_non_assignment_triggers_have_no_assignee():
+    assert svc._sample_event_for(_route(trigger="alert_created")).assignee_username is None
+
+
+def test_unknown_trigger_falls_back_rather_than_raising():
+    """A hand-edited row shouldn't make the test button 500."""
+    event = svc._sample_event_for(_route(trigger="something_removed"))
+    assert event.trigger.value == "investigation_complete"
+
+
+# ── dispatch behaviour ────────────────────────────────────────────────────
+
+
+def test_a_successful_test_is_reported_and_logged():
+    outcome, send, rec = _run(_route())
+
+    assert outcome.status == DispatchStatus.SENT
+    assert send.await_count == 1
+    assert rec.await_count == 1, "a test send consumes quota; it belongs in the log"
+
+
+def test_a_failed_test_reports_the_providers_message():
+    outcome, _send, _rec = _run(_route(), send_result=SendResult.failed("Domain not verified"))
+    assert outcome.status == DispatchStatus.FAILED
+    assert outcome.error_message == "Domain not verified"
+
+
+def test_a_raising_provider_is_reported_not_propagated():
+    """The button must return a result, never a 500."""
+    send = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch.object(type(CHANNEL_REGISTRY["webhook"]), "send", send),
+        patch.object(svc, "_record_log", AsyncMock(return_value=True)),
+    ):
+        outcome = asyncio.run(svc.send_test_notification(_route(), AsyncMock()))
+
+    assert outcome.status == DispatchStatus.FAILED
+    assert "RuntimeError" in outcome.error_message
+
+
+def test_unknown_channel_is_reported_without_touching_a_provider():
+    outcome = asyncio.run(svc.send_test_notification(_route(channel="carrier-pigeon"), AsyncMock()))
+    assert outcome.status == DispatchStatus.FAILED
+    assert "Unsupported channel" in outcome.error_message
+
+
+@pytest.mark.parametrize("scope,customer_code", [("customer", "TENANT_A"), ("internal", None)])
+def test_both_scopes_can_be_tested(scope, customer_code):
+    outcome, send, _rec = _run(_route(scope=scope, customer_code=customer_code))
+    assert outcome.status == DispatchStatus.SENT
+    assert send.await_count == 1

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -1,5 +1,6 @@
 import type { FlaskBaseResponse } from "@/types/flask"
 import type {
+	DispatchOutcome,
 	NotificationChannelDescriptor,
 	NotificationDispatchLogEntry,
 	NotificationRoute,
@@ -42,6 +43,19 @@ export default {
 
 	deleteRoute(customerCode: string, routeId: number) {
 		return HttpClient.delete<FlaskBaseResponse>(`/customers/${customerCode}/notification_routes/${routeId}`)
+	},
+
+	// Sends a REAL notification through the route — consumes provider quota and
+	// is recorded in the dispatch log, exactly like a live one.
+	testRoute(customerCode: string, routeId: number) {
+		return HttpClient.post<FlaskBaseResponse & DispatchOutcome>(
+			`/customers/${customerCode}/notification_routes/${routeId}/test`
+		)
+	},
+	testInternalRoute(routeId: number) {
+		return HttpClient.post<FlaskBaseResponse & DispatchOutcome>(
+			`/internal_notification_routes/${routeId}/test`
+		)
 	},
 
 	// Internal-scope routes live outside the /customers/{code}/... tree because

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/ChannelConfigFields.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/ChannelConfigFields.vue
@@ -1,0 +1,134 @@
+<template>
+	<div class="flex flex-col gap-1">
+		<n-form-item v-for="field of fields" :key="field.key" :label="field.label" :path="`config.${field.key}`">
+			<!-- string[] — one input per entry, add/remove inline -->
+			<n-dynamic-input
+				v-if="field.kind === 'string-array'"
+				:value="asArray(field.key)"
+				:on-create="() => ''"
+				class="w-full"
+				@update:value="v => set(field.key, v)"
+			/>
+
+			<n-checkbox
+				v-else-if="field.kind === 'boolean'"
+				:checked="Boolean(model[field.key])"
+				@update:checked="v => set(field.key, v)"
+			>
+				{{ field.label }}
+			</n-checkbox>
+
+			<n-input-number
+				v-else-if="field.kind === 'number'"
+				:value="(model[field.key] as number | null) ?? null"
+				clearable
+				class="w-full"
+				@update:value="v => set(field.key, v)"
+			/>
+
+			<n-input
+				v-else
+				:value="(model[field.key] as string | null) ?? null"
+				:placeholder="field.placeholder"
+				clearable
+				@update:value="v => set(field.key, v)"
+			/>
+
+			<template v-if="field.description" #feedback>{{ field.description }}</template>
+		</n-form-item>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { NotificationChannelDescriptor } from "@/types/notifications"
+import { NCheckbox, NDynamicInput, NFormItem, NInput, NInputNumber } from "naive-ui"
+import { computed } from "vue"
+
+// Renders a channel's config form from the JSON Schema its provider advertises,
+// for channels that have no hand-written block.
+//
+// This is a FALLBACK, not a replacement. Shuffle needs a searchable app picker
+// that fetches a customer's orgs and then that org's authenticated apps; Resend
+// needs `to` to appear only in static recipient mode. Neither is expressible in
+// JSON Schema, and rendering them generically would be a downgrade. Channels
+// whose config is genuinely a few flat fields — Teams is a webhook URL — get
+// this for free and need no frontend work at all.
+
+const props = defineProps<{
+	descriptor: NotificationChannelDescriptor
+	model: Record<string, unknown>
+}>()
+
+// The parent owns `config`. Emitting a key/value rather than mutating the prop
+// keeps ownership in one place and satisfies vue/no-mutating-props.
+const emit = defineEmits<{
+	(e: "update", key: string, value: unknown): void
+}>()
+
+type FieldKind = "string" | "number" | "boolean" | "string-array"
+
+interface RenderableField {
+	key: string
+	label: string
+	kind: FieldKind
+	description?: string
+	placeholder?: string
+}
+
+interface SchemaNode {
+	type?: string
+	title?: string
+	description?: string
+	default?: unknown
+	anyOf?: SchemaNode[]
+	items?: SchemaNode
+}
+
+/**
+ * Resolve a property's effective type.
+ *
+ * Pydantic renders `Optional[str]` as `anyOf: [{type: "string"}, {type: "null"}]`
+ * rather than a plain type, so a renderer that only reads `.type` silently falls
+ * through to a text input for every optional field — including numbers and
+ * booleans. Unwrap to the first non-null branch.
+ */
+function resolveKind(node: SchemaNode): FieldKind {
+	let resolved: SchemaNode = node
+	if (node.anyOf?.length) {
+		resolved = node.anyOf.find(n => n.type && n.type !== "null") ?? node.anyOf[0]
+	}
+
+	if (resolved.type === "array") {
+		return resolved.items?.type === "string" ? "string-array" : "string"
+	}
+	if (resolved.type === "boolean") return "boolean"
+	if (resolved.type === "integer" || resolved.type === "number") return "number"
+	return "string"
+}
+
+/** "webhook_url" -> "Webhook url", when the schema supplies no title. */
+function humanize(key: string): string {
+	const spaced = key.replace(/_/g, " ")
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+const fields = computed<RenderableField[]>(() => {
+	const properties = (props.descriptor.config_schema?.properties ?? {}) as Record<string, SchemaNode>
+	return Object.entries(properties).map(([key, node]) => ({
+		key,
+		label: node.title || humanize(key),
+		kind: resolveKind(node),
+		description: node.description,
+		placeholder: typeof node.default === "string" && node.default ? String(node.default) : undefined
+	}))
+})
+
+function asArray(key: string): string[] {
+	const value = props.model[key]
+	return Array.isArray(value) ? (value as string[]) : []
+}
+
+function set(key: string, value: unknown) {
+	emit("update", key, value)
+}
+</script>

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -213,6 +213,16 @@
 			</n-alert>
 		</template>
 
+		<!-- Any channel without a hand-written block above renders from the JSON
+		     Schema its provider advertises, so adding one needs no frontend work. -->
+		<template v-else-if="activeDescriptor">
+			<ChannelConfigFields
+				:descriptor="activeDescriptor"
+				:model="cfg"
+				@update="(key, value) => (cfg[key as keyof EditableChannelConfig] = value as never)"
+			/>
+		</template>
+
 		<n-form-item label="Custom message template (optional)" path="format_template" :show-feedback="false">
 			<n-input
 				v-model:value="form.format_template"
@@ -263,7 +273,18 @@
 			<n-checkbox v-model:checked="form.enabled">Enabled</n-checkbox>
 		</n-form-item>
 
-		<div class="flex justify-end gap-2">
+		<div class="flex flex-wrap items-center justify-end gap-2">
+			<!--
+				Only offered on a saved route: the test sends through the STORED
+				config, so offering it on unsaved edits would test something the
+				operator isn't looking at.
+			-->
+			<n-button v-if="editing" secondary :loading="testing" class="mr-auto" @click="sendTest">
+				<template #icon>
+					<Icon :name="TestIcon" :size="14" />
+				</template>
+				Send test
+			</n-button>
 			<n-button @click="$emit('close')">Cancel</n-button>
 			<n-button type="primary" :loading="submitting" @click="submit">
 				{{ editing ? "Save changes" : "Create route" }}
@@ -276,6 +297,7 @@
 import type { FormInst, FormRules } from "naive-ui"
 import type {
 	NotificationChannel,
+	NotificationChannelDescriptor,
 	NotificationRoute,
 	NotificationRoutePayload,
 	NotificationScope,
@@ -288,7 +310,9 @@ import type {
 import { NAlert, NButton, NCheckbox, NDynamicInput, NForm, NFormItem, NInput, NInputNumber, NSelect, useMessage } from "naive-ui"
 import { computed, onBeforeMount, reactive, ref } from "vue"
 import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
 import { getApiErrorMessage } from "@/utils"
+import ChannelConfigFields from "./ChannelConfigFields.vue"
 
 const props = defineProps<{
 	// Empty for internal-scope routes, which belong to no tenant.
@@ -377,6 +401,49 @@ async function loadLegacyWorkflowState() {
 		legacyWorkflowEnabled.value = rows.some(n => n.enabled)
 	} catch {
 		legacyWorkflowEnabled.value = null
+	}
+}
+
+// The channel catalog drives the generic fallback renderer. Loaded once per
+// form open; a failure just means an unknown channel shows no config fields
+// rather than the form breaking.
+const channels = ref<NotificationChannelDescriptor[]>([])
+const activeDescriptor = computed(() => channels.value.find(c => c.key === form.channel) ?? null)
+
+async function loadChannels() {
+	try {
+		const res = await Api.notifications.getChannels()
+		if (res.data.success) channels.value = res.data.channels
+	} catch {
+		channels.value = []
+	}
+}
+
+const TestIcon = "carbon:send-alt"
+const testing = ref(false)
+
+async function sendTest() {
+	if (!props.editingRoute) return
+	testing.value = true
+	try {
+		const routeId = props.editingRoute.id
+		const code = props.customerCode
+		const res =
+			isInternalScope.value || !code
+				? await Api.notifications.testInternalRoute(routeId)
+				: await Api.notifications.testRoute(code, routeId)
+
+		// The endpoint reports the delivery outcome rather than throwing on a
+		// failed send: "domain not verified" is information, not an error state.
+		if (res.data.status === "sent") {
+			message.success(`Test sent via ${res.data.channel} in ${res.data.latency_ms ?? "?"}ms`)
+		} else {
+			message.warning(res.data.error_message || `Test ${res.data.status}`)
+		}
+	} catch (err) {
+		message.error(getApiErrorMessage(err as never) || "Failed to send test notification")
+	} finally {
+		testing.value = false
 	}
 }
 
@@ -798,6 +865,7 @@ async function submit() {
 }
 
 onBeforeMount(async () => {
+	loadChannels()
 	loadLegacyWorkflowState()
 	await loadIntegrations()
 	// If editing a Shuffle route, prefetch the apps for its integration

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -62,6 +62,16 @@ export interface ResendChannelConfig extends ChannelConfig {
 	max_per_hour?: number | null
 }
 
+export interface DispatchOutcome {
+	route_id: number
+	route_name: string
+	channel: string
+	status: DispatchStatus
+	error_message: string | null
+	latency_ms: number | null
+	provider_reference: string | null
+}
+
 export interface ResendQuota {
 	sent_this_month: number
 	limit: number


### PR DESCRIPTION
Closes #1029. **No migration.**

Two pieces of foundation deferred earlier, both now with the context that was missing when I deferred them.

## Generic renderer

Channels without a hand-written block now render from the JSON Schema their provider advertises via `GET /notification_channels`. That's the last part of Phase 1's promise still outstanding — **adding a channel now genuinely needs no frontend work**.

**Deliberately a fallback, not a replacement.** The two reasons I deferred it still hold:

- Rendering **Shuffle** generically would replace a searchable app picker — which fetches a customer's orgs, then that org's authenticated apps — with a bare text input for `app_id`.
- **Resend** needs `to` to appear only in static recipient mode, which is form logic JSON Schema can't express.

Channels whose config is genuinely a few flat fields get this for free. Teams (#1005) is the first consumer, and should need no form block at all.

**The subtlety worth reviewing:** Pydantic renders `Optional[str]` as `anyOf: [{type:"string"},{type:"null"}]`, not a plain type. A renderer reading only `.type` silently falls through to a text input for *every optional field* — including numbers and booleans. It unwraps to the first non-null branch.

## Send test

Delivers **one real notification** through the route's actual provider, rather than a per-provider probe.

A probe would test the wrong thing. The Resend key in use here is **send-only restricted**, so an account-state check 401s while sending works fine. What an operator wants to know is whether a real notification arrives, and only a real send answers that.

**The outcome is logged.** A test consumes provider quota exactly like a live send — omitting it would make the Resend monthly counter under-report and hide test traffic from the audit trail. The dedupe key carries a uuid so repeated tests always send; one that silently no-ops the second time would be worse than useless.

Offered only on **saved** routes, since it tests the stored config rather than whatever is on screen.

Verified end to end against the live API: `sent`, 351ms, message id captured.

## Two bugs the suite didn't catch

Running it for real surfaced both, and neither would have been caught by the green suite because nothing exercised that path:

- **`NotificationSeverity` was unimported** in the sample-event builder — `NameError` for every trigger.
- **`DispatchOutcome` was passed `shuffle_execution_id`**, which #1022 renamed to `provider_reference`. Pydantic accepted the construction and failed on read — rename residue that a passing test run hides.

Both now have regression tests carrying the reason in their docstrings. Worth weighing when judging how much "219 passed" is telling you about new code paths.

## Testing

```
13 new     tests/test_notification_test_send.py
219 passed backend tests/
type-check exit 0 · eslint clean · pre-commit clean
```

Covers the two regressions above, per-trigger sample-event construction, unique dedupe keys, entity type following the trigger, assignment triggers carrying an assignee (without one, testing an assignee-mode route would always skip and tell the operator nothing), unknown-trigger fallback, a raising provider being reported rather than 500-ing, unknown channels, and both scopes.

## Note

I ran the app's own `add_connectors_if_not_exist` against the dev database to seed the Resend connector row — normally created at startup, and the backend hadn't restarted since #1026 added the tuple. Idempotent and the same code path boot uses, but it is a write, so flagging it.

## Next

#1005 (Teams) — and this PR is what makes it small: with the fallback renderer, a channel whose config is a single webhook URL needs a provider module and a registry line, nothing else.
