### PR TITLE
feat(incidents): store alert severity, resolve unknown at read time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,13 @@ PORTAINER_ENDPOINT_ID=2
 TALON_URL=http://127.1.1.1:3100
 TALON_API_KEY=REPLACE_ME
 
+# Severity applied to alerts whose source supplies none. Wazuh alerts map from
+# their rule level; Office 365, CrowdStrike, Carbon Black, Huntress and others
+# carry no equivalent, and would otherwise be invisible to any notification
+# route gating above the fallback.
+# One of: Informational | Low | Medium | High | Critical. Default: High.
+DEFAULT_ALERT_SEVERITY=High
+
 # CoPilot's own public URL, used to build deep links in notifications
 # ("Open in CoPilot"). Optional — unset simply means notifications carry no
 # link. No trailing slash.

--- a/backend/alembic/versions/c92e4a1f8b73_add_alert_severity.py
+++ b/backend/alembic/versions/c92e4a1f8b73_add_alert_severity.py
@@ -1,0 +1,61 @@
+"""add severity to incident_management_alert
+
+Revision ID: c92e4a1f8b73
+Revises: b3f5a91c72d4
+Create Date: 2026-08-02 14:50:00.000000
+
+Alerts had no stored severity. It was derived at ingest from the Wazuh rule
+level, used for the notification, and discarded — so anything after ingest
+(assignment notifications, manual send, filtering, sorting) was blind to it.
+
+See issue #1040.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c92e4a1f8b73"
+down_revision: Union[str, None] = "b3f5a91c72d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable with NO default and NO backfill, both deliberate.
+    #
+    # NULL means "the source did not tell us", which is a different fact from
+    # any particular severity — Wazuh alerts carry a rule level to map from,
+    # while Office 365, CrowdStrike, Carbon Black and the rest carry no
+    # equivalent. Resolution to the deployment default (DEFAULT_ALERT_SEVERITY)
+    # happens at read time in `severity_of`.
+    #
+    # Stamping a value here would freeze it: changing the setting later would
+    # then only affect alerts created afterwards, and "the source said High"
+    # would become indistinguishable from "we guessed High".
+    #
+    # Existing rows therefore stay NULL and immediately resolve to the default,
+    # which is why no backfill is needed. Recomputing from incident_management_
+    # alertcontext would only help Wazuh-shaped rows anyway, and would bake in
+    # exactly the guess this design avoids.
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("severity", sa.String(length=20), nullable=True),
+    )
+    # Filtering and sorting by severity is the point of storing it.
+    op.create_index("ix_incident_management_alert_severity", "incident_management_alert", ["severity"])
+
+
+def downgrade() -> None:
+    """Non-lossy in any way that matters.
+
+    The column only ever holds a value re-derivable from the source event, and
+    the pre-migration code did not read it. Dropping it returns to deriving
+    severity at ingest for notifications and having none thereafter.
+    """
+    op.drop_index("ix_incident_management_alert_severity", table_name="incident_management_alert")
+    op.drop_column("incident_management_alert", "severity")

--- a/backend/app/incidents/models.py
+++ b/backend/app/incidents/models.py
@@ -41,6 +41,20 @@ class Alert(SQLModel, table=True):
     customer_code: str = Field(max_length=50, nullable=False)
     time_closed: Optional[datetime] = Field(default=None)
     source: str = Field(max_length=50, nullable=False)
+
+    # How serious this alert is: Critical | High | Medium | Low | Informational.
+    #
+    # NULL means "the source did not tell us" — not "unimportant". Wazuh alerts
+    # carry a rule level we map from; Office 365, CrowdStrike, Carbon Black,
+    # Huntress and the rest carry no equivalent, so their alerts land here NULL.
+    #
+    # Deliberately resolved at READ time rather than stamped at ingest: see
+    # `severity_of()`. Storing the fallback would freeze it, so changing
+    # DEFAULT_ALERT_SEVERITY would only affect alerts created afterwards.
+    #
+    # Indexed because filtering and sorting by it is the point of storing it.
+    severity: Optional[str] = Field(default=None, max_length=20, nullable=True, index=True)
+
     assigned_to: Optional[str] = Field(max_length=50, nullable=True)
     escalated: bool = Field(default=False, nullable=False)
 

--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -106,6 +106,7 @@ from app.incidents.schema.db_operations import UpdateAlertStatus
 from app.incidents.schema.db_operations import UpdateCaseStatus
 from app.incidents.schema.incident_alert import CreatedAlertPayload
 from app.incidents.schema.incident_alert import CreatedCaseNotificationPayload
+from app.incidents.services.alert_severity import severity_of
 
 # from app.incidents.services.db_operations import list_alerts
 # from app.incidents.services.db_operations import alerts_open_multiple_filters
@@ -782,6 +783,11 @@ async def update_assigned_to_endpoint(
     previous_assignee = existing_alert.assigned_to if existing_alert else None
     alert_title = existing_alert.alert_name if existing_alert else None
     alert_customer = existing_alert.customer_code if existing_alert else None
+    # Being handed a Critical alert is a different event from being handed an
+    # Informational one; a route gating at High should see the first. Resolved
+    # rather than read raw, so an alert whose source gave no severity uses the
+    # deployment default instead of ranking below everything.
+    alert_severity = severity_of(existing_alert) if existing_alert else None
 
     updated = await update_alert_assigned_to(assigned_to.alert_id, assigned_to.assigned_to, db)
 
@@ -793,6 +799,7 @@ async def update_assigned_to_endpoint(
                 assignee=assigned_to.assigned_to,
                 actor=current_user.username,
                 customer_code=alert_customer,
+                severity=alert_severity,
             ),
         )
 

--- a/backend/app/incidents/services/alert_severity.py
+++ b/backend/app/incidents/services/alert_severity.py
@@ -1,0 +1,111 @@
+"""Resolving an alert's severity.
+
+`Alert.severity` is nullable, and NULL means **"the source did not tell us"** —
+not "unimportant". Wazuh alerts carry a rule level we map from; Office 365,
+CrowdStrike, Carbon Black, Huntress and the rest carry no equivalent, so their
+alerts land NULL.
+
+Before this existed, that gap was invisible: severity was derived at ingest, used
+for the notification, and discarded. An alert from a non-Wazuh source resolved to
+`Medium` inside the notification builder, which meant a route gating at *High and
+above* silently dropped every one of them.
+
+**Resolution happens here, at read time, not at ingest.** Stamping the fallback
+onto the row would freeze it: changing `DEFAULT_ALERT_SEVERITY` would then only
+affect alerts created afterwards, and there would be no way to distinguish "the
+source said Medium" from "we guessed Medium". Keeping NULL preserves that
+distinction and makes the setting take effect immediately, including for alerts
+already in the database.
+
+Every read path must come through `severity_of` so they cannot disagree.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from typing import Optional
+
+from loguru import logger
+
+#: Ordered least-to-most severe. Mirrors NotificationSeverity in the
+#: notifications schema; kept here as plain strings so the incidents module
+#: doesn't depend on the notifications one.
+SEVERITY_LEVELS = ("Informational", "Low", "Medium", "High", "Critical")
+
+#: Applied when a source gives us nothing.
+#:
+#: High rather than Critical: loud enough that an unmapped source is never
+#: silently suppressed by a sensible route, while leaving "Critical only" as a
+#: filter that still means something. A blanket Critical would make min_severity
+#: useless for exactly the sources that most need triage — and would remove the
+#: main brake on the Resend monthly quota, where severity gating is what stops
+#: 1,000 emails evaporating.
+#:
+#: Deployment-wide and configurable: a SOC that would rather over-notify sets
+#: DEFAULT_ALERT_SEVERITY=Critical and changes nothing else.
+FALLBACK_SEVERITY = "High"
+
+_ENV_VAR = "DEFAULT_ALERT_SEVERITY"
+
+
+def default_severity() -> str:
+    """The deployment's fallback for alerts whose source gave no severity.
+
+    Read per call rather than cached at import: tests and a future settings UI
+    both want to change it without a restart, and this is not a hot path
+    relative to the database read that precedes it.
+
+    An unrecognised value falls back rather than raising — a typo in the
+    environment should not take down alert ingestion.
+    """
+    configured = (os.getenv(_ENV_VAR) or "").strip()
+    if not configured:
+        return FALLBACK_SEVERITY
+
+    for level in SEVERITY_LEVELS:
+        if configured.lower() == level.lower():
+            return level
+
+    logger.warning(
+        f"{_ENV_VAR}={configured!r} is not one of {SEVERITY_LEVELS}; " f"falling back to {FALLBACK_SEVERITY}.",
+    )
+    return FALLBACK_SEVERITY
+
+
+def normalize_severity(value: Optional[str]) -> Optional[str]:
+    """Coerce a source-supplied severity onto our vocabulary, or None.
+
+    Case-insensitive, because sources are inconsistent about it. Returns None
+    for anything unrecognised so the caller stores NULL and the alert resolves
+    to the deployment default — better than persisting a value nothing can
+    filter on.
+    """
+    if not value:
+        return None
+    for level in SEVERITY_LEVELS:
+        if str(value).strip().lower() == level.lower():
+            return level
+    return None
+
+
+def severity_of(alert: Any) -> str:
+    """This alert's effective severity — stored value, or the deployment default.
+
+    Takes the alert (or anything with a `.severity`) rather than the raw string,
+    so call sites read as a question about the alert and can't accidentally skip
+    the fallback.
+    """
+    stored = normalize_severity(getattr(alert, "severity", None))
+    return stored or default_severity()
+
+
+def severity_rank(severity: Optional[str]) -> int:
+    """Position in SEVERITY_LEVELS, for comparisons. Unknown sorts lowest.
+
+    Callers comparing against a threshold should pass `severity_of(alert)`, not
+    `alert.severity` — otherwise a NULL-severity alert ranks below Informational
+    and is dropped by every filter, which is the bug this module exists to fix.
+    """
+    normalized = normalize_severity(severity)
+    return SEVERITY_LEVELS.index(normalized) if normalized else -1

