### PR TITLE
feat(notifications): emit AI notifications from write-back, add review trigger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,11 @@ PORTAINER_ENDPOINT_ID=2
 TALON_URL=http://127.1.1.1:3100
 TALON_API_KEY=REPLACE_ME
 
+# CoPilot's own public URL, used to build deep links in notifications
+# ("Open in CoPilot"). Optional — unset simply means notifications carry no
+# link. No trailing slash.
+COPILOT_URL=https://copilot.example.com
+
 # RESEND : transactional email for notification routes (https://resend.com)
 # Deployment-wide, like SHUFFLER_API_KEY — the per-customer differentiator is the
 # to/from addresses on each notification route. Free tier is 1,000 emails/month

--- a/backend/app/ai_analyst/services/ai_analyst.py
+++ b/backend/app/ai_analyst/services/ai_analyst.py
@@ -46,6 +46,9 @@ from app.db.universal_models import AiAnalystPalaceLesson
 from app.db.universal_models import AiAnalystReport
 from app.db.universal_models import AiAnalystReview
 from app.incidents.models import Alert
+from app.notifications.services.emit import emit
+from app.notifications.services.event_builders import ai_report_reviewed_event
+from app.notifications.services.event_builders import investigation_complete_event
 
 
 def _job_to_response(job: AiAnalystJob) -> JobResponse:
@@ -261,6 +264,21 @@ async def submit_report(request: SubmitReportRequest, session: AsyncSession) -> 
     await session.refresh(report)
 
     logger.info(f"AI analyst report {report.id} created for job {request.job_id}")
+
+    # Notification routes (#1007). Emitted here rather than relying solely on
+    # Talon's POST /notifications/dispatch, which is single-attempt: a network
+    # blip or a CoPilot restart loses the notification even though the report is
+    # already durably stored. Both paths build the same dedupe key, so whichever
+    # arrives first wins and the other is a no-op.
+    emit(
+        investigation_complete_event(
+            alert_id=report.alert_id,
+            customer_code=report.customer_code,
+            severity=report.severity_assessment,
+            summary=report.summary or "An AI investigation completed for this alert.",
+        ),
+    )
+
     return SubmitReportResponse(success=True, message="Report submitted", report=_report_to_response(report))
 
 
