### PR TITLE
feat(notifications): add Microsoft Teams as a delivery channel

### DIFF
--- a/backend/app/notifications/channels/__init__.py
+++ b/backend/app/notifications/channels/__init__.py
@@ -21,12 +21,14 @@ from app.notifications.channels.base import DispatchContext
 from app.notifications.channels.base import SendResult
 from app.notifications.channels.resend import ResendChannel
 from app.notifications.channels.shuffle import ShuffleChannel
+from app.notifications.channels.teams import TeamsChannel
 from app.notifications.channels.webhook import WebhookChannel
 
 _PROVIDERS: List[ChannelProvider] = [
     ShuffleChannel(),
     WebhookChannel(),
     ResendChannel(),
+    TeamsChannel(),
 ]
 
 CHANNEL_REGISTRY: Dict[str, ChannelProvider] = {p.key: p for p in _PROVIDERS}

--- a/backend/app/notifications/channels/base.py
+++ b/backend/app/notifications/channels/base.py
@@ -117,6 +117,13 @@ class ChannelProvider(ABC):
     #: fixed URL so it cannot resolve an assignee; email can.
     supports_recipient_modes: ClassVar[Set[str]] = {"static"}
 
+    #: Whether this channel can serve an internal-scope route. False only where
+    #: something ties the channel to a specific customer — Shuffle's org is an
+    #: FK to a per-customer table, so a tenant-less route has nothing to point
+    #: at. Declared here so the route form can filter generically instead of
+    #: hardcoding channel names.
+    supports_internal_scope: ClassVar[bool] = True
+
     #: Config keys holding secrets. Encrypted at rest and redacted on read in
     #: #1020; declared here so providers own the classification.
     secret_fields: ClassVar[Set[str]] = set()

--- a/backend/app/notifications/channels/shuffle.py
+++ b/backend/app/notifications/channels/shuffle.py
@@ -83,6 +83,9 @@ class ShuffleChannel(ChannelProvider):
     display_name = "Shuffle"
     config_schema = ShuffleConfig
     supports_recipient_modes = {"static"}