--- a/backend/app/incidents/services/incident_alert.py
+++ b/backend/app/incidents/services/incident_alert.py
@@ -39,6 +39,7 @@ from app.incidents.schema.incident_alert import CreatedAlertPayload
 from app.incidents.schema.incident_alert import FieldNames
 from app.incidents.schema.incident_alert import GenericAlertModel
 from app.incidents.schema.incident_alert import GenericSourceModel
+from app.incidents.services.alert_severity import normalize_severity
 from app.incidents.services.db_operations import get_alert_title_names
 from app.incidents.services.db_operations import get_asset_names
 from app.incidents.services.db_operations import get_customer_ai_trigger
@@ -1196,6 +1197,11 @@ async def create_alert_in_copilot(alert_payload: CreatedAlertPayload, customer_c
         alert_creation_time=datetime.utcnow(),
         customer_code=customer_code,
         source=alert_payload.source,
+        # Persisted so everything after ingest can read it. NULL when the source
+        # supplied nothing — Wazuh carries a rule level, Office 365 / CrowdStrike
+        # / Carbon Black and the rest do not. NULL is resolved to the deployment
+        # default at read time by `severity_of`, deliberately not stamped here.
+        severity=normalize_severity(alert_payload.severity),
         assigned_to=None,
     )
     # Commit it to the database

