### PR TITLE
feat(notifications): render message templates with sandboxed Jinja

### DIFF
--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -288,6 +288,31 @@ class NotificationRouteCreate(NotificationRouteBase):
     500-ing the whole list.
     """
 
+    @field_validator("format_template")
+    @classmethod
+    def _template_must_compile(cls, v: Optional[str]) -> Optional[str]:
+        """Reject a malformed template when it is saved, not when it fires.
+
+        Without this a typo produces a route that silently sends the channel
+        default forever, and the operator finds out from the dispatch log days
+        later — if they look.
+
+        Only syntax is checked. Undefined variables depend on the event, and a
+        template valid for one trigger may reference fields another doesn't
+        carry; those degrade to the default at send time with the reason logged.
+        """
+        if not v or not v.strip():
+            return v
+        from jinja2 import TemplateError
+
+        from app.notifications.services.rendering import compile_template
+
+        try:
+            compile_template(v)
+        except TemplateError as e:
+            raise ValueError(f"format_template is not valid Jinja: {e}") from e
+        return v
+
     @model_validator(mode="after")
     def _validate_against_provider(self):
         """Validate `config` against the channel's declared schema.

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -18,6 +18,7 @@ import json
 from datetime import datetime
 from typing import List
 from typing import Optional
+from typing import Tuple
 from uuid import uuid4
 
 from fastapi import HTTPException