@@ -603,6 +621,22 @@ async def submit_review(
 
     action = "updated" if is_edit else "created"
     logger.info(f"Review {review.id} {action} for report {report_id}")
+
+    # Notification routes (#1007). Creation only — an analyst revising their own
+    # review is not a new sign-off. Lets an operator run an internal route on
+    # report submission and a customer-facing route only after review.
+    if not is_edit:
+        emit(
+            ai_report_reviewed_event(
+                alert_id=report.alert_id,
+                report_id=report_id,
+                customer_code=report.customer_code,
+                severity=report.severity_assessment,
+                summary=report.summary or "An analyst reviewed the AI investigation for this alert.",
+                reviewer=str(reviewer_user_id),
+                verdict=request.overall_verdict.value if request.overall_verdict else None,
+            ),
+        )
     return SubmitReviewResponse(
         success=True,
         message=f"Review {action}",

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -43,6 +43,7 @@ class NotificationTrigger(str, Enum):
     """
 
     INVESTIGATION_COMPLETE = "investigation_complete"
+    AI_REPORT_REVIEWED = "ai_report_reviewed"
 
     # Fired by CoPilot itself rather than pushed in by Talon.
     ALERT_CREATED = "alert_created"
@@ -157,6 +158,7 @@ INTERNAL_TRIGGERS: frozenset = frozenset(
 AI_SOURCED_TRIGGERS: frozenset = frozenset(
     {
         "investigation_complete",
+        "ai_report_reviewed",
         "severity_critical_or_high",
     },
 )

--- a/backend/app/notifications/services/event_builders.py
+++ b/backend/app/notifications/services/event_builders.py
@@ -15,6 +15,7 @@ governed by the route's trigger filter rather than accidentally suppressed.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 from typing import Optional
 
@@ -45,6 +46,85 @@ def _coerce_severity(value: Optional[str]) -> NotificationSeverity:
         return NotificationSeverity.MEDIUM
 
 
+def _copilot_link(path: str) -> Optional[str]:
+    """Build a deep link back into CoPilot, when the base URL is configured.
+
+    CoPilot has never known its own public URL — Talon supplied `report_url` on
+    the dispatches it pushed. Now that CoPilot emits `investigation_complete`
+    itself (and wins the dedupe, since write-back happens first), the link has to
+    come from somewhere.
+
+    `COPILOT_URL` is optional: unset means no link, which is the same state as a
+    Talon push that omitted one. Set it and every notification gains a working
+    link, including triggers Talon never knew about.
+    """
+    base = (os.getenv("COPILOT_URL") or "").strip().rstrip("/")
+    return f"{base}/{path.lstrip('/')}" if base else None
+
+
+def investigation_complete_event(
+    *,
+    alert_id: int,
+    customer_code: Optional[str],
+    severity: Optional[str],
+    summary: str,
+    alert_name: Optional[str] = None,
+) -> NotificationEvent:
+    """An AI investigation finished and its report was written back.
+
+    The dedupe key is identical to the one `event_from_dispatch_request` builds,
+    which is what makes CoPilot's own emit and Talon's push converge on a single
+    notification rather than two.
+    """
+    return NotificationEvent(
+        customer_code=customer_code,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity=_coerce_severity(severity),
+        subject=alert_name or f"Alert #{alert_id}",
+        summary=summary,
+        entity_type=EntityType.ALERT,
+        entity_id=alert_id,
+        dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.INVESTIGATION_COMPLETE.value}",
+        link_url=_copilot_link(f"/alerts/{alert_id}"),
+        context={"alert_name": alert_name},
+    )
+
+
+def ai_report_reviewed_event(
+    *,
+    alert_id: int,
+    report_id: int,
+    customer_code: Optional[str],
+    severity: Optional[str],
+    summary: str,
+    reviewer: Optional[str] = None,
+    verdict: Optional[str] = None,
+) -> NotificationEvent:
+    """An analyst signed off on an AI report.
+
+    Exists as a separate trigger rather than a flag on the route so an operator
+    can run an internal route on submission AND a customer-facing route only
+    after review — two different audiences at two different moments, which a
+    boolean could not express.
+
+    Keyed on the alert, not the report: "this alert's findings have been
+    reviewed" happens once. A second reviewer, or a revision, does not re-notify.
+    """
+    return NotificationEvent(
+        customer_code=customer_code,
+        trigger=NotificationTrigger.AI_REPORT_REVIEWED,
+        severity=_coerce_severity(severity),
+        subject=f"Reviewed: alert #{alert_id}",
+        summary=summary,
+        entity_type=EntityType.ALERT,
+        entity_id=alert_id,
+        dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.AI_REPORT_REVIEWED.value}",
+        link_url=_copilot_link(f"/alerts/{alert_id}"),
+        actor_username=reviewer,
+        context={"report_id": report_id, "reviewer": reviewer, "verdict": verdict},
+    )
+
+
 def alert_created_event(
     *,
     alert_id: int,
@@ -71,7 +151,7 @@ def alert_created_event(
         entity_type=EntityType.ALERT,
         entity_id=alert_id,
         dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.ALERT_CREATED.value}",
-        link_url=link_url,
+        link_url=link_url or _copilot_link(f"/alerts/{alert_id}"),
         context={"alert_name": title, "rule_level": rule_level, "asset_name": asset_name},
     )
 

--- a/backend/tests/test_notification_ai_emit_paths.py
+++ b/backend/tests/test_notification_ai_emit_paths.py
@@ -1,0 +1,205 @@
+"""AI-sourced notification emission from CoPilot itself.
+
+Two changes, both about the AI analyst path:
+
+**Write-back emit.** Talon's `POST /notifications/dispatch` is single-attempt —
+a network blip or a CoPilot restart loses the notification even though the
+report is already durably stored in `ai_analyst_report`. CoPilot now emits at
+write-back too. Both paths must converge on ONE notification, which they do by
+building the same dedupe key; the log's idempotency does the rest.
+
+**`ai_report_reviewed`.** A separate trigger rather than a flag on the route, so
+an operator can run an internal route on submission AND a customer-facing route
+only after an analyst signs off — two audiences at two moments, which a boolean
+can't express.
+
+Unit tests — no DB, no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_ai_emit_paths.py
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.notifications.schema.events import event_from_dispatch_request  # noqa: E402
+from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import INTERNAL_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import DispatchRequest  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.event_builders import (  # noqa: E402
+    ai_report_reviewed_event,
+)
+from app.notifications.services.event_builders import alert_created_event  # noqa: E402
+from app.notifications.services.event_builders import (  # noqa: E402
+    investigation_complete_event,
+)
+
+CUSTOMER = "TENANT_A"
+
+
+def _talon_push(alert_id=42, alert_name="Mimikatz signature", report_url="https://talon.invalid/42"):
+    """The event Talon's dispatch POST produces."""
+    return event_from_dispatch_request(
+        DispatchRequest(
+            customer_code=CUSTOMER,
+            alert_id=alert_id,
+            trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+            severity_assessment=NotificationSeverity.CRITICAL,
+            summary="Credential dumping observed.",
+            report_url=report_url,
+            alert_name=alert_name,
+        ),
+    )
+
+
+def _copilot_writeback(alert_id=42, alert_name="Mimikatz signature"):
+    """The event CoPilot's own write-back produces."""
+    return investigation_complete_event(
+        alert_id=alert_id,
+        customer_code=CUSTOMER,
+        severity="Critical",
+        summary="Credential dumping observed.",
+        alert_name=alert_name,
+    )
+
+
+# ── convergence: the reason this can't double-notify ──────────────────────
+
+
+def test_both_paths_produce_the_same_dedupe_key():
+    """The whole safety property. If these ever diverged, every investigation
+    would notify twice — once from Talon's push and once from write-back."""
+    assert _copilot_writeback().dedupe_key == _talon_push().dedupe_key
+
+
+def test_the_shared_key_is_the_one_the_migration_backfilled():
+    """#1019 backfilled 'alert:{id}:{trigger}' for pre-existing rows. A
+    different key here would make every historical dispatch look new."""
+    assert _copilot_writeback().dedupe_key == "alert:42:investigation_complete"
+
+
+def test_different_alerts_still_key_apart():
+    assert _copilot_writeback(alert_id=1).dedupe_key != _copilot_writeback(alert_id=2).dedupe_key
+
+
+def test_both_paths_agree_on_trigger_and_entity():
+    ours, theirs = _copilot_writeback(), _talon_push()
+    assert ours.trigger == theirs.trigger
+    assert (ours.entity_type, ours.entity_id) == (theirs.entity_type, theirs.entity_id)
+    assert ours.customer_code == theirs.customer_code
+
+
+# ── the deep link, which write-back had to solve ──────────────────────────
+
+
+def test_no_link_when_the_base_url_is_unset():
+    """Unset COPILOT_URL means no link — the same state as a Talon push that
+    omitted one. Deliberately not an error."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("COPILOT_URL", None)
+        assert _copilot_writeback().link_url is None
+
+
+def test_link_is_built_when_the_base_url_is_set():
+    """Write-back wins the dedupe over Talon's push, so without this the link
+    Talon used to supply would silently disappear."""
+    with patch.dict(os.environ, {"COPILOT_URL": "https://copilot.example.com"}):
+        assert _copilot_writeback().link_url == "https://copilot.example.com/alerts/42"
+
+
+def test_a_trailing_slash_does_not_double_up():
+    with patch.dict(os.environ, {"COPILOT_URL": "https://copilot.example.com/"}):
+        assert _copilot_writeback().link_url == "https://copilot.example.com/alerts/42"
+
+
+def test_alert_created_gains_a_link_too():
+    """It never had one — Talon only ever supplied report_url for
+    investigations."""
+    with patch.dict(os.environ, {"COPILOT_URL": "https://copilot.example.com"}):
+        event = alert_created_event(alert_id=7, customer_code=CUSTOMER, alert_title="New alert")
+        assert event.link_url == "https://copilot.example.com/alerts/7"
+
+
+def test_an_explicit_link_is_not_overridden():
+    with patch.dict(os.environ, {"COPILOT_URL": "https://copilot.example.com"}):
+        event = alert_created_event(
+            alert_id=7,
+            customer_code=CUSTOMER,
+            alert_title="New alert",
+            link_url="https://explicit.invalid/7",
+        )
+        assert event.link_url == "https://explicit.invalid/7"
+
+
+# ── ai_report_reviewed ────────────────────────────────────────────────────
+
+
+def test_review_is_a_distinct_trigger_from_submission():
+    """The point of it being a trigger and not a route flag: an operator can
+    have both, firing at different moments for different audiences."""
+    assert (
+        ai_report_reviewed_event(
+            alert_id=42,
+            report_id=1,
+            customer_code=CUSTOMER,
+            severity="High",
+            summary="s",
+        ).dedupe_key
+        != _copilot_writeback().dedupe_key
+    )
+
+
+def test_review_is_keyed_on_the_alert_not_the_report():
+    """'This alert's findings have been reviewed' happens once. A second
+    reviewer must not re-notify the customer."""
+    first = ai_report_reviewed_event(alert_id=42, report_id=1, customer_code=CUSTOMER, severity="High", summary="s")
+    second = ai_report_reviewed_event(alert_id=42, report_id=2, customer_code=CUSTOMER, severity="High", summary="s")
+    assert first.dedupe_key == second.dedupe_key
+
+
+def test_review_carries_the_reviewer_and_verdict_for_templates():
+    event = ai_report_reviewed_event(
+        alert_id=42,
+        report_id=1,
+        customer_code=CUSTOMER,
+        severity="High",
+        summary="s",
+        reviewer="analyst_one",
+        verdict="accurate",
+    )
+    assert event.actor_username == "analyst_one"
+    assert event.context["verdict"] == "accurate"
+    assert event.context["report_id"] == 1
+
+
+# ── scope and gating ──────────────────────────────────────────────────────
+
+
+def test_review_is_ai_sourced_so_the_opt_out_gate_applies():
+    """It carries AI-written findings, so a customer who opted out of AI
+    reports must not receive it."""
+    assert NotificationTrigger.AI_REPORT_REVIEWED.value in AI_SOURCED_TRIGGERS
+
+
+def test_review_is_customer_facing_not_internal():
+    """Sign-off is the moment findings become publishable — the opposite of an
+    assignment, which is internal."""
+    assert NotificationTrigger.AI_REPORT_REVIEWED.value not in INTERNAL_TRIGGERS
+
+
+@pytest.mark.parametrize("severity,expected", [("Critical", "Critical"), (None, "Medium"), ("Nonsense", "Medium")])
+def test_severity_falls_back_rather_than_raising(severity, expected):
+    """A report with no assessed severity must not be filtered out of every
+    route gating above Informational."""
+    event = investigation_complete_event(
+        alert_id=1,
+        customer_code=CUSTOMER,
+        severity=severity,
+        summary="s",
+    )
+    assert event.severity.value == expected


### PR DESCRIPTION
Closes #1007. **No migration.**

The third part of that issue — the AI-report opt-out gate (L1) — shipped separately as #1014, because it was an existing bug rather than new work. These are the two that remained.

## Write-back emit

Talon's `POST /notifications/dispatch` is **single-attempt**. A network blip or a CoPilot restart loses the notification even though the report is already durably stored in `ai_analyst_report`.

`submit_report` now emits `investigation_complete` itself. Talon's push stays and is unchanged — it's an external contract.

**Both paths build the identical dedupe key**, so whichever arrives first wins and the other is a no-op against the log's idempotency. That convergence is the first assertion in the test file: if the two keys ever diverged, every investigation would notify **twice**.

There's also a test pinning the key to `alert:{id}:{trigger}` — the value #1019's migration backfilled. A different key here would make every historical dispatch look new.

## `ai_report_reviewed`

A distinct trigger rather than a flag on the route, so an operator can run an internal route on **submission** and a customer-facing route only after **sign-off** — two audiences at two moments, which a boolean can't express.

Three decisions in it:

- **Creation only.** `submit_review` already tracked `is_edit`, so an analyst revising their own review doesn't re-notify.
- **Keyed on the alert, not the report.** "This alert's findings have been reviewed" happens once; a second reviewer must not re-notify the customer.
- **AI-sourced and customer-scoped.** The opt-out gate applies, and sign-off is precisely the moment findings become publishable — the opposite of an assignment, which is internal.

## COPILOT_URL — not in the issue, but write-back forced it

CoPilot has never known its own public URL. Talon supplied `report_url` on the dispatches it pushed.

Now that write-back **wins the dedupe**, that link would have silently disappeared. That's a regression, not a gap — worth catching before it shipped rather than after someone noticed their notifications lost their links.

`COPILOT_URL` is **optional**:

- **Unset** → no link. Exactly today's state when Talon omits one. Existing deployments lose nothing.
- **Set** → every notification gains a working link, including `alert_created`, which never had one because Talon only ever supplied `report_url` for investigations.

Trailing slashes are handled, and an explicitly-passed link is never overridden.

## Testing

```
17 new     tests/test_notification_ai_emit_paths.py
277 passed backend tests/
pre-commit clean
```

Covers: both paths producing the same dedupe key, that key matching the migration backfill, different alerts keying apart, both paths agreeing on trigger/entity/customer; link absent when unset, built when set, trailing-slash handling, explicit link precedence; the review trigger being distinct from submission, keyed on the alert, carrying reviewer and verdict for templates, being AI-gated and customer-scoped; and severity falling back to Medium rather than raising, so a report with no assessed severity isn't filtered out of every route gating above Informational.

## Worth a manual check

The convergence property is the one thing unit tests can only prove structurally. On a live deployment: let an investigation complete, then confirm exactly one dispatch-log row exists for that alert — not two.