--- a/backend/app/notifications/services/event_builders.py
+++ b/backend/app/notifications/services/event_builders.py
@@ -19,31 +19,39 @@ import os
 from typing import Any
 from typing import Optional
 
+from app.incidents.services.alert_severity import default_severity
 from app.notifications.schema.events import EntityType
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.schema.notifications import NotificationSeverity
 from app.notifications.schema.notifications import NotificationTrigger
 
-#: Assignments carry no security severity of their own. INFORMATIONAL means a
-#: route filters them by trigger, not by an invented severity — anything higher
-#: would silently drop them on routes tuned for real alerts.
+#: Used when an assignment concerns something with no severity of its own — a
+#: case or a task. Alerts now carry a stored severity (#1040), so an alert
+#: assignment reports the alert's real seriousness instead.
+#:
+#: INFORMATIONAL rather than something higher: a case assignment is a workflow
+#: event, and inventing a severity would let it trip routes tuned for real
+#: alerts.
 _ASSIGNMENT_SEVERITY = NotificationSeverity.INFORMATIONAL
 
 
 def _coerce_severity(value: Optional[str]) -> NotificationSeverity:
-    """Map a payload severity string onto the enum, defaulting to Medium.
+    """Map a severity string onto the enum, falling back to the deployment default.
 
