### PR TITLE
docs: notification routing, Resend and Teams

### DIFF
--- a/docs/architecture/SHUFFLE_NOTIFICATIONS.md
+++ b/docs/architecture/SHUFFLE_NOTIFICATIONS.md
@@ -1,368 +1,105 @@
-# Shuffle MCP integration — per-customer notification routing
+# Notification routing — architecture
 
-Planning doc for the Shuffle integration. Lives here while the feature is in
-flight; gets folded into the architecture set or removed when the work
-ships and the user-facing docs land.
-
-**Branch:** `feat/shuffle-notifications`
-**Status:** Planning — no code yet.
-
----
-
-## Problem
-
-Today, every Talon investigation writes back to the CoPilot database (job,
-report, IOCs). That's it. There's no per-customer notification fan-out —
-if one customer wants a Slack message on every true positive and another
-wants an Outlook email on Critical-only, neither path exists.
-
-Goals:
-
-1. Let each customer pick their own notification destinations (Slack, Outlook,
-   Teams, email — eventually any of Shuffle's 3,000+ integrations).
-2. Route per-customer, with severity thresholds and trigger types.
-3. Don't change Talon's existing prompts or per-alert templates.
-4. Keep the MCP boundary uniform — the agent should reach notifications via
-   the same stdio MCP pattern it already uses for `mysql`, `opensearch`, etc.
-
-Non-goals:
-
-- Replacing existing CoPilot integrations (Shuffle is for outbound notifications,
-  not for swapping out our connectors).
-- Building our own integration catalog. We're consuming Shuffle's hosted MCP
-  layer, not reinventing it.
+> This file was the planning doc for per-customer notification routing, written
+> before any code existed. It said of itself that it "gets folded into the
+> architecture set or removed when the work ships and the user-facing docs
+> land." Both have now happened, so this is a short note on what it actually
+> became, for developers touching the area.
+>
+> **User-facing setup lives in [Notifications (Admin/Operator)](../user/notifications.md).**
 
 ---
 
-## Architecture overview
+## Shape
+
+The engine lives in `backend/app/notifications/` and follows the standard
+`routes / services / schema` split, plus one addition:
 
 ```
-┌──────────────────────────────────────────────────────────────────┐
-│                      CoPilot frontend (Vue)                      │
-│                                                                  │
-│  Customers → [Acme] → Notifications tab                          │
-│   ┌───────────────────────────────────────────┐                  │
-│   │ Connected integrations  ← <ShuffleMCP>    │                  │
-│   │  • Slack  • Outlook  • Teams              │                  │
-│   ├───────────────────────────────────────────┤                  │
-│   │ Routing rules                             │                  │
-│   │  • Critical+ → Slack #soc-alerts          │                  │
-│   │  • High+ → Outlook ir@corp.com            │                  │
-│   └───────────────────────────────────────────┘                  │
-└────────────────────────┬─────────────────────────────────────────┘
-                         │ REST (CoPilot DB)
-                         ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                   CoPilot backend (FastAPI)                      │
-│                                                                  │
-│  New tables:                                                     │
-│    customer_shuffle_integrations  (per-customer Shuffle keys)    │
-│    customer_notification_routes   (severity → app → destination) │
-│    notification_dispatch_log      (idempotency + audit)          │
-│                                                                  │
-│  New routes:                                                     │
-│    GET/POST  /customers/{code}/shuffle_integrations              │
-│    GET/POST  /customers/{code}/notification_routes               │
-│    GET       /customers/{code}/notification_dispatch_log         │
-└────────────────────────┬─────────────────────────────────────────┘
-                         │ read-only MCP (mysql)
-                         ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                       Talon (NanoClaw)                           │
-│                                                                  │
-│  groups/copilot/.mcp.json gains:                                 │
-│    "shuffle": "/workspace/extra/shuffle-mcp/shuffle-mcp.sh"      │
-│                                                                  │
-│  shuffle-mcp/shuffle-mcp.py exposes:                             │
-│    shuffle_list_apps(customer_code)                              │
-│    shuffle_invoke(customer_code, app, input)                     │
-│    shuffle_dispatch_notifications(customer_code, alert_id,       │
-│                                   trigger, severity, summary)    │
-│                                                                  │
-│  groups/copilot/CLAUDE.md gains a single new instruction:        │
-│    "After report write-back, call                                │
-│     shuffle_dispatch_notifications(...) — best effort, log       │
-│     failures, never fail the investigation."                     │
-└────────────────────────┬─────────────────────────────────────────┘
-                         │ HTTP (JSON-RPC)
-                         ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                      Shuffle (hosted)                            │
-│  https://shuffler.io/api/v1/apps/{app}/mcp                       │
-│  Authorization: Bearer <per-customer Shuffle key>                │
-└──────────────────────────────────────────────────────────────────┘
+app/notifications/
+  channels/            <- one module per delivery channel
+    base.py            ChannelProvider ABC, SendResult, DispatchContext
+    __init__.py        CHANNEL_REGISTRY
+    shuffle.py  webhook.py  resend.py  teams.py
+  services/
+    notifications.py   CRUD + the dispatch loop
+    dispatchers.py     raw HTTP per provider
+    emit.py            fire-and-forget emission from inside CoPilot
+    event_builders.py  NotificationEvent construction per trigger
+    resend_quota.py    throttle + monthly counter
+  schema/
+    events.py          NotificationEvent (the envelope)
+    notifications.py   API shapes, enums, trigger sets
 ```
 
----
+### Adding a channel
 
-## Phase 1 — Manual webhooks, no Shuffle yet
+One module under `channels/` and one line in `CHANNEL_REGISTRY`. No migration,
+no schema edit, and no frontend work unless the channel wants richer UX than the
+generic renderer gives — the route form builds its config inputs from the JSON
+Schema the provider advertises via `GET /notification_channels`.
 
-**Why first:** ships value before any third-party dependency. Validates the
-table shape, the dispatch loop, and the agent's "after write-back, fan out"
-instruction.
+Teams was the first channel added under this contract and needed exactly that:
+a provider, a dispatcher function, a registry entry.
 
-### Backend
+## The three ideas worth knowing
 
-#### Tables
+**`NotificationEvent` is the envelope.** Every trigger builds one; the dispatch
+loop and every provider consume only that. `DispatchRequest` — Talon's wire
+format, an external contract — is adapted into one at the route boundary and is
+otherwise untouched.
 
-```python
-class CustomerNotificationRoute(SQLModel, table=True):
-    __tablename__ = "customer_notification_routes"
+**Scope is a tenancy boundary, not a preference.** `scope='customer'` routes
+carry a `customer_code` and serve the end customer. `scope='internal'` routes
+have `customer_code IS NULL` and serve the SOC. Assignment triggers resolve only
+against internal routes, because telling a customer which analyst picked up
+their alert is a leak. The CRUD layer enforces the invariant both ways, and
+internal routes have their own endpoints (`/internal_notification_routes`)
+because there is no customer code to put in the path.
 
-    id: int | None = Field(default=None, primary_key=True)
-    customer_code: str = Field(foreign_key="customers.customer_code", index=True)
+**`dedupe_key` owns idempotency.** The dispatch log is unique on
+`(route_id, dedupe_key)`, and the key travels on the event — so each trigger
+decides its own semantics. Assignment keys include the assignee, which is what
+makes reassigning A → B → A notify A again. Manual test sends carry a uuid so
+they always deliver.
 
-    name: str                            # human label, e.g. "SOC team Slack #alerts"
-    trigger: str                         # 'investigation_true_positive', 'severity_critical', ...
-    channel: str                         # Phase 1 set: 'smtp_email' only. Phase 2 adds 'shuffle'.
-    destination: str                     # webhook URL or email address
-    min_severity: str                    # 'Critical' | 'High' | 'Medium' | 'Low' | 'Informational'
-    format_template: str | None = None   # optional Jinja override
+## Things that bite
 
-    enabled: bool = True
+**`emit()` must not block.** `alert_created` is on the ingest hot path. Emission
+is fire-and-forget with its **own** `AsyncSession` — reusing the request-scoped
+one after the response has returned raises `MissingGreenlet` — plus a bounded
+timeout and a strong task reference (asyncio holds only a weak one).
 
-    last_dispatched_at: datetime | None = None  # denorm for UI list
-    dispatch_count: int = 0                     # denorm counter
-    created_by: str | None = None               # CoPilot user who added it
+**Two guards prevent notification spam.** The `alert_created` emit sits *after*
+`create_alert()`'s recurrence early-return, so a repeated alert doesn't
+re-notify. Assignment emits only fire when the value actually changed.
 
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
-```
+**The AI-report gate is scope-aware.** `customer_portal_ai_report_settings` is
+opt-in and governs whether AI findings may reach a customer. It gates
+customer-scoped routes only; internal routes are exempt, because running
+investigations while keeping results in-house is a supported configuration. The
+predicate is imported from `app/customer_portal/services/ai_reports.py` rather
+than reimplemented, so the two enforcement points can't drift.
 
-```python
-class NotificationDispatchLog(SQLModel, table=True):
-    __tablename__ = "notification_dispatch_log"
-    __table_args__ = (
-        UniqueConstraint(
-            "customer_code", "alert_id", "route_id", "trigger",
-            name="uq_notif_dispatch_idem",
-        ),
-    )
+**A valid Resend key can answer 401.** Send-only restricted keys are the
+recommended shape for a service that only sends mail. Connector verification
+treats `restricted_api_key` as success — a naive "200 means healthy" check
+reports a correct production key as broken.
 
-    id: int | None = Field(default=None, primary_key=True)
-    customer_code: str = Field(index=True)
-    alert_id: int = Field(index=True)
-    route_id: int = Field(foreign_key="customer_notification_routes.id")
-    trigger: str
+**Teams fails silently when wrong.** A malformed payload returns `200 OK` and
+displays nothing. The Adaptive Card envelope
+(`{"type":"message","attachments":[…]}`) is load-bearing, as are the 28 KB size
+ceiling and the ~4 req/s throttle.
 
-    dispatched_at: datetime = Field(default_factory=datetime.utcnow)
-    status: str                                 # 'sent' | 'failed' | 'skipped'
-    error_message: str | None = None
-    latency_ms: int | None = None
-    payload_preview: str | None = None          # first 500 chars, debugging
-```
+**The legacy path still exists.** `handle_customer_notifications()` in
+`app/incidents/services/incident_alert.py` fires the older per-customer Shuffle
+*workflow* on the same event as `alert_created`. Both are opt-in and coexist
+deliberately; the route form warns when a customer has both. Consolidating them
+would mean migrating live customer config and remains an open follow-up.
 
-#### Deferred / dropped
+## Not yet done
 
-- **`anonymize`** — dropped. Recipients are SOC analysts who already see
-  deanonymized reports in the UI; toggle has no consumer.
-- **`tags`**, **`payload_filter`**, **`rate_limit_per_minute`** — deferred.
-  `trigger` + `min_severity` covers the 80% case. Phase 4 can layer on
-  richer filters / rate limits without touching this schema (rate limit
-  derivable from a windowed count over the dispatch log).
-
-#### Wiring
-
-- Alembic migration creates both tables
-- Pydantic schemas in `app/notifications/schema.py`
-- CRUD service + REST routes (`/customers/{code}/notification_routes`)
-- Initial dispatch helper: `dispatch_smtp_email(to, subject, body)` —
-  SMTP only. Slack/Teams/etc. arrive in Phase 2 via Shuffle's hosted
-  MCP rather than as raw webhook URLs in CoPilot, since Phase 2's
-  picker-based OAuth replaces the manual-paste UX entirely. Shipping
-  `slack_webhook` as a Phase 1 channel would have been throwaway UI.
-- Logger writes to `notification_dispatch_log` with the unique-index
-  upsert pattern for idempotency
-
-### Frontend
-
-- Customer detail page → new "Notifications" tab
-- Form: pick channel (Slack/email), enter webhook URL or email, severity
-  threshold, trigger type
-- List view of existing routes with enable/disable toggle
-- Dispatch log viewer (read-only)
-
-### Talon
-
-- Add a single new section to `groups/copilot/CLAUDE.md`:
-  > **After report write-back**, query `customer_notification_routes` for the
-  > alert's `customer_code` filtered by trigger and severity. For each
-  > enabled row, format the summary per the route's template (default:
-  > severity + alert link + summary) and POST the webhook / send the email.
-  > Notifications are **best-effort** — log success/failure to
-  > `notification_dispatch_log` keyed by `(customer_code, alert_id, route_id,
-  > trigger)`. Skip if the log already has a row for that key (idempotency).
-  > Do **not** fail the investigation on dispatch errors.
-- The agent uses its existing tools (MySQL MCP for the route lookup + log
-  write, Bash with curl for the webhook POST). No new Talon-side MCP yet.
-
-### Acceptance
-
-- Set `SMTP_HOST` / `SMTP_PORT` / `SMTP_FROM` (and creds if required) in CoPilot's environment
-- Configure an SMTP route on one customer (e.g. `severity_critical_or_high` → `soc@example.com`)
-- Trigger an investigation that resolves Critical or High
-- Email arrives within ~10s of report write-back
-- `notification_dispatch_log` has the row
-- Re-running the same investigation does not re-fire the email
-
----
-
-## Phase 2 — Shuffle proxy MCP in Talon
-
-**Why:** unlocks the 3,000+ catalog without forcing the agent to learn each
-provider's REST API. Single stdio MCP, same boundary as `mysql-mcp.sh`.
-
-### Talon
-
-- New directory: `nanoclaw/shuffle-mcp/`
-  - `shuffle-mcp.sh` — bash wrapper (loads `.env`, exec's the python entry)
-  - `shuffle-mcp.py` — stdio MCP server using the standard MCP Python SDK
-  - `setup.sh` — install/activate per the existing pattern
-  - `CLAUDE.md` — short tool-selection guide for the agent
-- Tools exposed:
-
-  | Tool | Purpose |
-  |------|---------|
-  | `shuffle_list_apps(customer_code)` | Return the customer's authenticated apps + a one-line description from the Shuffle catalog. Used at runtime so the agent picks intelligently. |
-  | `shuffle_invoke(customer_code, app, input)` | POST to `https://shuffler.io/api/v1/apps/{app}/mcp` with the customer's Bearer key. `input` is the natural-language string Shuffle expects. |
-  | `shuffle_dispatch_notifications(customer_code, alert_id, trigger, severity, summary)` | High-level convenience: looks up routes for the customer, formats per channel, calls `shuffle_invoke` for each, writes the dispatch log. Idempotent. |
-
-- API key sourcing: the MCP queries CoPilot's MySQL for
-  `customer_shuffle_integrations.api_key WHERE customer_code = ?`. **Never**
-  trusts a `customer_code` parameter from the agent for cross-tenant lookups
-  — the MCP enforces the tenant boundary, not the prompt.
-- Container build: install `shuffle-mcp` into a venv via
-  `container/Dockerfile`, like the existing `opensearch-mcp` / `mempalace`
-  pattern.
-
-### CoPilot backend
-
-- Alembic migration: `customer_shuffle_integrations`
-  - `id`, `customer_code` (FK), `app` (text, e.g. "slack"),
-    `display_name`, `api_key` (encrypted), `connected_at`, `last_used_at`,
-    `enabled`
-- REST: CRUD for integrations + a "test" route that calls Shuffle to verify
-  the key works (`tools/list` against the app's MCP endpoint)
-- `customer_notification_routes` gains a `shuffle_app` column referencing
-  the integration. Phase 1's manual `channel`/`destination` columns become
-  optional — routes use one or the other.
-
-### Talon prompt change
-
-Replace Phase 1's "POST the webhook" instruction with:
-
-> **After report write-back**, call
-> `shuffle_dispatch_notifications(customer_code, alert_id, trigger,
-> severity, summary)`. The MCP handles routing, formatting, and the
-> dispatch log internally. Best-effort — failures already logged.
-
-Single tool call from the agent's perspective. The MCP owns the per-channel
-formatting + idempotency + tenant scoping.
-
-### Acceptance
-
-- Manually insert a row in `customer_shuffle_integrations` for one customer
-  with a real Shuffle API key
-- Investigation completes → agent calls
-  `shuffle_dispatch_notifications` → Slack message arrives via Shuffle (not
-  via raw webhook)
-- Verify the dispatch log entry shows `app=slack` and references the
-  Shuffle integration row, not a raw URL
-
----
-
-## Phase 3 — Shuffle picker in CoPilot frontend
-
-**Why:** removes the manual API key paste. Customers self-serve via the
-embedded picker.
-
-### Frontend
-
-- Install `@shuffleio/shuffle-mcps` (peer deps already met by Vue side via
-  the Vue export `@singulio/singul/vue`)
-- Replace the manual "API key" input on the Notifications tab with the
-  `<ShuffleMCP>` (or Vue equivalent) component
-- On `onAppSelected`, kick off Shuffle's OAuth flow, capture the resulting
-  Bearer key, POST it to CoPilot's `/customers/{code}/shuffle_integrations`
-- Show connected integrations as cards; "Disconnect" button revokes the
-  CoPilot row (does not revoke at Shuffle — admin must do that themselves
-  via shuffler.io)
-
-### Backend
-
-- No schema change — the picker just writes through the existing
-  `customer_shuffle_integrations` endpoint
-- Optional: webhook receiver for Shuffle revocation events (later)
-
-### Acceptance
-
-- A customer admin opens the Notifications tab → clicks "+ Add integration"
-  → picker shows 3,000+ apps → picks Slack → OAuth pops → returns a key
-  stored in CoPilot
-- A new notification route can immediately reference this integration
-
----
-
-## Phase 4 — Hardening
-
-- **Per-channel format templates:** Slack gets compact + thread, email gets
-  full markdown, Teams gets adaptive card. Default templates in
-  `shuffle-mcp/templates/{channel}.j2`. Routes can override via
-  `format_template`.
-- **Retry semantics:** failed dispatches retry once after 30s, then mark
-  failed. Logged in `notification_dispatch_log.status='failed'` with the
-  upstream error.
-- **Audit trail UI:** Customer → Notifications → Dispatch log tab shows
-  recent fires, status, retry count.
-- **Rate limiting per customer:** prevent runaway dispatch storms (e.g. a
-  detection rule firing 100x/min) — coalesce to 1 dispatch per minute per
-  route, summarize the rest.
-
----
-
-## Cross-cutting concerns
-
-| Concern | Decision |
-|---------|----------|
-| **Tenant isolation** | The Shuffle MCP itself is a stateless adapter — same `/apps/slack` URL for every customer. Isolation lives in two CoPilot-side places: (1) which `customer_shuffle_integrations.api_key` row gets fetched (Bearer token differs per customer's OAuth-issued workspace), (2) which `customer_notification_routes.destination` (channel name / email) is used. Both are filtered by `customer_code` at lookup time — single SQLAlchemy boundary. Cross-tenant leak risk is "did the lookup pull the right customer's row" — covered by the FK + an explicit test. |
-| **Shuffle outage** | Notification step wrapped in try/except; failure does not fail the investigation. Logged to `notification_dispatch_log.status='failed'`. |
-| **PII** | Recipients are SOC analysts who already see deanonymized reports in the CoPilot UI. No anonymization layer needed. The `anonymize` column from earlier drafts has been dropped. |
-| **Idempotency** | Unique index on `(customer_code, alert_id, route_id, trigger)`. Agent's instruction is "skip if log row already exists." Re-runs are safe. |
-| **Format mismatch** | Default templates per channel. Custom override per route via `format_template`. Phase 4 ships the default template set. |
-| **Cost** | Shuffle's per-call pricing exists but isn't blocking — revisit once we have real volume. Phase 4's coalescing/rate-limit work covers it preemptively if needed. |
-| **Failure mode visibility** | `notification_dispatch_log` is the source of truth. Frontend surfaces it. |
-
----
-
-## Open questions
-
-1. **Shuffle key revocation** — does Shuffle expose a webhook when a user
-   revokes upstream? Need this for clean state in CoPilot.
-2. **Shuffle's `tools/list` schema** — does each app expose typed tool
-   schemas, or only the natural-language `tool_name` + `input` shape? If
-   typed, Phase 2 can register N tools per app instead of one generic
-   `shuffle_invoke`. Worth a 30-min spike before locking Phase 2's design.
-
----
-
-## Out of scope (for now)
-
-- Inbound: Talon receiving messages back through Shuffle (Shuffle → Talon).
-  Possible future use: slash commands in Slack to trigger investigations.
-  Not Phase 1–4.
-- Replacing CoPilot's existing alerting (Graylog → CoPilot).
-- Bidirectional state (closing an alert from Slack).
-
----
-
-## Summary of phasing
-
-| Phase | Duration estimate | Ships |
-|-------|-------------------|-------|
-| **1** | ~3 days | Working notifications via plain webhooks/SMTP. Schema + agent loop validated. |
-| **2** | ~3 days | Shuffle MCP in Talon. 3,000+ apps reachable via the catalog. |
-| **3** | ~2 days | Picker in CoPilot. Customer self-service. |
-| **4** | ~3 days | Templates, anonymize, retry, audit, rate limit. |
-
-Total ~11 working days end-to-end. Phase 1 is the only one that materially
-touches Talon's prompt; Phases 2–4 are additive on the MCP / DB / UI sides.
+- **Secrets are stored in cleartext.** `config` holds webhook auth headers and
+  Teams webhook URLs, both credentials. Encryption at rest is outstanding.
+- **No digest/batching.** Every matching event sends immediately. Relevant
+  mainly to email, where the free tier is 1,000/month deployment-wide.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "SOCFortress CoPilot",
-  "description": "SOCFortress CoPilot documentation \u2014 operator workflows, admin/engineer configuration, and developer/AI-agent guides.",
+  "description": "SOCFortress CoPilot documentation — operator workflows, admin/engineer configuration, and developer/AI-agent guides.",
   "logo": {
     "light": "/assets/brand/logo-text.png",
     "dark": "/assets/brand/logo-text.png",
@@ -103,7 +103,7 @@
             ]
           },
           {
-            "group": "Alerting (Graylog \u2192 CoPilot)",
+            "group": "Alerting (Graylog → CoPilot)",
             "pages": [
               "user/ui/incident-sources",
               "user/ui/graylog-management",
@@ -111,9 +111,11 @@
             ]
           },
           {
-            "group": "Alerting (CoPilot \u2192 Shuffle)",
+            "group": "Notifications & Alerting (outbound)",
             "pages": [
-              "user/ui/alerting-shuffle"
+              "user/ui/notifications",
+              "user/ui/alerting-shuffle",
+              "user/notifications"
             ]
           },
           {

--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -1,0 +1,314 @@
+# Notifications (Admin/Operator)
+
+CoPilot can send a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose **what** triggers it, **who** receives it, and **which channel** carries it.
+
+This guide covers the notification routing engine as a whole, plus setup for each channel: **Email (Resend)**, **Microsoft Teams**, **Shuffle**, and **direct webhooks**.
+
+> **Not to be confused with Notification Workflows.** CoPilot has an older, separate per-customer feature that fires a single Shuffle *workflow* on alert creation, configured under *Customers → (customer) → Notification Workflows*. Both still work. See [Overlap with Notification Workflows](#overlap-with-notification-workflows) before enabling both.
+
+---
+
+## The idea
+
+A **route** is one rule. It answers three questions:
+
+| Question | Field |
+|---|---|
+| When should this fire? | **Trigger** |
+| How severe must it be? | **Minimum severity** |
+| Where does it go? | **Channel** + its configuration |
+
+You can have as many routes as you like. Every route matching an event fires independently, so one alert can notify a customer's Teams channel *and* a webhook into your automation platform *and* nothing else, depending on what you've configured.
+
+### Two kinds of route
+
+This distinction matters more than any other setting.
+
+**Customer routes** deliver to the end customer. They live under *Customers → (customer) → Notifications* and carry that customer's code. Use them for things the customer should know about: an alert was raised, an investigation concluded.
+
+**Internal routes** deliver to your SOC. They live under *Internal Notifications* in the main navigation, belong to no customer, and are **admin-only**. Use them for things your team should know about: who picked up which alert.
+
+Assignment notifications are internal by design. If you assign an ACME alert to an analyst, that notification reaches your team — never ACME's channel. This isn't configurable, and it isn't meant to be: telling a customer which of your analysts is handling their incident is rarely intended.
+
+---
+
+## Triggers
+
+### Customer-facing
+
+| Trigger | Fires when |
+|---|---|
+| **An alert is created** | A new alert is ingested. Recurrences of an existing open alert do **not** re-fire. |
+| **An AI investigation completes** | Talon finishes investigating an alert and writes its report back. |
+
+### Internal
+
+| Trigger | Fires when |
+|---|---|
+| **An alert is assigned** | An alert's assignee changes |
+| **A case is assigned** | A case's assignee changes |
+| **A case task is assigned** | A task within a case is assigned |
+
+Assignment triggers only fire on an **actual change**. Re-saving the same assignee sends nothing. By default, assigning something to *yourself* also sends nothing — there's a per-route **Notify on self-assign** option if your team wants the audit trail anyway.
+
+### Severity filtering
+
+**Minimum severity** is inclusive: a route set to *High* fires on High and Critical, not Medium.
+
+For alert creation, severity comes from the Wazuh rule level (12–15 Critical, 8–11 High, 4–7 Medium, 1–3 Low). Alerts from sources with no rule level are treated as **Medium** so they aren't silently filtered out.
+
+Assignment notifications are **Informational** — being assigned something isn't a security severity. Set assignment routes to *Informational and above*, or they'll never fire.
+
+---
+
+## Channels
+
+| Channel | Delivers to | Can email the assignee? |
+|---|---|---|
+| **Email (Resend)** | Fixed addresses, or whoever an item is assigned to | **Yes** |
+| **Microsoft Teams** | A Teams channel, via an incoming webhook | No |
+| **Shuffle** | A Shuffle app in the customer's org | No |
+| **Webhook** | Any HTTPS endpoint | No |
+
+Only email can address a *person*. A webhook targets a fixed URL and Teams targets a fixed channel, so "notify whoever this was assigned to" requires the Resend channel.
+
+**Shuffle is unavailable on internal routes.** A Shuffle integration belongs to a specific customer, and an internal route has no customer — so the option isn't offered there.
+
+---
+
+## Setting up Email (Resend)
+
+Resend is a transactional email service. Its free tier covers 1,000 emails per month.
+
+### 1. Create a Resend account and API key
+
+1. Sign up at [resend.com](https://resend.com)
+2. Create an API key. A **send-only** ("Sending access") key is sufficient and recommended — CoPilot never needs to manage your account.
+3. **Verify a sending domain** under *Domains*. Until you do, Resend only delivers to the email address that owns the account, which is fine for testing and useless in production.
+
+### 2. Configure the connector
+
+Add these to your `.env` and restart CoPilot:
+
+```bash
+RESEND_URL=https://api.resend.com
+RESEND_API_KEY=re_your_key_here
+# Must be on a domain you verified in Resend.
+RESEND_FROM_ADDRESS=alerts@yourdomain.com
+```
+
+Then go to **Connectors**, find **Resend**, and click **Verify**.
+
+> A send-only key is *expected* to report success here even though CoPilot probes a management endpoint it can't reach. Verification recognises restricted keys and treats them as valid. If you used a full-access key, verification additionally reports which sending domains are verified.
+
+### 3. Create a route
+
+Under *Customers → (customer) → Notifications* (or *Internal Notifications* for assignments):
+
+| Field | Notes |
+|---|---|
+| **Channel** | Email (Resend) |
+| **Deliver to** | *A fixed list of addresses*, or *Whoever it's assigned to* |
+| **To** | Recipients. Hidden when delivering to the assignee. |
+| **From** | Optional. Overrides `RESEND_FROM_ADDRESS`; must be on a verified domain. |
+| **Subject prefix** | Defaults to `[CoPilot]` |
+| **Max emails per hour** | Defaults to 20. Clear it to disable throttling. |
+
+Click **Send test** to confirm delivery before relying on it.
+
+### Watch the quota
+
+The 1,000/month free tier is **shared across your entire deployment** — every customer's routes draw from the same allowance. That's roughly 33 emails per day for everyone combined.
+
+The route form shows current usage and warns as the month fills. Two things keep it under control:
+
+- **Minimum severity.** An alert-creation route set to *Informational* on a busy customer will exhaust the tier quickly. Start at *High*.
+- **Max emails per hour.** A per-route ceiling, so one noisy route can't drain the allowance for everybody. Throttled sends are recorded in the dispatch log with the reason.
+
+If you need more, Resend's paid plans raise the limit and nothing in CoPilot needs to change.
+
+### Notifying the assignee
+
+Set **Deliver to** → *Whoever it's assigned to*. At delivery time CoPilot looks up the assignee's CoPilot account and uses the email address on it.
+
+This means analysts must have a valid email on their user account. If one is missing, the notification is recorded as failed with the reason — it won't silently vanish, and it won't fall back to the static list.
+
+---
+
+## Setting up Microsoft Teams
+
+### 1. Create a webhook in Teams
+
+Microsoft retired the old Office 365 connectors in 2026. The current mechanism is the **Workflows** app:
+
+1. In Teams, go to the channel you want notifications in
+2. **More options (…)** next to the channel → **Workflows**
+3. Choose the **Send webhook alerts to a channel** template
+4. Configure and save, then **copy the webhook URL**
+
+### 2. Create a route
+
+Choose **Microsoft Teams** as the channel and paste the URL. That's the only field.
+
+Then click **Send test** — and actually look at Teams.
+
+> **Why that matters here specifically.** If the payload shape is wrong, Teams responds `200 OK` and displays nothing. A successful-looking test with no visible card means something is wrong. A correct test produces a card with a coloured header and a working **Open in CoPilot** link.
+
+### What the card looks like
+
+The header is coloured by severity — red for Critical and High, amber for Medium, green for Low — which makes a busy channel scannable. Below it, a facts table (customer, entity, assignee) and the message body.
+
+### Limits worth knowing
+
+- **28 KB per message.** Teams rejects anything larger. A long AI report is truncated with a note saying so, and the deep link is preserved so the full detail is one click away.
+- **~4 requests per second.** Above that Teams throttles and CoPilot records the notification as failed with a rate-limit message. This is transient — it means retry later, not that anything is misconfigured.
+
+---
+
+## Setting up Shuffle
+
+Shuffle routes deliver through a customer's own authenticated Shuffle org, giving access to its app catalogue (Slack, Outlook, Jira, and several thousand more).
+
+1. Add a **Shuffle integration** for the customer — *Customers → (customer) → Notifications → Shuffle integrations*
+2. Create a route with **Shuffle** as the channel
+3. Pick the integration, then the app within it
+4. Set a **destination hint** — a channel name, email address or handle. This is prepended to the outgoing message so Shuffle's app agent knows where to deliver.
+
+For the wider Shuffle setup, see [CoPilot ↔ Shuffle Integration](./shuffle-integration.md).
+
+---
+
+## Setting up a webhook
+
+The generic option: an HTTPS POST to any endpoint.
+
+| Field | Notes |
+|---|---|
+| **Webhook URL** | Required, must be `https://` |
+| **Method** | POST or PUT |
+| **Custom headers** | Optional. For `Authorization`, `X-API-Key` and similar. |
+| **Include full AI report** | Adds the report markdown, recommended actions and IOC list to the payload |
+
+By default CoPilot sends a structured JSON object:
+
+```json
+{
+  "customer_code": "00001",
+  "alert_id": 42,
+  "alert_name": "Mimikatz signature detected",
+  "severity": "Critical",
+  "summary": "Credential dumping observed on WKSTN-04.",
+  "report_url": "https://copilot.example.com/alerts/42",
+  "text": "…the rendered message body…"
+}
+```
+
+If you set a **custom message template**, its rendered output is sent as the raw body instead — which is how you match a provider-specific shape like Discord's `{"content": …}` or Slack's `{"text": …}`.
+
+---
+
+## Custom message templates
+
+Any route can override the default wording. Templates use `{{token}}` substitution:
+
+| Token | Contains |
+|---|---|
+| `{{customer_code}}` | Customer code |
+| `{{alert_id}}` / `{{entity_id}}` | The alert, case or task id |
+| `{{alert_name}}` | Alert title |
+| `{{severity}}` | Critical / High / Medium / Low / Informational |
+| `{{summary}}` | The default one-paragraph summary |
+| `{{report_url}}` | Deep link back into CoPilot |
+| `{{assignee}}` | Who it was assigned to (assignment triggers) |
+| `{{actor}}` | Who did the assigning |
+| `{{entity_type}}` | `alert`, `case` or `case_task` |
+
+On webhook routes only, `{{report}}` injects the full AI report as a JSON object.
+
+---
+
+## Testing and troubleshooting
+
+### Send test
+
+Every saved route has a **Send test** button. It sends a **real** notification through the real path — so it consumes quota and appears in the dispatch log, exactly like a live one. That's deliberate: a test that took a different path wouldn't prove much.
+
+### The dispatch log
+
+*Customers → (customer) → Notifications → Dispatch log* records every attempt:
+
+| Status | Meaning |
+|---|---|
+| **sent** | The provider accepted it |
+| **failed** | It didn't go out — the reason is recorded |
+| **skipped** | Deliberately not sent: rate limit, self-assignment, or the customer's AI reports are disabled |
+
+`skipped` is not an error. It's CoPilot recording a decision it made, which is usually what you want to see when asking "why didn't I get an email".
+
+### Nothing arrived
+
+Work down this list:
+
+1. **Is the route enabled?**
+2. **Does the trigger match?** An assignment won't fire an *alert is created* route.
+3. **Is the severity high enough?** Assignment routes must be set to *Informational and above*.
+4. **Right scope?** Assignment notifications only reach **internal** routes. A customer route with an assignment trigger can never fire — which is why the UI doesn't offer that combination.
+5. **Check the dispatch log.** A `failed` row carries the provider's own message. A `skipped` row says which rule applied.
+6. **Is the connector verified?** Connectors → Resend → Verify.
+
+### AI report notifications aren't arriving for one customer
+
+There's a separate switch: *Customers → (customer) → AI Report*. It controls whether AI-written findings may reach that customer at all, and it's **opt-in** — a customer who has never been enabled is disabled.
+
+When it's off, AI notifications to that customer's routes are suppressed and logged as `skipped`. Internal routes are unaffected, so you can keep running investigations while keeping results in-house.
+
+---
+
+## Overlap with Notification Workflows
+
+CoPilot has an older per-customer feature — *Customers → (customer) → Notification Workflows* — that fires a single Shuffle workflow when an alert is created.
+
+That still works and is untouched. But it fires on the **same event** as an *alert is created* route, so a customer with both configured gets **two notifications per alert**.
+
+Both are opt-in, so this only happens if you set up both. The route form warns you when it applies. If you see that warning, disable whichever you don't want.
+
+---
+
+## Reference
+
+### Trigger → scope
+
+| Trigger | Routes |
+|---|---|
+| An alert is created | Customer |
+| An AI investigation completes | Customer |
+| An alert / case / case task is assigned | Internal |
+
+### Channel capabilities
+
+| Channel | Assignee delivery | Internal routes | Secret |
+|---|---|---|---|
+| Email (Resend) | Yes | Yes | API key on the connector |
+| Microsoft Teams | No | Yes | The webhook URL itself |
+| Webhook | No | Yes | Custom headers |
+| Shuffle | No | **No** | Deployment API key |
+
+### Environment variables
+
+```bash
+# Email (Resend)
+RESEND_URL=https://api.resend.com
+RESEND_API_KEY=re_your_key_here
+RESEND_FROM_ADDRESS=alerts@yourdomain.com
+```
+
+Teams and webhook routes need no environment configuration — their URLs live on the route. Shuffle uses the existing deployment-wide `SHUFFLER_API_KEY`.
+
+---
+
+## Related
+
+- [CoPilot ↔ Shuffle Integration](./shuffle-integration.md)
+- [Alerting → Shuffle (notifications)](./ui/alerting-shuffle.md)
+- [Connectors](./ui/connectors.md)
+- [Customers](./ui/customers.md)

--- a/docs/user/ui/alerting-shuffle.md
+++ b/docs/user/ui/alerting-shuffle.md
@@ -12,6 +12,10 @@ CoPilot integrates with **Shuffle** to run automation/playbooks and send notific
 
 This is the recommended way to extend CoPilot alerting into external systems without needing a custom integration inside CoPilot for every downstream tool.
 
+> **There is now a second, newer notification system.** [Notification routes](./notifications.md) let you send to **email, Microsoft Teams, Shuffle or any webhook**, with per-route triggers and severity filtering — including notifying an analyst when work is assigned to them.
+>
+> The workflow described on this page still works and is unchanged. But it fires on the **same event** as an *alert is created* route, so a customer configured with both receives **two notifications per alert**. The route form warns you when that applies.
+
 ## Video walkthrough
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ko5jLfkSCrk?si=YHEv-wHYhY3FuRUe" title="Revolutionize Your SIEM Alerts: Integrate CoPilot &amp; Shuffle" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
@@ -25,6 +29,8 @@ This is the recommended way to extend CoPilot alerting into external systems wit
 - **CoPilot ↔ Shuffle Integration (Admin/Operator)**: ../shuffle-integration.md
 
 ## Related alerting pages
+
+- Notification routes (email / Teams / Shuffle / webhook): ./notifications.md
 
 - Graylog management (detections): ./graylog-management.md
 - Incident sources (mapping context): ./incident-sources.md

--- a/docs/user/ui/notifications.md
+++ b/docs/user/ui/notifications.md
@@ -1,0 +1,49 @@
+---
+title: Notifications (routes & channels)
+description: Send alerts, AI investigation results and assignment events to email, Teams, Shuffle or a webhook.
+---
+
+# Notifications (routes & channels)
+
+CoPilot sends a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose the **trigger**, the **severity floor**, and the **channel**.
+
+Four channels ship today:
+
+| Channel | Delivers to |
+|---|---|
+| **Email (Resend)** | Fixed addresses, or whoever an item is assigned to |
+| **Microsoft Teams** | A Teams channel, via a Workflows webhook |
+| **Shuffle** | An app in the customer's Shuffle org |
+| **Webhook** | Any HTTPS endpoint |
+
+## Where to configure it
+
+**Per-customer routes** — *Customers → (customer) → Notifications*
+
+Things the customer should know about: an alert was raised, an investigation concluded.
+
+**Internal routes** — *Internal Notifications* in the main navigation (admin only)
+
+Things your SOC should know about: who picked up which alert. These belong to no customer, which is the point — assigning an ACME alert to an analyst notifies your team, never ACME.
+
+## The one thing to know
+
+**Assignment notifications are internal by design.** They only reach internal routes. A customer route with an assignment trigger could never fire, so the interface doesn't offer that combination.
+
+If you want the assignee emailed directly, use the **Email (Resend)** channel with *Deliver to → Whoever it's assigned to*. It's the only channel that can address a person; a webhook targets a URL and Teams targets a channel.
+
+## Testing
+
+Every saved route has a **Send test** button. It sends a real notification through the real path, so it consumes quota and appears in the dispatch log like any other.
+
+For Teams, look at the channel afterwards rather than trusting the result. A malformed payload returns `200 OK` and displays nothing.
+
+## Read the full guide
+
+- **Notifications (Admin/Operator)**: ../notifications.md — setup for each channel, quota management, message templates, and troubleshooting
+
+## Related pages
+
+- Alerting → Shuffle (legacy notification workflows): ./alerting-shuffle.md
+- Connectors (verify the Resend connector): ./connectors.md
+- Customers: ./customers.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Quickstart (Admins/Engineers): user/admins-quickstart.md
       - Customer Provisioning (Tenancy): user/customer-provisioning.md
       - Features by Area: user/features.md
+      - Notifications (Admin/Operator): user/notifications.md
       - CoPilot ↔ Shuffle Integration (Admin/Operator): user/shuffle-integration.md
       - Navigation Guide (UI): user/navigation.md
       - UI Guide (mirrors menu):
@@ -92,6 +93,7 @@ nav:
               - Cases: user/ui/incident-cases.md
               - Case Templates: user/ui/incident-case-templates.md
               - Alerting → Shuffle (notifications): user/ui/alerting-shuffle.md
+              - Notifications (routes & channels): user/ui/notifications.md
           - Alerts:
               - Alerts: user/ui/alerts.md
               - SIEM: user/ui/alerts-siem.md


### PR DESCRIPTION
Documentation for the notification engine, which shipped across twelve PRs with none.

## What's here

| File | |
|---|---|
| `docs/user/notifications.md` | **New.** The full guide |
| `docs/user/ui/notifications.md` | **New.** Short UI page mirroring the menu |
| `mkdocs.yml` · `docs/docs.json` | Both navs |
| `docs/user/ui/alerting-shuffle.md` | Cross-reference + double-notification warning |
| `docs/architecture/SHUFFLE_NOTIFICATIONS.md` | Rewritten — see below |

Both navs, because the repo publishes through **mkdocs and Mintlify** and they have to stay in step.

## How the guide is written

**Around what an operator should do**, not what we built:

- The Resend quota section leads with *"start at High severity"* rather than explaining the counter's implementation.
- The Teams section says to **look at the channel** after a test rather than trusting the result — a malformed payload returns `200 OK` and displays nothing, the failure mode that looks like success.
- Troubleshooting is a numbered list to work down, ending at the dispatch log.

**It leads with the customer-vs-internal scope distinction**, because that's the concept everything else depends on and the one most likely to generate a support ticket. Someone creating an "alert assigned" route under a customer would otherwise wonder why it never fires — the answer is that the combination can't exist, and the docs say so before they try it.

It also explains **why `skipped` isn't an error** in the dispatch log. That's CoPilot recording a decision — rate limit, self-assignment, AI reports disabled for that customer — and it's usually the row you want when asking "why didn't I get an email".

## The architecture doc

A strict docs build surfaced `SHUFFLE_NOTIFICATIONS.md` as orphaned from the nav. Reading it, it was the **original planning doc for this entire feature**, still declaring:

> **Status:** Planning — no code yet.

It also said of itself that it *"gets folded into the architecture set or removed when the work ships and the user-facing docs land."* Both are now true, and a doc telling the next developer the feature doesn't exist is worse than no doc at all.

Rewritten as a short architecture note: the registry contract (adding a channel is one module plus one registry line), the scope invariant, the dedupe-key convention, and five things that bite — including that a **valid Resend key can answer 401**, and that **Teams fails silently** when the envelope is wrong.

It also records the two open gaps honestly: **secrets are stored in cleartext** (webhook auth headers and Teams webhook URLs are both credentials), and **there is no digest batching**.

Nothing referenced the old file.

## Verification

```
mkdocs build --strict   passes, no warnings
relative links          all resolve (fragments stripped)
docs.json targets       all exist
site/                   correctly gitignored
pre-commit              clean
```

Both new pages render at `site/user/notifications/` and `site/user/ui/notifications/`.

## Not covered, deliberately

No video walkthrough — `alerting-shuffle.md` embeds one, and this feature has none yet. Worth adding later; the page is structured so an embed drops in near the top.

Closes #1011.