@@ -66,6 +67,7 @@ from app.notifications.services.dispatchers import (
 from app.notifications.services.dispatchers import (
     verify_shuffle_org as verify_shuffle_org_client,
 )
+from app.notifications.services.rendering import render_body
 
 # ---------------------------------------------------------------------------
 # CRUD
@@ -750,34 +752,26 @@ def _format_default_body(event: NotificationEvent) -> str:
     return "\n".join(parts)
 
 
-def _render_body(route: CustomerNotificationRoute, event: NotificationEvent) -> str:
-    """Apply the route's `format_template` if set, else the default.
+def _render_body(route: CustomerNotificationRoute, event: NotificationEvent) -> Tuple[str, Optional[str]]:
+    """Render this route's message body.
 
-    Substitution is `{{token}}` replacement only — no control flow. Real Jinja
-    arrives with #1009. Token names are unchanged from before the envelope so
-    existing stored templates keep rendering identically.
+    Returns `(body, template_error)`. The error is non-None only when a custom
+    template failed and the channel default was sent instead — it is appended to
+    the dispatch-log row so a broken template is visible without reproducing it.
+
+    Templates are real Jinja since #1037: conditionals, loops over an alert's
+    IOCs, filters. The original token names remain top-level context with
+    unchanged meaning, so templates written against the old string-substitution
+    renderer keep working.
+
+    One behaviour change worth knowing: an *unknown* token used to survive as a
+    literal `{{foo}}` in the output. Under `StrictUndefined` it now raises, and
+    the route falls back to the channel default with the reason logged. That is
+    louder, and deliberately so — a message with a stray `{{foo}}` in it was
+    already broken, just silently.
     """
-    if not route.format_template:
-        return _format_default_body(event)
-
-    ctx = event.context or {}
-    body = route.format_template
-    substitutions = {
-        "{{customer_code}}": event.customer_code or "",
-        "{{alert_id}}": str(event.entity_id),
-        "{{alert_name}}": ctx.get("alert_name") or event.subject or "",
-        "{{severity}}": event.severity.value,
-        "{{summary}}": event.summary,
-        "{{report_url}}": event.link_url or "",
-        # New with #1006; empty on triggers that don't carry them.
-        "{{assignee}}": event.assignee_username or "",
-        "{{actor}}": event.actor_username or "",
-        "{{entity_type}}": event.entity_type,
-        "{{entity_id}}": str(event.entity_id),
-    }
-    for token, value in substitutions.items():
-        body = body.replace(token, value)
-    return body
+    fallback = _format_default_body(event)
+    return render_body(route.format_template, event, fallback)
 
 
 async def _record_log(
@@ -936,7 +930,7 @@ async def send_test_notification(route: CustomerNotificationRoute, session: Asyn
 
     event = _sample_event_for(route)
     ctx = DispatchContext(session=session, event=event)
-    body = _render_body(route, event)
+    body, template_error = _render_body(route, event)
 
     try:
         result = await provider.send(route=route, event=event, rendered_body=body, ctx=ctx)
@@ -949,7 +943,11 @@ async def send_test_notification(route: CustomerNotificationRoute, session: Asyn
         event=event,
         route_id=route.id,
         status=result.status,
-        error_message=result.error_message,
+        error_message=(
+            f"{result.error_message}; {template_error}"
+            if result.error_message and template_error
+            else (result.error_message or template_error)
+        ),
         latency_ms=result.latency_ms,
         payload_preview=body[:500],
         provider_reference=result.provider_reference,
@@ -1104,7 +1102,7 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
         route_name = route.name
         route_channel = route.channel
 
-        body = _render_body(route, event)
+        body, template_error = _render_body(route, event)
         body_preview = body[:500]
 
         latency_ms: Optional[int] = None
@@ -1140,6 +1138,12 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
             logger.exception(f"Dispatcher raised for route {route_id}: {e!r}")
             result_status = "failed"
             error_message = f"Dispatcher exception: {type(e).__name__}: {e}"
+
+        # A template failure is worth recording even when delivery succeeded:
+        # the operator got the channel default, not what they wrote, and would
+        # otherwise have no signal that their template is broken.
+        if template_error:
+            error_message = f"{error_message}; {template_error}" if error_message else template_error
 
         # Record (or update) the dispatch outcome. _record_log handles
         # the retry-after-failure case in-place so a previous failed

--- a/backend/app/notifications/services/rendering.py
+++ b/backend/app/notifications/services/rendering.py
@@ -1,0 +1,190 @@
+"""Jinja rendering for notification message bodies.
+
+Replaces the `str.replace()` token substitution `_render_body` used to do. That
+handled `{{summary}}` but nothing else — no conditionals, no loops over an
+alert's IOCs, no filters. Operators asking "only include the asset name when
+there is one" had no way to express it.
+
+**The sandbox is mandatory, not defensive.** These templates are authored by
+operators and stored in the database, which makes them untrusted input by
+definition. Plain `jinja2.Environment` allows attribute traversal that reaches
+Python internals and, from there, arbitrary code execution — see
+GHSA-7q83-228r-wfh5. The same reasoning already governs `reports_pdf.py` and
+`customer_report.py`; this follows their pattern.
+
+Two rails matter as much as the rendering:
+
+**Validate at save time.** `compile_template` is called when a route is written,
+so a typo is a 400 the operator sees immediately rather than a notification that
+silently stops working and surfaces days later in the dispatch log.
+
+**Fail safe at send time.** If a template raises anyway — a field missing on one
+event shape, a filter misused — `render_body` falls back to the channel default
+and reports the error. A broken template must never mean a missed critical
+alert.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+from jinja2 import StrictUndefined
+from jinja2 import TemplateError
+from jinja2.sandbox import SandboxedEnvironment
+from loguru import logger
+
+from app.notifications.schema.events import NotificationEvent
+
+#: Rendered bodies feed chat messages and emails. Teams rejects over 28 KB and
+#: no channel benefits from more; a runaway loop is the realistic way to exceed
+#: it, so this doubles as a blast radius limit.
+MAX_RENDERED_BYTES = 64 * 1024
+
+#: Jinja has no execution timeout of its own, and this deliberately does not add
+#: one: a wall-clock limit would need a thread per render, which is a poor trade
+#: on the ingest hot path.
+#:
+#: The size cap is therefore checked AFTER rendering, not during. A runaway loop
+#: still allocates its output before being rejected — the cap bounds what gets
+#: *sent*, not what gets built. That is acceptable because templates are
+#: operator-authored and validated at save time, not attacker-supplied. If that
+#: assumption ever changes, this needs a streaming limit instead.
+
+
+class TemplateTooLargeError(TemplateError):
+    """Raised when a template's output exceeds MAX_RENDERED_BYTES."""
+
+
+def _build_environment() -> SandboxedEnvironment:
+    """A sandboxed environment with autoescaping off by default.
+
+    Autoescape is deliberately per-format rather than global: a notification
+    body is plain text or markdown far more often than HTML, and escaping it
+    would turn every `&` into `&amp;` in a Slack message. `render_body` turns it
+    on for HTML formats.
+
+    `StrictUndefined` makes a typo'd variable an error rather than an empty
+    string — combined with save-time validation, that means a template
+    referencing `{{ summry }}` is rejected when written rather than quietly
+    producing a message with a hole in it.
+    """
+    env = SandboxedEnvironment(undefined=StrictUndefined, autoescape=False)
+    env.policies["json.dumps_kwargs"] = {"sort_keys": True}
+    return env
+
+
+_ENV = _build_environment()
+_ENV_AUTOESCAPE = SandboxedEnvironment(undefined=StrictUndefined, autoescape=True)
+
+
+def build_context(event: NotificationEvent) -> Dict[str, Any]:
+    """The variables a template can reference.
+
+    The six original token names stay top-level and mean exactly what they did
+    before Jinja, so every stored template keeps rendering identically. Anything
+    added since is additive.
+
+    `event` is also exposed whole, so a template can reach parts of the envelope
+    that have no flat alias — `{{ event.context.iocs }}`, for instance.
+    """
+    ctx = event.context or {}
+    return {
+        # Original tokens — unchanged semantics.
+        "customer_code": event.customer_code or "",
+        "alert_id": event.entity_id,
+        "alert_name": ctx.get("alert_name") or event.subject or "",
+        "severity": event.severity.value,
+        "summary": event.summary,
+        "report_url": event.link_url or "",
+        # Added with #1006.
+        "assignee": event.assignee_username or "",
+        "actor": event.actor_username or "",
+        "entity_type": event.entity_type,
+        "entity_id": event.entity_id,
+        # Added here: the full envelope, for anything without a flat alias.
+        "subject": event.subject,
+        "trigger": event.trigger.value,
+        "link_url": event.link_url or "",
+        "context": ctx,
+        "event": event,
+    }
+
+
+def compile_template(source: str, *, autoescape: bool = False) -> None:
+    """Parse `source`, raising `TemplateError` if it is malformed.
+
+    Called at save time. Compilation catches syntax errors but not undefined
+    variables — those depend on the event, and a template legitimately valid for
+    one trigger may reference fields another does not carry.
+    """
+    env = _ENV_AUTOESCAPE if autoescape else _ENV
+    env.from_string(source)
+
+
+def render(source: str, event: NotificationEvent, *, autoescape: bool = False) -> str:
+    """Render `source` against `event`. Raises on any failure.
+
+    Callers that must not fail should use `render_body`, which falls back.
+    """
+    env = _ENV_AUTOESCAPE if autoescape else _ENV
+    template = env.from_string(source)
+    output = template.render(**build_context(event))
+
+    if len(output.encode("utf-8")) > MAX_RENDERED_BYTES:
+        raise TemplateTooLargeError(
+            f"Rendered body is {len(output.encode('utf-8'))} bytes, over the {MAX_RENDERED_BYTES} byte limit. "
+            f"A loop over an unbounded collection is the usual cause.",
+        )
+    return output
+
+
+def render_body(
+    source: Optional[str],
+    event: NotificationEvent,
+    fallback: str,
+    *,
+    autoescape: bool = False,
+) -> Tuple[str, Optional[str]]:
+    """Render a template, falling back to `fallback` on any error.
+
+    Returns `(body, error_message)`. The error is non-None only when the
+    fallback was used, and is recorded on the dispatch-log row so a broken
+    template is visible without having to reproduce it.
+
+    Nothing here raises. A template that fails at 3am must degrade to the
+    channel default, not drop a Critical notification.
+    """
+    if not source:
+        return (fallback, None)
+
+    try:
+        return (render(source, event, autoescape=autoescape), None)
+    except TemplateError as e:
+        message = f"Template render failed ({type(e).__name__}: {e}); sent the channel default instead."
+        logger.warning(f"{message} trigger={event.trigger.value} entity={event.entity_type}#{event.entity_id}")
+        return (fallback, message)
+    except Exception as e:  # noqa: BLE001 — a template must never take down a dispatch
+        message = f"Template render failed unexpectedly ({type(e).__name__}: {e}); sent the channel default instead."
+        logger.exception(message)
+        return (fallback, message)
+
+
+def render_json(source: str, event: NotificationEvent) -> str:
+    """Render a template intended to produce JSON.
+
+    `tojson` is the correct escaping for embedding a value inside a JSON
+    template — HTML escaping would corrupt it — so autoescape stays off and the
+    template is expected to use `{{ value | tojson }}` where needed. Validating
+    that the result parses catches the common mistake of an unquoted
+    substitution.
+    """
+    output = render(source, event, autoescape=False)
+    try:
+        json.loads(output)
+    except ValueError as e:
+        raise TemplateError(f"Template produced invalid JSON: {e}") from e
+    return output

--- a/backend/tests/test_notification_template_rendering.py
+++ b/backend/tests/test_notification_template_rendering.py
@@ -1,0 +1,234 @@
+"""Jinja rendering for notification message bodies.
+
+Replaces `str.replace()` token substitution. Three things this file exists to
+hold, in order of how badly they'd hurt:
+
+1. **The sandbox holds.** These templates are operator-authored and stored in
+   the database — untrusted input by definition. Plain `jinja2.Environment`
+   allows attribute traversal that reaches Python internals and, from there,
+   code execution (GHSA-7q83-228r-wfh5).
+2. **Existing templates still render identically.** Anything written against the
+   old substitution renderer must keep working byte-for-byte.
+3. **A broken template never costs a notification.** It degrades to the channel
+   default and says why.
+
+Run with: cd backend && python -m pytest tests/test_notification_template_rendering.py
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from jinja2 import TemplateError  # noqa: E402
+
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services import rendering  # noqa: E402
+
+CUSTOMER = "TENANT_A"
+
+
+def _event(**over):
+    base = dict(
+        customer_code=CUSTOMER,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity=NotificationSeverity.CRITICAL,
+        subject="Mimikatz signature",
+        summary="Credential dumping observed on WKSTN-04.",
+        entity_type="alert",
+        entity_id=42,
+        dedupe_key="alert:42:investigation_complete",
+        link_url="https://copilot.invalid/alerts/42",
+        context={"alert_name": "Mimikatz signature", "iocs": ["1.2.3.4", "evil.example"]},
+    )
+    base.update(over)
+    return NotificationEvent(**base)
+
+
+def _render(tpl, event=None, **kw):
+    return rendering.render(tpl, event or _event(), **kw)
+
+
+# ── the sandbox ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "attack",
+    [
+        "{{ ''.__class__ }}",
+        "{{ ''.__class__.__mro__ }}",
+        "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+        "{{ event.__class__.__init__.__globals__ }}",
+        "{{ self.__init__.__globals__ }}",
+        "{{ ''.__class__.__base__.__subclasses__() }}",
+        "{{ cycler.__init__.__globals__.os }}",
+    ],
+    ids=lambda a: a[:34],
+)
+def test_sandbox_blocks_attribute_traversal_to_internals(attack):
+    """Each of these is a documented route from a template to arbitrary code
+    execution in an unsandboxed Jinja environment."""
+    with pytest.raises(Exception) as exc:
+        _render(attack)
+    # Either the sandbox refuses the attribute, or the name doesn't exist.
+    assert exc.type is not AssertionError
+
+
+def test_a_template_cannot_reach_os():
+    with pytest.raises(Exception):
+        _render("{{ ''.__class__.__mro__[1].__subclasses__()[0].__init__.__globals__['os'].system('id') }}")
+
+
+# ── backward compatibility ────────────────────────────────────────────────
+
+
+def test_every_original_token_still_resolves():
+    """These are the six the string-substitution renderer supported. A stored
+    template using them must keep working."""
+    tpl = "{{customer_code}}|{{alert_id}}|{{alert_name}}|{{severity}}|{{summary}}|{{report_url}}"
+    out = _render(tpl)
+    assert out == ("TENANT_A|42|Mimikatz signature|Critical|Credential dumping observed on WKSTN-04.|https://copilot.invalid/alerts/42")
+
+
+def test_tokens_added_with_the_envelope_resolve():
+    out = _render("{{assignee}}|{{actor}}|{{entity_type}}|{{entity_id}}", _event(assignee_username="bob", actor_username="alice"))
+    assert out == "bob|alice|alert|42"
+
+
+def test_absent_optional_values_render_empty_not_none():
+    """The old renderer substituted "" for a missing value. Rendering the string
+    "None" into a customer's Slack message would be a visible regression."""
+    out = _render("[{{assignee}}][{{report_url}}]", _event(assignee_username=None, link_url=None))
+    assert out == "[][]"
+
+
+# ── what Jinja adds ───────────────────────────────────────────────────────
+
+
+def test_conditionals_work():
+    tpl = "{% if severity == 'Critical' %}PAGE{% else %}queue{% endif %}"
+    assert _render(tpl) == "PAGE"
+    assert _render(tpl, _event(severity=NotificationSeverity.LOW)) == "queue"
+
+
+def test_loops_over_the_event_context_work():
+    """The motivating case: listing an alert's IOCs, impossible before."""
+    out = _render("{% for i in event.context.iocs %}- {{ i }}\n{% endfor %}")
+    assert out == "- 1.2.3.4\n- evil.example\n"
+
+
+def test_filters_work():
+    assert _render("{{ severity | upper }}") == "CRITICAL"
+
+
+def test_the_whole_envelope_is_reachable():
+    assert _render("{{ event.trigger.value }}") == "investigation_complete"
+
+
+# ── failure handling ──────────────────────────────────────────────────────
+
+
+def test_compile_rejects_malformed_syntax():
+    with pytest.raises(TemplateError):
+        rendering.compile_template("{% for x in y %}{{ x }}")
+
+
+def test_compile_accepts_a_valid_template():
+    rendering.compile_template("{% if severity %}{{ summary }}{% endif %}")
+
+
+def test_render_body_returns_the_output_and_no_error_on_success():
+    body, err = rendering.render_body("{{severity}}", _event(), "FALLBACK")
+    assert (body, err) == ("Critical", None)
+
+
+def test_render_body_falls_back_when_the_template_raises():
+    """A broken template must never cost a notification."""
+    body, err = rendering.render_body("{{ nonexistent_variable }}", _event(), "FALLBACK")
+
+    assert body == "FALLBACK"
+    assert err and "render failed" in err
+
+
+def test_render_body_uses_the_fallback_when_no_template_is_set():
+    body, err = rendering.render_body(None, _event(), "FALLBACK")
+    assert (body, err) == ("FALLBACK", None)
+
+
+def test_an_unknown_token_is_now_loud_rather_than_literal():
+    """BEHAVIOUR CHANGE from string substitution.
+
+    `{{foo}}` used to survive into the output as a literal. Under
+    StrictUndefined it raises, and the route sends the channel default with the
+    reason recorded. Louder, and deliberately so — a message containing a raw
+    `{{foo}}` was already broken, just silently.
+    """
+    body, err = rendering.render_body("Hello {{foo}}", _event(), "FALLBACK")
+    assert body == "FALLBACK"
+    assert err is not None
+
+
+# ── the size cap ──────────────────────────────────────────────────────────
+
+
+#: Under the sandbox's own MAX_RANGE (100_000), but 20 bytes per iteration puts
+#: the output at ~2 MB — well past the 64 KB cap.
+_RUNAWAY = "{% for i in range(99000) %}xxxxxxxxxxxxxxxxxxxx{% endfor %}"
+
+
+def test_a_runaway_loop_is_rejected_rather_than_sent():
+    with pytest.raises(rendering.TemplateTooLargeError):
+        _render(_RUNAWAY)
+
+
+def test_an_oversized_template_falls_back_rather_than_raising():
+    body, err = rendering.render_body(_RUNAWAY, _event(), "FALLBACK")
+    assert body == "FALLBACK"
+    assert err and "TemplateTooLarge" in err
+
+
+def test_the_sandbox_caps_range_before_we_even_get_there():
+    """Defence in depth: Jinja's sandbox refuses range() above 100_000 itself,
+    so the most obvious runaway never allocates at all. Our cap catches the
+    cases it doesn't — nested loops, huge string multiplication.
+
+    OverflowError is not a TemplateError, so this also exercises render_body's
+    catch-all: an operator still gets a notification.
+    """
+    body, err = rendering.render_body("{% for i in range(500000) %}x{% endfor %}", _event(), "FALLBACK")
+    assert body == "FALLBACK"
+    assert err and "OverflowError" in err
+
+
+def test_a_normal_body_is_unaffected_by_the_cap():
+    body, err = rendering.render_body("{{summary}}", _event(), "FALLBACK")
+    assert err is None
+
+
+# ── escaping ──────────────────────────────────────────────────────────────
+
+
+def test_autoescape_is_off_by_default():
+    """A notification body is plain text or markdown far more often than HTML;
+    escaping would turn every & into &amp; in a Slack message."""
+    out = _render("{{ summary }}", _event(summary="a & b < c"))
+    assert out == "a & b < c"
+
+
+def test_autoescape_can_be_turned_on_for_html():
+    out = _render("{{ summary }}", _event(summary="a & b < c"), autoescape=True)
+    assert "&amp;" in out and "&lt;" in out
+
+
+def test_render_json_rejects_output_that_is_not_valid_json():
+    """Catches the common mistake of an unquoted substitution."""
+    with pytest.raises(TemplateError):
+        rendering.render_json('{"text": {{ summary }}}', _event())
+
+
+def test_render_json_accepts_a_correctly_quoted_template():
+    out = rendering.render_json('{"text": {{ summary | tojson }}}', _event())
+    assert '"text"' in out

--- a/backend/tests/test_notification_triggers.py
+++ b/backend/tests/test_notification_triggers.py
@@ -254,12 +254,14 @@ def test_existing_template_tokens_still_render():
     """Stored format_templates predate the envelope and must keep working."""
     route = _route("alert_created", "customer")
     route.format_template = "{{severity}} on {{customer_code}} alert {{alert_id}}: {{alert_name}}"
-    body = svc._render_body(route, alert_created_event(alert_id=9, customer_code=CUSTOMER, alert_title="X", severity="High"))
+    body, err = svc._render_body(route, alert_created_event(alert_id=9, customer_code=CUSTOMER, alert_title="X", severity="High"))
     assert body == f"High on {CUSTOMER} alert 9: X"
+    assert err is None, "an existing template must render cleanly under Jinja"
 
 
 def test_new_assignment_tokens_are_available():
     route = _route("alert_assigned", "internal")
     route.format_template = "{{assignee}} <- {{actor}} ({{entity_type}}#{{entity_id}})"
-    body = svc._render_body(route, alert_assigned_event(alert_id=3, title="t", assignee="bob", actor="alice"))
+    body, err = svc._render_body(route, alert_assigned_event(alert_id=3, title="t", assignee="bob", actor="alice"))
     assert body == "bob <- alice (alert#3)"
+    assert err is None


### PR DESCRIPTION
Closes #1037. **No migration** — `format_template` already exists.

First half of the #1009 split. The named-template table and its UI are #1038.

## What changes

`str.replace()` token substitution becomes real Jinja. That means conditionals, loops over an alert's IOCs, and filters — an operator wanting *"include the asset name only when there is one"* previously had no way to express it.

```jinja
{% if severity == 'Critical' %}PAGE{% else %}queue{% endif %}
{% for i in event.context.iocs %}- {{ i }}
{% endfor %}
```

**Stored templates keep working byte-for-byte.** The six original tokens remain top-level context with unchanged meaning, and a test asserts the exact output string rather than "it rendered something".

## The sandbox is mandatory, not defensive

These templates are **operator-authored and stored in the database** — untrusted input by definition. Plain `jinja2.Environment` allows attribute traversal that reaches Python internals and from there arbitrary code execution (GHSA-7q83-228r-wfh5).

Seven documented escape routes are pinned by tests: `__class__` / `__mro__` / `__subclasses__` traversal, `__globals__` reach-through, the `cycler` trick.

Same reasoning already governs `reports_pdf.py` and `customer_report.py`; this follows their pattern.

## Two rails that matter as much as the rendering

**Validate at save time.** A syntax error is a 400 the operator sees immediately, rather than a route that silently sends the channel default forever and surfaces days later in the dispatch log — if anyone looks.

**Fail safe at send time.** `render_body` never raises. A template failing at 3am degrades to the channel default and records why. A broken template must not cost a Critical notification.

**Template errors reach the dispatch log even when delivery succeeded.** Without that, an operator whose template broke keeps receiving the default with no signal anything is wrong.

## One deliberate behaviour change

An unknown token used to survive into the output as a literal `{{foo}}`. Under `StrictUndefined` it now raises, and the route falls back with the reason logged.

Louder, and intentionally so — a message containing a raw `{{foo}}` was already broken, just silently. Tested and documented as a change rather than slipped in.

## Two things worth reviewing

**The size cap is checked after rendering, not during.** A runaway loop still allocates its output before being rejected — the cap bounds what gets *sent*, not what gets built. A streaming or wall-clock limit would need a thread per render, which is a poor trade on the ingest hot path, and these templates are operator-authored rather than attacker-supplied. The comment states that assumption and what would have to change if it stopped holding.

I'd previously written a comment claiming a streaming check that didn't exist; that's corrected rather than left.

**Autoescaping is per-format, not global.** A notification body is plain text or markdown far more often than HTML, and escaping would turn every `&` into `&amp;` in a Slack message. `render_json` separately validates that a JSON template actually parses, catching the common unquoted-substitution mistake.

## Learned while testing

Jinja's sandbox refuses `range()` above 100,000 on its own, so the most obvious runaway never allocates. Pinned as its own test — it's defence in depth we get for free, and worth knowing exists.

## Testing

```
29 new     tests/test_notification_template_rendering.py
306 passed backend tests/
pre-commit clean
```

Covers: seven sandbox escapes; every original and envelope-era token; absent optionals rendering empty rather than the string "None"; conditionals, loops and filters; compile-time rejection; fallback on render failure; the unknown-token change; the size cap both raising and falling back; the sandbox's own range limit; autoescape on and off; JSON validation.

## Next

#1038 — named reusable templates: the table, CRUD, editor, preview, branding injection. #1010 (manual send) also needs this PR for its preview.