+    # A Shuffle integration belongs to a specific customer, so a route with no
+    # tenant has no org to dispatch through.
+    supports_internal_scope = False
 
     async def send(
         self,

--- a/backend/app/notifications/channels/teams.py
+++ b/backend/app/notifications/channels/teams.py
@@ -1,0 +1,212 @@
+"""Microsoft Teams delivery via an incoming webhook.
+
+Teams is NOT the generic `webhook` channel with a different URL. It requires an
+Adaptive Card wrapped in a `{"type": "message", "attachments": [...]}` envelope;
+posting a bare JSON body produces a 200 and no visible message, which is the
+worst possible failure mode.
+
+**Which webhook.** Microsoft retired the Office 365 connector webhooks
+(`*.webhook.office.com`) during 2026 in favour of Power Automate **Workflows**,
+whose URLs live on `*.powerautomate.com`, `*.powerplatform.com` and
+`flow.microsoft.com`. Workflows accept both Adaptive Card and the legacy
+MessageCard format; we send Adaptive Cards. The host is deliberately NOT
+validated beyond https — a deployment may still have a working legacy connector,
+and Microsoft has changed these hosts before.
+
+**Constraints that shaped this, both from Microsoft's docs rather than
+guesswork:** messages over 28 KB are rejected outright, and Teams throttles
+above roughly four requests per second with a 429.
+
+Configuration is a single URL, so this channel needs no bespoke form block —
+the route form renders it from the schema below. That was the point of #1029.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from pydantic import field_validator
+
+from app.notifications.channels.base import ChannelConfig
+from app.notifications.channels.base import ChannelProvider
+from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import SendResult
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.services.dispatchers import TEAMS_MAX_PAYLOAD_BYTES
+from app.notifications.services.dispatchers import dispatch_teams
+
+#: Adaptive Card container styles by severity. Teams renders these as a coloured
+#: band, which is what makes a channel of alerts scannable.
+_SEVERITY_STYLE = {
+    "Critical": "attention",
+    "High": "attention",
+    "Medium": "warning",
+    "Low": "good",
+    "Informational": "default",
+}
+
+#: Pinned rather than "latest": Teams renders a card at the version declared,
+#: and a newer schema silently degrades on older clients.
+_ADAPTIVE_CARD_VERSION = "1.4"
+
+
+class TeamsConfig(ChannelConfig):
+    """`customer_notification_route.config` when channel='teams'.
+
+    One field, which is the point — a channel this simple should need no
+    frontend work, and the generic renderer handles it.
+    """
+
+    webhook_url: Optional[str] = None
+
+    @field_validator("webhook_url")
+    @classmethod
+    def _must_be_https(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        cleaned = v.strip()
+        if cleaned and not cleaned.lower().startswith("https://"):
+            raise ValueError("webhook_url must start with https://")
+        return cleaned
+
+
+class TeamsChannel(ChannelProvider):
+    key = "teams"
+    display_name = "Microsoft Teams"
+    config_schema = TeamsConfig
+    # A webhook targets a fixed channel, so it cannot deliver to a resolved
+    # person — same constraint as the generic webhook channel.
+    supports_recipient_modes = {"static"}
+    # The URL is the credential: anyone holding it can post to the channel.
+    secret_fields = {"webhook_url"}
+
+    async def send(
+        self,
+        *,
+        route: Any,
+        event: NotificationEvent,
+        rendered_body: str,
+        ctx: DispatchContext,
+    ) -> SendResult:
+        # Read attributes before the first await — an expired ORM object would
+        # otherwise trigger a synchronous refresh and MissingGreenlet.
+        has_template = bool(route.format_template)
+        try:
+            cfg = self.parse_config(route)
+        except ValueError as e:
+            return SendResult.failed(f"Invalid teams config: {e}")
+
+        if not cfg.webhook_url:
+            return SendResult.failed("Route config has no webhook_url (data integrity issue)")
+
+        card = self._build_card(event, rendered_body, raw_body=has_template)
+        card = self._fit_within_size_limit(card, event, rendered_body)
+
+        status, error_message, latency_ms, _ = await dispatch_teams(webhook_url=cfg.webhook_url, card=card)
+        return SendResult(status=status, error_message=error_message, latency_ms=latency_ms)
+
+    # -- card construction --------------------------------------------------
+
+    def _build_card(self, event: NotificationEvent, body: str, *, raw_body: bool) -> Dict[str, Any]:
+        """Wrap the rendered body in an Adaptive Card envelope.
+
+        When the route sets a `format_template` the operator has chosen their
+        own wording, so the body is shown verbatim under a minimal header rather
+        than being decomposed into facts they didn't ask for.
+        """
+        style = _SEVERITY_STYLE.get(event.severity.value, "default")
+
+        elements: List[Dict[str, Any]] = [
+            {
+                "type": "Container",
+                "style": style,
+                "bleed": True,
+                "items": [
+                    {
+                        "type": "TextBlock",
+                        "text": f"{event.severity.value} · {event.subject}",
+                        "weight": "Bolder",
+                        "size": "Medium",
+                        "wrap": True,
+                    },
+                ],
+            },
+        ]
+
+        if not raw_body:
+            facts = [{"title": "Trigger", "value": event.trigger.value.replace("_", " ")}]
+            if event.customer_code:
+                facts.append({"title": "Customer", "value": event.customer_code})
+            facts.append({"title": "Entity", "value": f"{event.entity_type} #{event.entity_id}"})
+            if event.assignee_username:
+                facts.append({"title": "Assignee", "value": event.assignee_username})
+            if event.actor_username:
+                facts.append({"title": "By", "value": event.actor_username})
+            elements.append({"type": "FactSet", "facts": facts})
+
+        elements.append({"type": "TextBlock", "text": body, "wrap": True})
+
+        card_content: Dict[str, Any] = {
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "type": "AdaptiveCard",
+            "version": _ADAPTIVE_CARD_VERSION,
+            "body": elements,
+        }
+
+        if event.link_url:
+            # Both an action AND a text line. Microsoft's own docs are ambiguous
+            # about whether button rendering survives in Workflows, and a deep
+            # link that silently vanishes is worse than a slightly redundant one.
+            card_content["actions"] = [
+                {"type": "Action.OpenUrl", "title": "Open in CoPilot", "url": event.link_url},
+            ]
+            elements.append(
+                {
+                    "type": "TextBlock",
+                    "text": f"[Open in CoPilot]({event.link_url})",
+                    "wrap": True,
+                    "isSubtle": True,
+                },
+            )
+
+        return {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "contentUrl": None,
+                    "content": card_content,
+                },
+            ],
+        }
+
+    def _fit_within_size_limit(self, card: Dict[str, Any], event: NotificationEvent, body: str) -> Dict[str, Any]:
+        """Truncate the body until the card fits Teams' 28 KB ceiling.
+
+        Teams rejects an oversized message outright, and an AI report with a full
+        markdown write-up and IOC list can exceed it. A truncated notification
+        that arrives beats a complete one that doesn't — the deep link is
+        preserved so the full detail is always one click away.
+        """
+        if len(json.dumps(card).encode("utf-8")) <= TEAMS_MAX_PAYLOAD_BYTES:
+            return card
+
+        # Binary-search the longest body that fits, rather than guessing a
+        # character count: the overhead depends on how many facts were rendered.
+        low, high = 0, len(body)
+        best = ""
+        while low <= high:
+            mid = (low + high) // 2
+            candidate = body[:mid]
+            trial = self._build_card(event, candidate + "\n\n…truncated by CoPilot to fit Teams' 28 KB limit.", raw_body=True)
+            if len(json.dumps(trial).encode("utf-8")) <= TEAMS_MAX_PAYLOAD_BYTES:
+                best = candidate
+                low = mid + 1
+            else:
+                high = mid - 1
+
+        return self._build_card(event, best + "\n\n…truncated by CoPilot to fit Teams' 28 KB limit.", raw_body=True)

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -258,6 +258,7 @@ async def list_channels_route() -> ChannelListResponse:
             display_name=provider.display_name,
             config_schema=provider.config_schema.model_json_schema(),
             supports_recipient_modes=sorted(provider.supports_recipient_modes),
+            supports_internal_scope=provider.supports_internal_scope,
             secret_fields=sorted(provider.secret_fields),
         )
         for provider in CHANNEL_REGISTRY.values()

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -76,6 +76,7 @@ class NotificationChannel(str, Enum):
     SHUFFLE = "shuffle"
     WEBHOOK = "webhook"
     RESEND = "resend"
+    TEAMS = "teams"
 
 
 class NotificationSeverity(str, Enum):
@@ -329,6 +330,10 @@ class NotificationRouteCreate(NotificationRouteBase):
                 raise ValueError("config.url is required when channel='webhook'")
             if not str(url).lower().startswith(("http://", "https://")):
                 raise ValueError("config.url must start with http:// or https://")
+        elif self.channel == NotificationChannel.TEAMS:
+            url = self.config.get("webhook_url")
+            if not url:
+                raise ValueError("config.webhook_url is required when channel='teams'")
         elif self.channel == NotificationChannel.RESEND:
             # `to` is only meaningful for static delivery — in assignee mode the
             # address comes from the event, and requiring both would imply the
@@ -496,6 +501,7 @@ class ChannelDescriptor(BaseModel):
     display_name: str
     config_schema: Dict[str, Any]
     supports_recipient_modes: List[str]
+    supports_internal_scope: bool
     secret_fields: List[str]
 
 

--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -59,6 +59,7 @@ _WEBHOOK_TIMEOUT_S = 15.0
 WebhookDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
 # (status, error_message, latency_ms, provider_reference)
 ResendDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
+TeamsDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +145,59 @@ async def dispatch_webhook(
     except Exception as e:  # noqa: BLE001
         latency_ms = int((time.monotonic() - started) * 1000)
         logger.warning(f"Webhook dispatch failed: {e!r}")
+        return ("failed", f"{type(e).__name__}: {e}", latency_ms, None)
+
+
+# ---------------------------------------------------------------------------
+# Microsoft Teams dispatcher
+# ---------------------------------------------------------------------------
+
+_TEAMS_TIMEOUT_S = 15.0
+
+#: Teams rejects messages over 28 KB outright. AI report bodies can exceed that,
+#: so the provider truncates rather than letting the send fail.
+TEAMS_MAX_PAYLOAD_BYTES = 28 * 1024
+
+
+async def dispatch_teams(*, webhook_url: str, card: Dict[str, Any]) -> TeamsDispatchResult:
+    """POST an Adaptive Card envelope to a Teams webhook.
+
+    Returns (status, error_message, latency_ms, provider_reference). Teams
+    returns no message id, so the reference is always None — the field exists
+    for channels that do.
+
+    Teams throttles above 4 requests/second and answers 429. That is surfaced
+    distinctly from other 4xx: it means "retry later", not "your config is
+    wrong", and an operator seeing a bare 429 would reasonably check the URL.
+    """
+    started = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=_TEAMS_TIMEOUT_S) as client:
+            response = await client.post(
+                webhook_url,
+                headers={"Content-Type": "application/json"},
+                json=card,
+            )
+        latency_ms = int((time.monotonic() - started) * 1000)
+
+        if response.status_code == 429:
+            return (
+                "failed",
+                "Teams rate-limited this request (429). Teams throttles above ~4 requests/second.",
+                latency_ms,
+                None,
+            )
+        if response.status_code >= 400:
+            return (
+                "failed",
+                f"Teams returned {response.status_code}: {response.text[:200]}",
+                latency_ms,
+                None,
+            )
+        return ("sent", None, latency_ms, None)
+    except Exception as e:  # noqa: BLE001
+        latency_ms = int((time.monotonic() - started) * 1000)
+        logger.warning(f"Teams dispatch failed: {e!r}")
         return ("failed", f"{type(e).__name__}: {e}", latency_ms, None)
 
 

--- a/backend/tests/test_notification_channel_registry.py
+++ b/backend/tests/test_notification_channel_registry.py
@@ -97,10 +97,10 @@ def _shuffle_route(config=None, **over):
 
 
 def test_registry_contains_the_shipped_channels():
-    assert sorted(channel_keys()) == ["resend", "shuffle", "webhook"]
+    assert sorted(channel_keys()) == ["resend", "shuffle", "teams", "webhook"]
 
 
-@pytest.mark.parametrize("key", ["resend", "shuffle", "webhook"])
+@pytest.mark.parametrize("key", ["resend", "shuffle", "teams", "webhook"])
 def test_every_provider_declares_the_required_classvars(key):
     provider = CHANNEL_REGISTRY[key]
     assert isinstance(provider, ChannelProvider)

--- a/backend/tests/test_notification_teams_channel.py
+++ b/backend/tests/test_notification_teams_channel.py
@@ -1,0 +1,288 @@
+"""Microsoft Teams delivery.
+
+Teams is not the generic webhook channel with a different URL. It requires an
+Adaptive Card inside a `{"type": "message", "attachments": [...]}` envelope, and
+posting a bare JSON body returns **200 with no visible message** — the worst
+failure mode available, since nothing looks wrong. Most of these tests exist to
+pin that envelope.
+
+Two constraints come from Microsoft's documentation rather than guesswork:
+messages over 28 KB are rejected outright, and Teams throttles above roughly
+four requests per second with a 429.
+
+Unit tests with stubbed HTTP — no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_teams_channel.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.notifications.channels.teams as teams_mod  # noqa: E402
+from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
+from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.channels.teams import TeamsConfig  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.dispatchers import TEAMS_MAX_PAYLOAD_BYTES  # noqa: E402
+
+WEBHOOK = "https://prod-11.westus.logic.azure.com:443/workflows/abc/triggers/manual/paths/invoke"
+
+
+def _event(severity=NotificationSeverity.CRITICAL, link="https://copilot.invalid/alerts/42", assignee=None, summary="Credential dumping."):
+    return NotificationEvent(
+        customer_code="TENANT_A",
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity=severity,
+        subject="Mimikatz signature",
+        summary=summary,
+        entity_type="alert",
+        entity_id=42,
+        dedupe_key="alert:42:investigation_complete",
+        link_url=link,
+        assignee_username=assignee,
+    )
+
+
+def _route(config=None, format_template=None):
+    cfg = {"webhook_url": WEBHOOK}
+    cfg.update(config or {})
+    return SimpleNamespace(id=1, name="SOC Teams", channel="teams", format_template=format_template, config=json.dumps(cfg))
+
+
+def _send(route, event=None, body="RENDERED BODY", result=("sent", None, 12, None)):
+    ev = event or _event()
+    sent = AsyncMock(return_value=result)
+    with patch.object(teams_mod, "dispatch_teams", sent):
+        outcome = asyncio.run(
+            CHANNEL_REGISTRY["teams"].send(
+                route=route,
+                event=ev,
+                rendered_body=body,
+                ctx=DispatchContext(session=AsyncMock(), event=ev),
+            ),
+        )
+    return outcome, (sent.await_args.kwargs if sent.await_args else None)
+
+
+def _card(kwargs):
+    return kwargs["card"]["attachments"][0]["content"]
+
+
+# ── the envelope: a bare body 200s and shows nothing ──────────────────────
+
+
+def test_payload_is_wrapped_in_the_message_envelope():
+    _outcome, kwargs = _send(_route())
+    payload = kwargs["card"]
+
+    assert payload["type"] == "message"
+    assert len(payload["attachments"]) == 1
+    assert payload["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+
+
+def test_content_is_an_adaptive_card_with_a_pinned_version():
+    """Pinned rather than 'latest': Teams renders at the declared version, and a
+    newer schema degrades silently on older clients."""
+    _outcome, kwargs = _send(_route())
+    card = _card(kwargs)
+
+    assert card["type"] == "AdaptiveCard"
+    assert card["$schema"] == "http://adaptivecards.io/schemas/adaptive-card.json"
+    assert card["version"] == "1.4"
+
+
+def test_the_rendered_body_reaches_the_card():
+    _outcome, kwargs = _send(_route(), body="A very specific body")
+    assert any(el.get("text") == "A very specific body" for el in _card(kwargs)["body"])
+
+
+# ── severity styling ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("severity", "style"),
+    [
+        (NotificationSeverity.CRITICAL, "attention"),
+        (NotificationSeverity.HIGH, "attention"),
+        (NotificationSeverity.MEDIUM, "warning"),
+        (NotificationSeverity.LOW, "good"),
+        (NotificationSeverity.INFORMATIONAL, "default"),
+    ],
+)
+def test_severity_drives_the_header_colour(severity, style):
+    """The coloured band is what makes a channel of alerts scannable."""
+    _outcome, kwargs = _send(_route(), event=_event(severity=severity))
+    header = _card(kwargs)["body"][0]
+
+    assert header["type"] == "Container"
+    assert header["style"] == style
+
+
+def test_header_carries_severity_and_subject():
+    _outcome, kwargs = _send(_route())
+    text = _card(kwargs)["body"][0]["items"][0]["text"]
+    assert "Critical" in text
+    assert "Mimikatz signature" in text
+
+
+# ── the deep link, belt and braces ────────────────────────────────────────
+
+
+def test_link_appears_as_both_an_action_and_body_text():
+    """Microsoft's docs are ambiguous about whether button rendering survives in
+    Workflows. A deep link that silently vanishes is worse than a redundant one.
+    """
+    _outcome, kwargs = _send(_route())
+    card = _card(kwargs)
+
+    assert card["actions"][0]["type"] == "Action.OpenUrl"
+    assert card["actions"][0]["url"] == "https://copilot.invalid/alerts/42"
+    assert any("copilot.invalid/alerts/42" in str(el.get("text", "")) for el in card["body"])
+
+
+def test_no_link_means_no_actions_block():
+    _outcome, kwargs = _send(_route(), event=_event(link=None))
+    assert "actions" not in _card(kwargs)
+
+
+# ── facts vs a custom template ────────────────────────────────────────────
+
+
+def test_default_body_gets_a_factset():
+    _outcome, kwargs = _send(_route())
+    factsets = [el for el in _card(kwargs)["body"] if el["type"] == "FactSet"]
+    assert len(factsets) == 1
+    titles = {f["title"] for f in factsets[0]["facts"]}
+    assert {"Trigger", "Customer", "Entity"} <= titles
+
+
+def test_a_custom_template_is_shown_verbatim_without_facts():
+    """The operator chose their own wording; decomposing it into facts they
+    didn't ask for would override that choice."""
+    _outcome, kwargs = _send(_route(format_template="{{summary}}"), body="My exact wording")
+    card = _card(kwargs)
+
+    assert not [el for el in card["body"] if el["type"] == "FactSet"]
+    assert any(el.get("text") == "My exact wording" for el in card["body"])
+
+
+def test_assignee_and_actor_appear_when_present():
+    event = _event(assignee="bob")
+    event.actor_username = "alice"
+    _outcome, kwargs = _send(_route(), event=event)
+    facts = [el for el in _card(kwargs)["body"] if el["type"] == "FactSet"][0]["facts"]
+    values = {f["title"]: f["value"] for f in facts}
+
+    assert values["Assignee"] == "bob"
+    assert values["By"] == "alice"
+
+
+# ── the 28 KB ceiling ─────────────────────────────────────────────────────
+
+
+def test_an_oversized_body_is_truncated_to_fit():
+    """Teams rejects an oversized message outright. A truncated notification
+    that arrives beats a complete one that doesn't."""
+    huge = "x" * (TEAMS_MAX_PAYLOAD_BYTES * 2)
+    _outcome, kwargs = _send(_route(), body=huge)
+
+    encoded = len(json.dumps(kwargs["card"]).encode("utf-8"))
+    assert encoded <= TEAMS_MAX_PAYLOAD_BYTES, f"payload was {encoded} bytes"
+
+
+def test_truncation_says_so_rather_than_cutting_silently():
+    huge = "x" * (TEAMS_MAX_PAYLOAD_BYTES * 2)
+    _outcome, kwargs = _send(_route(), body=huge)
+    assert any("truncated" in str(el.get("text", "")).lower() for el in _card(kwargs)["body"])
+
+
+def test_truncation_keeps_the_deep_link_so_full_detail_stays_reachable():
+    huge = "x" * (TEAMS_MAX_PAYLOAD_BYTES * 2)
+    _outcome, kwargs = _send(_route(), body=huge)
+    card = _card(kwargs)
+    assert card["actions"][0]["url"] == "https://copilot.invalid/alerts/42"
+
+
+def test_a_normal_body_is_not_truncated():
+    _outcome, kwargs = _send(_route(), body="short body")
+    assert not any("truncated" in str(el.get("text", "")).lower() for el in _card(kwargs)["body"])
+
+
+# ── config ────────────────────────────────────────────────────────────────
+
+
+def test_missing_webhook_url_fails_without_calling_out():
+    outcome, kwargs = _send(_route(config={"webhook_url": None}))
+    assert outcome.status == "failed"
+    assert "webhook_url" in outcome.error_message
+    assert kwargs is None
+
+
+def test_non_https_url_is_rejected():
+    with pytest.raises(ValueError):
+        TeamsConfig(webhook_url="http://insecure.invalid/hook")
+
+
+def test_the_host_is_not_restricted():
+    """Deliberately unvalidated beyond https: a deployment may still have a
+    working legacy connector, and Microsoft has changed these hosts before."""
+    for url in [
+        "https://prod-11.westus.logic.azure.com/workflows/x",
+        "https://acme.webhook.office.com/webhookb2/x",
+        "https://default.api.powerplatform.com/powerautomate/x",
+    ]:
+        assert TeamsConfig(webhook_url=url).webhook_url == url
+
+
+def test_unknown_config_key_is_rejected():
+    with pytest.raises(ValueError):
+        TeamsConfig.model_validate({"webhook_url": WEBHOOK, "cardstyle": "oops"})
+
+
+def test_malformed_config_fails_only_this_route():
+    broken = _route()
+    broken.config = "{not json"
+    outcome, kwargs = _send(broken)
+
+    assert outcome.status == "failed"
+    assert "Invalid teams config" in outcome.error_message
+    assert kwargs is None
+
+
+# ── throttling ────────────────────────────────────────────────────────────
+
+
+def test_rate_limiting_is_reported_as_retry_later_not_misconfiguration():
+    """A bare 429 would send an operator checking their URL. Teams throttles
+    above ~4 requests/second, which is a transient condition."""
+    outcome, _kwargs = _send(
+        _route(),
+        result=("failed", "Teams rate-limited this request (429). Teams throttles above ~4 requests/second.", 5, None),
+    )
+    assert outcome.status == "failed"
+    assert "429" in outcome.error_message
+
+
+# ── the point of #1029 ────────────────────────────────────────────────────
+
+
+def test_config_is_simple_enough_for_the_generic_form_renderer():
+    """One string field, so this channel needed no bespoke frontend block —
+    which is what the generic renderer was built for."""
+    schema = CHANNEL_REGISTRY["teams"].config_schema.model_json_schema()
+    assert list(schema["properties"]) == ["webhook_url"]
+
+
+def test_the_webhook_url_is_declared_as_a_secret():
+    """Anyone holding it can post to the channel."""
+    assert CHANNEL_REGISTRY["teams"].secret_fields == {"webhook_url"}

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -533,21 +533,22 @@ const INTERNAL_TRIGGER_OPTIONS = [
 
 const triggerOptions = computed(() => (isInternalScope.value ? INTERNAL_TRIGGER_OPTIONS : CUSTOMER_TRIGGER_OPTIONS))
 
-// Shuffle is unavailable to internal routes: a Shuffle integration belongs to a
-// specific customer, and an internal route belongs to none. The backend rejects
-// it too — this just avoids offering something that would 400.
-const channelOptions = computed(() =>
-	isInternalScope.value
-		? [
-				{ label: "Email (Resend)", value: "resend" },
-				{ label: "Webhook (direct HTTP to any URL)", value: "webhook" }
-			]
-		: [
-				{ label: "Shuffle (Slack / Teams / Outlook / 3,000+ apps)", value: "shuffle" },
-				{ label: "Webhook (direct HTTP to any URL)", value: "webhook" },
-				{ label: "Email (Resend)", value: "resend" }
-			]
-)
+// Derived from the channel catalog rather than a hardcoded list, so adding a
+// channel needs no change here. Providers declare whether they can serve an
+// internal route: Shuffle can't, because its org is an FK to a per-customer
+// table and an internal route has no tenant.
+const channelOptions = computed(() => {
+	const available = isInternalScope.value
+		? channels.value.filter(c => c.supports_internal_scope)
+		: channels.value
+
+	// Before the catalog loads, fall back to whatever the route already uses so
+	// the select isn't briefly empty when editing.
+	if (!available.length) {
+		return [{ label: form.channel, value: form.channel }]
+	}
+	return available.map(c => ({ label: c.display_name, value: c.key }))
+})
 
 const methodOptions = [
 	{ label: "POST", value: "POST" },

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -25,7 +25,7 @@ export function isInternalTrigger(trigger: NotificationTrigger): boolean {
 	return INTERNAL_TRIGGERS.includes(trigger)
 }
 
-export type NotificationChannel = "shuffle" | "webhook" | "resend"
+export type NotificationChannel = "shuffle" | "webhook" | "resend" | "teams"
 
 export type NotificationSeverity = "Critical" | "High" | "Medium" | "Low" | "Informational"
 
@@ -79,6 +79,10 @@ export interface ResendQuota {
 	configured: boolean
 }
 
+export interface TeamsChannelConfig extends ChannelConfig {
+	webhook_url?: string | null
+}
+
 export interface WebhookChannelConfig extends ChannelConfig {
 	url?: string | null
 	method?: string
@@ -98,6 +102,9 @@ export interface NotificationChannelDescriptor {
 		[key: string]: unknown
 	}
 	supports_recipient_modes: RecipientMode[]
+	// False only where something ties the channel to a specific customer —
+	// Shuffle's org is per-customer, so it can't serve an internal route.
+	supports_internal_scope: boolean
 	secret_fields: string[]
 }
 


### PR DESCRIPTION
Closes #1005. **No migration. No frontend form block.**

## ⚠️ Not verified against a live Teams webhook

I had no Teams webhook URL, so unlike Resend there's no live send behind this. The envelope shape comes from Microsoft's own code sample and the tests pin it structurally, but **the first real send will be yours**.

Worth doing before merge specifically because of how Teams fails: posting a bare JSON body returns **200 with no visible message**. The failure mode looks exactly like success.

## The docs check changed the design

The issue called for confirming the current webhook contract rather than trusting recollection. It was worth it — three things were wrong or missing:

- **Workflows accept both Adaptive Card and legacy MessageCard**, not Adaptive-only as I'd assumed.
- **28 KB size ceiling.** Messages over it are rejected outright.
- **Throttling above ~4 requests/second**, answering 429.

The last two would have shipped as latent bugs.

## What that produced

**Size handling.** An AI report with a full markdown write-up and IOC list can exceed 28 KB. The provider binary-searches the longest body that fits, states that it truncated, and preserves the deep link so full detail stays one click away. Binary search rather than a fixed character count because the overhead depends on how many facts rendered.

**429 handling.** Surfaced as *"Teams throttles above ~4 requests/second"* rather than a bare status code — a bare 429 sends an operator checking their URL for a transient condition.

**An ambiguity resolved defensively.** Microsoft's known-issues note reads *"Workflows support both Adaptive Cards and Message Card format (button rendering won't be supported)"*, and it's genuinely unclear whether the parenthetical covers Adaptive Cards. The deep link goes out as **both** an `Action.OpenUrl` and a text line in the card body. Slightly redundant beats silently vanishing.

**Host deliberately unvalidated** beyond https. A deployment may still have a working legacy connector, and Microsoft has changed these hosts before. The URL is declared a **secret** — anyone holding it can post to the channel.

## This is the proof #1029 was for

Teams needed **no bespoke form block**: one URL field, rendered from its advertised JSON Schema.

I went one step further — the channel **list** now derives from the catalog rather than a hardcoded array, so channel #6 needs no frontend change at all. That required one honest addition: `supports_internal_scope` on `ChannelProvider`, because Shuffle can't serve an internal route (its org is an FK to a per-customer table) and the form had that knowledge hardcoded. Now providers declare it and the form filters generically.

So the full cost of this channel was: one provider module, one dispatcher function, one registry line.

## Testing

```
27 new     tests/test_notification_teams_channel.py
246 passed backend tests/
type-check exit 0 · eslint clean · pre-commit clean
```

Most tests pin the **envelope**, since getting it wrong is a silent 200. Also covers severity → header colour across all five levels, the deep link appearing in both places, a custom template being shown verbatim without a FactSet (the operator chose their wording; decomposing it would override that), truncation staying under the limit while keeping the link and saying it truncated, https-only validation, host permissiveness across all three URL shapes, and 429 distinctness.

## Suggested manual check before merge

1. Create a Workflow in a Teams channel via **Workflows → Send webhook alerts to a channel**, copy the URL
2. Add a route on the Teams channel, paste it
3. **Send test** — the button from #1029
4. Confirm a card appears with a coloured header and a working "Open in CoPilot" link

Step 4 is the one that matters: a 200 with nothing visible means the envelope is wrong.