-    `alert_payload.severity` is derived from the Wazuh rule level (issue #980)
-    and is None for sources that carry no level. Medium rather than
-    Informational so a severity-less alert isn't quietly filtered out of every
-    route that gates above Informational.
+    Previously hardcoded Medium here, which is what made non-Wazuh alerts —
+    Office 365, CrowdStrike, Carbon Black and the rest, none of which carry a
+    rule level — silently invisible to any route gating at High and above.
+
+    The fallback now comes from `DEFAULT_ALERT_SEVERITY` (High unless
+    configured otherwise), so an unmapped source is loud by default and the
+    behaviour is one setting away from whatever a given SOC wants. See #1040.
     """
-    if not value:
-        return NotificationSeverity.MEDIUM
-    try:
-        return NotificationSeverity(value)
-    except ValueError:
-        return NotificationSeverity.MEDIUM
+    if value:
+        try:
+            return NotificationSeverity(value)
+        except ValueError:
+            pass
+    return NotificationSeverity(default_severity())
 
 
 def _copilot_link(path: str) -> Optional[str]:
@@ -160,6 +168,7 @@ def _assignment_event(
     *,
     trigger: NotificationTrigger,
     entity_type: str,
+    severity: NotificationSeverity = _ASSIGNMENT_SEVERITY,
     entity_id: int,
     title: Optional[str],
     assignee: Optional[str],
@@ -182,7 +191,7 @@ def _assignment_event(
     return NotificationEvent(
         customer_code=customer_code,
         trigger=trigger,
-        severity=_ASSIGNMENT_SEVERITY,
+        severity=severity,
         subject=title or f"{entity_type} #{entity_id}",
         summary=summary,
         entity_type=entity_type,
@@ -202,9 +211,18 @@ def alert_assigned_event(
     assignee: Optional[str],
     actor: Optional[str],
     customer_code: Optional[str] = None,
+    severity: Optional[str] = None,
 ) -> NotificationEvent:
+    """An alert changed hands.
+
+    Carries the alert's own severity when the caller supplies it — being handed
+    a Critical alert is not the same event as being handed an Informational one,
+    and a route gating at High should see the first. Falls back to the
+    assignment default when unknown.
+    """
     return _assignment_event(
         trigger=NotificationTrigger.ALERT_ASSIGNED,
+        severity=_coerce_severity(severity) if severity else _ASSIGNMENT_SEVERITY,
         entity_type=EntityType.ALERT,
         entity_id=alert_id,
         title=title,

--- a/backend/tests/test_alert_severity.py
+++ b/backend/tests/test_alert_severity.py
@@ -1,0 +1,155 @@
+"""Alert severity storage and resolution.
+
+Alerts had no stored severity. It was derived at ingest from the Wazuh rule
+level, used for the notification, and discarded — so anything after ingest was
+blind to it, and sources carrying no rule level (Office 365, CrowdStrike, Carbon
+Black, Huntress) silently resolved to a hardcoded `Medium`. A route gating at
+*High and above* dropped every one of them.
+
+The design decision these tests mostly exist to protect: **NULL is resolved at
+read time, not stamped at ingest.** That keeps "the source said Medium"
+distinguishable from "we guessed", and makes changing the deployment default
+take effect immediately — including for alerts already in the database.
+
+Run with: cd backend && python -m pytest tests/test_alert_severity.py
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.incidents.services.alert_severity import FALLBACK_SEVERITY  # noqa: E402
+from app.incidents.services.alert_severity import SEVERITY_LEVELS  # noqa: E402
+from app.incidents.services.alert_severity import default_severity  # noqa: E402
+from app.incidents.services.alert_severity import normalize_severity  # noqa: E402
+from app.incidents.services.alert_severity import severity_of  # noqa: E402
+from app.incidents.services.alert_severity import severity_rank  # noqa: E402
+
+
+def _alert(severity=None):
+    return SimpleNamespace(id=1, severity=severity)
+
+
+def _with_default(value):
+    return patch.dict(os.environ, {"DEFAULT_ALERT_SEVERITY": value})
+
+
+def _without_default():
+    env = {k: v for k, v in os.environ.items() if k != "DEFAULT_ALERT_SEVERITY"}
+    return patch.dict(os.environ, env, clear=True)
+
+
+# ── resolution at read time ───────────────────────────────────────────────
+
+
+def test_a_stored_severity_is_used():
+    assert severity_of(_alert("Critical")) == "Critical"
+
+
+def test_null_resolves_to_the_deployment_default():
+    """NULL means "the source didn't say", not "unimportant"."""
+    with _without_default():
+        assert severity_of(_alert(None)) == FALLBACK_SEVERITY
+
+
+def test_changing_the_default_changes_existing_alerts_immediately():
+    """The reason NULL isn't stamped at ingest. If the fallback were written to
+    the row, changing this setting would only affect alerts created afterwards
+    and would need a backfill to apply retroactively."""
+    alert = _alert(None)
+    with _with_default("Critical"):
+        assert severity_of(alert) == "Critical"
+    with _with_default("Low"):
+        assert severity_of(alert) == "Low"
+
+
+def test_a_stored_value_is_not_overridden_by_the_default():
+    with _with_default("Critical"):
+        assert severity_of(_alert("Low")) == "Low"
+
+
+# ── the default ───────────────────────────────────────────────────────────
+
+
+def test_the_shipped_default_is_high():
+    """High rather than Critical: loud enough that an unmapped source is never
+    silently suppressed, while leaving "Critical only" a filter that still means
+    something. A blanket Critical would also remove the main brake on the Resend
+    monthly quota."""
+    with _without_default():
+        assert default_severity() == "High"
+    assert FALLBACK_SEVERITY == "High"
+
+
+@pytest.mark.parametrize("level", SEVERITY_LEVELS)
+def test_every_level_is_configurable(level):
+    with _with_default(level):
+        assert default_severity() == level
+
+
+def test_the_setting_is_case_insensitive():
+    with _with_default("critical"):
+        assert default_severity() == "Critical"
+
+
+def test_a_typo_in_the_setting_falls_back_rather_than_breaking_ingest():
+    """A bad environment variable must not take down alert creation."""
+    with _with_default("Sevre"):
+        assert default_severity() == FALLBACK_SEVERITY
+
+
+def test_an_empty_setting_falls_back():
+    with _with_default(""):
+        assert default_severity() == FALLBACK_SEVERITY
+
+
+# ── normalisation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("raw", ["critical", "CRITICAL", " Critical ", "Critical"])
+def test_sources_are_inconsistent_about_case_and_whitespace(raw):
+    assert normalize_severity(raw) == "Critical"
+
+
+@pytest.mark.parametrize("raw", [None, "", "Sev1", "urgent", "9"])
+def test_an_unrecognised_value_becomes_null_rather_than_being_stored(raw):
+    """Better to store NULL and resolve to the default than persist something
+    nothing can filter on."""
+    assert normalize_severity(raw) is None
+
+
+# ── ranking ───────────────────────────────────────────────────────────────
+
+
+def test_levels_rank_in_order():
+    ranks = [severity_rank(level) for level in SEVERITY_LEVELS]
+    assert ranks == sorted(ranks)
+    assert severity_rank("Critical") > severity_rank("High") > severity_rank("Informational")
+
+
+def test_an_unknown_severity_ranks_below_everything():
+    """Which is exactly why callers must rank `severity_of(alert)` and not
+    `alert.severity` — passing the raw NULL would drop the alert from every
+    filter, the bug this module exists to fix."""
+    assert severity_rank(None) < severity_rank("Informational")
+
+
+def test_ranking_the_resolved_value_puts_a_null_alert_above_informational():
+    with _without_default():
+        assert severity_rank(severity_of(_alert(None))) > severity_rank("Informational")
+
+
+# ── the reported bug ──────────────────────────────────────────────────────
+
+
+def test_a_non_wazuh_alert_is_not_dropped_by_a_high_gate():
+    """The concrete failure: a CrowdStrike alert has no rule level, stored NULL,
+    and previously resolved to Medium — so a route gating at High never saw it.
+    """
+    crowdstrike_alert = _alert(None)
+    with _without_default():
+        assert severity_rank(severity_of(crowdstrike_alert)) >= severity_rank("High")

--- a/backend/tests/test_notification_ai_emit_paths.py
+++ b/backend/tests/test_notification_ai_emit_paths.py
@@ -192,14 +192,21 @@ def test_review_is_customer_facing_not_internal():
     assert NotificationTrigger.AI_REPORT_REVIEWED.value not in INTERNAL_TRIGGERS
 
 
-@pytest.mark.parametrize("severity,expected", [("Critical", "Critical"), (None, "Medium"), ("Nonsense", "Medium")])
-def test_severity_falls_back_rather_than_raising(severity, expected):
+@pytest.mark.parametrize("severity", [None, "Nonsense"])
+def test_unknown_severity_falls_back_to_the_deployment_default(severity):
     """A report with no assessed severity must not be filtered out of every
-    route gating above Informational."""
-    event = investigation_complete_event(
-        alert_id=1,
-        customer_code=CUSTOMER,
-        severity=severity,
-        summary="s",
-    )
-    assert event.severity.value == expected
+    route gating above Informational.
+
+    Asserted against `default_severity()` rather than a literal: the fallback is
+    deployment-configurable (#1040), and hardcoding it here would fail for
+    anyone who changed the setting rather than catching a real bug.
+    """
+    from app.incidents.services.alert_severity import default_severity
+
+    event = investigation_complete_event(alert_id=1, customer_code=CUSTOMER, severity=severity, summary="s")
+    assert event.severity.value == default_severity()
+
+
+def test_a_supplied_severity_is_used_verbatim():
+    event = investigation_complete_event(alert_id=1, customer_code=CUSTOMER, severity="Critical", summary="s")
+    assert event.severity.value == "Critical"

--- a/backend/tests/test_notification_triggers.py
+++ b/backend/tests/test_notification_triggers.py
@@ -197,16 +197,22 @@ def test_alert_created_uses_the_payloads_derived_severity():
     assert event.context["rule_level"] == 14
 
 
-def test_alert_without_a_severity_defaults_to_medium_not_informational():
-    """Sources with no rule level would otherwise be filtered out of every route
-    gating above Informational."""
+def test_alert_without_a_severity_uses_the_deployment_default():
+    """Sources with no rule level — Office 365, CrowdStrike, Carbon Black — used
+    to land on a hardcoded Medium and were invisible to any route gating above
+    it. The fallback is now deployment-configurable and defaults to High (#1040).
+    """
+    from app.incidents.services.alert_severity import default_severity
+
     event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity=None)
-    assert event.severity.value == "Medium"
+    assert event.severity.value == default_severity()
 
 
 def test_unknown_severity_string_falls_back_rather_than_raising():
+    from app.incidents.services.alert_severity import default_severity
+
     event = alert_created_event(alert_id=1, customer_code=CUSTOMER, alert_title="t", severity="Catastrophic")
-    assert event.severity.value == "Medium"
+    assert event.severity.value == default_severity()
 
 
 def test_min_severity_still_gates_alert_created():


### PR DESCRIPTION
Closes #1040.

## The bug

Alerts had **no stored severity**. It was derived at ingest from the Wazuh rule level (#980), used for the `alert_created` notification, and discarded.

**Sources with no rule level got nothing.** Office 365, CrowdStrike, Carbon Black, Huntress and the rest carry no equivalent field, so severity resolved to `None` and the notification builder coerced it to a hardcoded `Medium`. A route gating at *High and above* silently dropped every alert from those sources — they fell through the cracks.

**Anything after ingest was blind.** Assignment notifications had no severity to read, which is why `_assignment_event` hardcoded `Informational`. Manual send (#1010) would have hit the same wall. Nothing could filter or sort by it.

## Considered and rejected: default everything to Critical

The obvious fix, and the wrong one. It makes `min_severity` meaningless for exactly the sources most needing triage — a route set to *Critical only* would fire on every CrowdStrike alert — and removes the main brake on the Resend monthly quota, where severity gating is what stops 1,000 emails evaporating.

The problem was that severity **wasn't stored**, not that the default was too low.

## The design decision worth reviewing

**NULL is resolved at read time, not stamped at ingest.**

NULL means *"the source did not tell us"* — a different fact from any particular severity. Stamping the fallback onto the row would freeze it:

- changing `DEFAULT_ALERT_SEVERITY` would only affect alerts created afterwards
- *"the source said High"* would become indistinguishable from *"we guessed High"*
- retuning after seeing real traffic would need a backfill

Keeping NULL preserves the distinction, makes the setting apply retroactively, and is why **no backfill is needed**.

## The default

`DEFAULT_ALERT_SEVERITY`, defaulting to **High** — loud enough that an unmapped source is never silently suppressed, low enough that *"Critical only"* remains a filter that means something. A SOC preferring to over-notify sets `Critical` and changes nothing else.

A typo in the variable logs a warning and falls back rather than taking down ingestion.

## Structure

`severity_of()` is the **single resolver** — every read path goes through it, so they cannot disagree.

`severity_rank()` ranks unknown *below* Informational deliberately, with a docstring saying callers must pass `severity_of(alert)` and not `alert.severity`. Passing the raw NULL reintroduces the exact bug this fixes, and there's a test asserting that contrast directly.

**Bonus:** alert assignment notifications now carry the alert's real severity instead of `Informational`. Being handed a Critical alert is not the same event as being handed an Informational one.

## Verified against the dev database

```
alembic_version : c92e4a1f8b73
column          : varchar(20), nullable, NO default
index           : ix_incident_management_alert_severity
rows            : 34 total, 34 NULL (no backfill, as designed)

NULL row resolves           -> High
gated at High               -> passes
gated at Critical           -> correctly excluded
raw NULL against High gate  -> FAILS  <- the old bug, reproduced
assignment event severity   -> High   (was hardcoded Informational)
DEFAULT_ALERT_SEVERITY=Critical -> same row resolves Critical, zero data written
```

One honest caveat: all 34 rows predate the migration, so they're NULL regardless of source. The Wazuh path *storing* a real severity is covered by unit tests but won't be observable until a new alert ingests — worth a glance at the next one.

## Testing

```
26 new     tests/test_alert_severity.py
332 passed backend tests/
pre-commit clean
```

Three existing tests asserted the old hardcoded `Medium`. They now assert against `default_severity()` rather than a literal, so they test the contract rather than the current setting — otherwise anyone changing the default would see failures that aren't bugs.

## Follow-on, deliberately not here

**Per-source severity mapping.** CrowdStrike and Defender both ship their own severity field; mapping them turns a guess into a fact. It's per-integration work and deserves its own issue now that there's somewhere to put the result.
