### PR TITLE
feat(notifications): manual send of an alert or case to a channel

### DIFF
--- a/backend/alembic/versions/d1a7c4e2f905_add_dispatch_log_trigger_source.py
+++ b/backend/alembic/versions/d1a7c4e2f905_add_dispatch_log_trigger_source.py
@@ -1,0 +1,65 @@
+"""record who triggered a dispatch and how
+
+Revision ID: d1a7c4e2f905
+Revises: c92e4a1f8b73
+Create Date: 2026-08-02 17:10:00.000000
+
+Manual send (#1010) pushes a specific customer's data outward on demand. "Who
+sent which customer's data where" is a compliance question, and the dispatch log
+had no way to answer it — every row looked the same whether it was fired by an
+alert landing or by a person clicking a button.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d1a7c4e2f905"
+down_revision: Union[str, None] = "c92e4a1f8b73"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # NULL for automatic dispatches — nobody triggered them. Also populated from
+    # the acting user on assignment events, where the actor is already known.
+    op.add_column(
+        "notification_dispatch_log",
+        sa.Column("triggered_by", sa.String(length=128), nullable=True),
+    )
+
+    # 'automatic' | 'manual' | 'test'. Every existing row predates manual send,
+    # so the server_default backfills them correctly in one step; it is then
+    # dropped so the column matches the model, which carries a Python-side
+    # default only.
+    op.add_column(
+        "notification_dispatch_log",
+        sa.Column("trigger_source", sa.String(length=16), nullable=False, server_default="automatic"),
+    )
+    op.create_index(
+        "ix_notification_dispatch_log_trigger_source",
+        "notification_dispatch_log",
+        ["trigger_source"],
+    )
+    op.alter_column(
+        "notification_dispatch_log",
+        "trigger_source",
+        existing_type=sa.String(length=16),
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    """Non-lossy for anything that existed before this revision.
+
+    Only manual and test sends carry values these columns record; automatic
+    dispatches were indistinguishable from each other anyway, which is the gap
+    this closed.
+    """
+    op.drop_index("ix_notification_dispatch_log_trigger_source", table_name="notification_dispatch_log")
+    op.drop_column("notification_dispatch_log", "trigger_source")
+    op.drop_column("notification_dispatch_log", "triggered_by")

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -1060,6 +1060,16 @@ class NotificationDispatchLog(SQLModel, table=True):
     # a customer says "the message looked wrong" we want to see what we
     # actually sent without storing the entire body history.
     payload_preview: Optional[str] = Field(sa_column=Column(Text), default=None)
+    # Who caused this dispatch, when a person did. NULL for automatic ones —
+    # nobody triggered them. "Who sent which customer's data where" is a
+    # compliance question, and manual send (#1010) made it answerable.
+    triggered_by: Optional[str] = Field(default=None, max_length=128)
+
+    # 'automatic' | 'manual' | 'test'. Lets the dispatch-log viewer answer
+    # "show me every time someone hand-sent data to a customer" without
+    # inferring it from the trigger.
+    trigger_source: str = Field(default="automatic", max_length=16, nullable=False, index=True)
+
     # Vendor-side identifier for this delivery, whatever the channel calls it —
     # Shuffle's execution id, and later Resend's message id. Lets an admin pivot
     # from "the notification didn't arrive" to the run in the provider's own UI

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -37,6 +37,7 @@ from app.notifications.schema.notifications import DispatchLogListResponse
 from app.notifications.schema.notifications import DispatchOutcome
 from app.notifications.schema.notifications import DispatchRequest
 from app.notifications.schema.notifications import DispatchResponse
+from app.notifications.schema.notifications import ManualSendRequest
 from app.notifications.schema.notifications import NotificationRouteCreate
 from app.notifications.schema.notifications import NotificationRouteListResponse
 from app.notifications.schema.notifications import NotificationRouteRead
@@ -166,6 +167,76 @@ async def test_route(
 async def test_internal_route(route_id: int, session: AsyncSession = Depends(get_db)) -> DispatchOutcome:
     route = await svc.get_internal_route(route_id, session)
     return await svc.send_test_notification(route, session)
+
+
+# ---------------------------------------------------------------------------
+# Manual send
+# ---------------------------------------------------------------------------
+#
+# A data egress control point rather than a convenience endpoint: it pushes a
+# specific customer's data outward on demand, bypassing the trigger and severity
+# filters that govern automatic notifications.
+#
+# The scope dependency below is intentionally the permissive one. Real
+# enforcement lives in the service — customer-facing targets need admin,
+# portal users are refused outright, the route is re-validated against the
+# item's tenant, and the caller must be able to see the item at all. Putting it
+# there rather than in a route dependency keeps every check in one auditable
+# place and applies to any future caller.
+
+
+@notifications_router.post(
+    "/notifications/send",
+    response_model=DispatchOutcome,
+    description=(
+        "Send a specific alert or case to a configured notification route. Sends a real "
+        "notification: it consumes provider quota and is recorded in the dispatch log. "
+        "Customer-facing routes require admin."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def manual_send_route(
+    payload: ManualSendRequest,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> DispatchOutcome:
+    from app.notifications.services.manual_send import send_manual
+
+    return await send_manual(
+        entity_type=payload.entity_type,
+        entity_id=payload.entity_id,
+        route_id=payload.route_id,
+        user=current_user,
+        session=session,
+        include_ai_report=payload.include_ai_report,
+    )
+
+
+@notifications_router.post(
+    "/notifications/send/preview",
+    description=(
+        "Render what a manual send would deliver, without sending it. Runs the same "
+        "authorization as the send itself, so a preview cannot reveal an item the caller "
+        "may not see."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def manual_send_preview_route(
+    payload: ManualSendRequest,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    session: AsyncSession = Depends(get_db),
+):
+    from app.notifications.services.manual_send import preview_manual
+
+    body = await preview_manual(
+        entity_type=payload.entity_type,
+        entity_id=payload.entity_id,
+        route_id=payload.route_id,
+        user=current_user,
+        session=session,
+        include_ai_report=payload.include_ai_report,
+    )
+    return {"success": True, "message": "Preview rendered", "body": body}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -515,6 +515,23 @@ class ShuffleOrgListResponse(BaseModel):
     orgs: List[ShuffleOrg]
 
 
+class ManualSendRequest(BaseModel):
+    """Body for POST /notifications/send.
+
+    Deliberately has NO destination field. The target is always a configured
+    route: routes are admin-managed and carry validated config, whereas a
+    free-text address would turn this into an arbitrary exfiltration tool.
+    """
+
+    entity_type: str = Field(description="'alert' or 'case'.")
+    entity_id: int
+    route_id: int = Field(description="An existing route. Re-validated server-side against the item's customer.")
+    include_ai_report: bool = Field(
+        default=False,
+        description="Attach the AI investigation report. Refused when the customer has opted out of AI reports.",
+    )
+
+
 class ChannelDescriptor(BaseModel):
     """One delivery channel, as the route form needs to see it.
 
@@ -588,6 +605,10 @@ class DispatchLogRead(BaseModel):
     latency_ms: Optional[int] = None
     payload_preview: Optional[str] = None
     provider_reference: Optional[str] = None
+    # Who caused this, when a person did, and how it was triggered. Lets the log
+    # answer "show me every hand-sent notification" without inference.
+    triggered_by: Optional[str] = None
+    trigger_source: str = "automatic"
     model_config = ConfigDict(from_attributes=True)
 
 

--- a/backend/app/notifications/services/manual_send.py
+++ b/backend/app/notifications/services/manual_send.py
@@ -1,0 +1,291 @@
+"""Sending a specific alert or case to a channel on demand.
+
+Every other notification in this system is *triggered* — something happened and
+routes matching it fire. This one is *chosen*: an analyst decides to push a
+particular alert somewhere, bypassing the trigger and severity filters that
+govern everything else.
+
+That makes it a **data egress control point**, not a convenience feature, and
+the guardrails below are the substance of the module rather than boilerplate:
+
+**Configured routes only.** There is deliberately no free-text destination. A
+route is admin-managed and carries validated config; a "send to this address"
+box would turn the button into an arbitrary exfiltration tool.
+
+**Admin for customer-facing targets.** Sending out to an end customer skips the
+filters by definition, so it gets a second pair of eyes. Internal sharing stays
+open to analysts.
+
+**Server-side re-validation of everything.** The route picker filters to the
+entity's own customer plus internal routes, but nothing here trusts that — the
+cross-tenant pairing the UI would never offer is exactly the one worth checking.
+
+**Object-level authorization.** Without it, manual send is a read primitive:
+sending an alert to a channel you can read is a way to see alerts the tag rules
+deny you.
+
+**The AI opt-out still applies.** Otherwise this is the hole in the control
+established by #1014 — an analyst hand-delivering AI findings to a customer who
+declined them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.models.users import RoleEnum
+from app.customer_portal.services.ai_reports import is_ai_reports_enabled
+from app.db.universal_models import CustomerNotificationRoute
+from app.incidents.models import Alert
+from app.incidents.models import Case
+from app.incidents.services.alert_severity import severity_of
+from app.notifications.schema.events import EntityType
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.schema.notifications import DispatchOutcome
+from app.notifications.schema.notifications import DispatchStatus
+from app.notifications.schema.notifications import NotificationScope
+from app.notifications.schema.notifications import NotificationSeverity
+from app.notifications.schema.notifications import NotificationTrigger
+
+SUPPORTED_ENTITY_TYPES = (EntityType.ALERT, EntityType.CASE)
+
+
+async def _load_entity(entity_type: str, entity_id: int, session: AsyncSession) -> Optional[Any]:
+    """Fetch the alert or case being sent."""
+    model = {EntityType.ALERT: Alert, EntityType.CASE: Case}.get(entity_type)
+    if model is None:
+        raise HTTPException(status_code=400, detail=f"Cannot send a '{entity_type}'; expected one of {SUPPORTED_ENTITY_TYPES}.")
+    result = await session.execute(select(model).where(model.id == entity_id))
+    return result.scalars().first()
+
+
+async def _load_route(route_id: int, session: AsyncSession) -> Optional[CustomerNotificationRoute]:
+    result = await session.execute(select(CustomerNotificationRoute).where(CustomerNotificationRoute.id == route_id))
+    return result.scalars().first()
+
+
+def build_manual_event(*, entity_type: str, entity_id: int, entity: Any, user: Any) -> NotificationEvent:
+    """The envelope for one manual send.
+
+    **The dedupe key carries a uuid, which is a deliberate exception to the
+    engine's core idempotency rule.** Every other trigger dedupes so a repeat is
+    a no-op; manual send must be repeatable, because clicking "send" twice on
+    purpose has to send twice. Each click therefore becomes its own dispatch-log
+    row — which is what an audit trail wants anyway.
+
+    Do not "fix" this to match the other triggers. Repeat sends would break
+    silently, and `test_every_manual_send_gets_a_unique_dedupe_key` exists to
+    catch that.
+    """
+    is_alert = entity_type == EntityType.ALERT
+    title = getattr(entity, "alert_name", None) if is_alert else getattr(entity, "case_name", None)
+    label = title or f"{entity_type} #{entity_id}"
+
+    # An alert carries a real severity (#1040); a case has none of its own, so a
+    # manual case send is Informational rather than an invented value.
+    severity = NotificationSeverity(severity_of(entity)) if is_alert else NotificationSeverity.INFORMATIONAL
+
+    return NotificationEvent(
+        customer_code=getattr(entity, "customer_code", None),
+        # Reuses the entity's natural trigger for body rendering; the fact that
+        # this was hand-sent is recorded on the log row, not in the trigger.
+        trigger=NotificationTrigger.ALERT_CREATED if is_alert else NotificationTrigger.CASE_ASSIGNED,
+        severity=severity,
+        subject=label,
+        summary=f"{label} was sent to this channel by {getattr(user, 'username', 'unknown')}.",
+        entity_type=entity_type,
+        entity_id=entity_id,
+        dedupe_key=f"{entity_type}:{entity_id}:manual:{uuid4()}",
+        actor_username=getattr(user, "username", None),
+        context={"alert_name": title, "title": title, "manual": True},
+    )
+
+
+def _require_send_permission(user: Any, route: CustomerNotificationRoute) -> None:
+    """Who may send, and where.
+
+    Customer-facing sends are admin-only: they push data to an end customer
+    outside the filters that normally govern it. Internal routes stay open to
+    analysts so routine sharing isn't gated behind an escalation.
+    """
+    role_id = getattr(user, "role_id", None)
+
+    if role_id == RoleEnum.customer_user.value:
+        raise HTTPException(status_code=403, detail="Portal users cannot send notifications.")
+
+    if role_id not in (RoleEnum.admin.value, RoleEnum.analyst.value):
+        raise HTTPException(status_code=403, detail="You do not have permission to send notifications.")
+
+    if route.scope == NotificationScope.CUSTOMER.value and role_id != RoleEnum.admin.value:
+        raise HTTPException(
+            status_code=403,
+            detail=("Sending to a customer-facing route requires admin. " "An internal route is available for sharing within the SOC."),
+        )
+
+
+def _require_route_matches_entity(route: CustomerNotificationRoute, entity: Any) -> None:
+    """Re-validate the submitted route against the entity's tenant.
+
+    The picker only offers the entity's own customer plus internal routes, but
+    the route_id arrives from the client. This is the check the UI can't be
+    trusted to have made.
+    """
+    if route.scope == NotificationScope.INTERNAL.value:
+        # Belongs to no tenant, so there is nothing to match against.
+        return
+
+    entity_customer = getattr(entity, "customer_code", None)
+    if route.customer_code != entity_customer:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"That route belongs to customer {route.customer_code!r}, but this item belongs to "
+                f"{entity_customer!r}. A customer-facing route can only receive its own customer's data."
+            ),
+        )
+
+
+async def _require_object_access(entity_type: str, entity: Any, user: Any, session: AsyncSession) -> None:
+    """The caller must be able to *see* the item before sending it anywhere.
+
+    Without this the button is a read primitive — sending an alert to a channel
+    you can read reveals alerts the tag rules deny you.
+    """
+    from app.incidents.middleware.tag_access import tag_access_handler
+    from app.middleware.customer_access import customer_access_handler
+
+    customer_code = getattr(entity, "customer_code", None)
+    if customer_code and not await customer_access_handler.check_customer_access(user, customer_code, session):
+        raise HTTPException(status_code=403, detail="Access denied — insufficient customer permissions for this item.")
+
+    if entity_type == EntityType.ALERT:
+        if not await tag_access_handler.can_user_access_alert(user, entity.id, session):
+            raise HTTPException(status_code=403, detail="Access denied — this alert is outside your tag access.")
+
+
+async def _require_ai_report_permitted(
+    route: CustomerNotificationRoute,
+    entity: Any,
+    include_ai_report: bool,
+    session: AsyncSession,
+) -> None:
+    """The #1014 opt-out applies to hand-delivered AI content too.
+
+    Only customer-facing sends are gated. Keeping AI findings internal while
+    still running investigations is a supported configuration.
+    """
+    if not include_ai_report or route.scope != NotificationScope.CUSTOMER.value:
+        return
+
+    customer_code = getattr(entity, "customer_code", None)
+    if not await is_ai_reports_enabled(customer_code, session):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "AI reports are not enabled for this customer, so the AI report cannot be included. "
+                "Send without it, or enable AI reports for the customer first."
+            ),
+        )
+
+
+async def _deliver(route: CustomerNotificationRoute, event: NotificationEvent, session: AsyncSession):
+    """Hand off to the channel provider and record the outcome.
+
+    Split out so the authorization path above can be tested without stubbing the
+    whole dispatch stack.
+    """
+    from app.notifications.services.notifications import deliver_one
+
+    return await deliver_one(route, event, session, trigger_source="manual")
+
+
+async def preview_manual(
+    *,
+    entity_type: str,
+    entity_id: int,
+    route_id: int,
+    user: Any,
+    session: AsyncSession,
+    include_ai_report: bool = False,
+) -> str:
+    """Render what a send would deliver, without delivering it.
+
+    Runs the **same authorization** as `send_manual`. A preview that skipped the
+    checks would be a read primitive of its own — showing an alert's contents to
+    someone who may not see the alert — which is precisely the hole the object
+    access check exists to close.
+
+    Renders against the real item rather than a sample event: the operator is
+    about to push this specific data outward and should see exactly what leaves.
+    """
+    from app.notifications.services.notifications import _render_body
+
+    entity = await _load_entity(entity_type, entity_id, session)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"{entity_type} {entity_id} not found")
+
+    route = await _load_route(route_id, session)
+    if route is None:
+        raise HTTPException(status_code=404, detail=f"Route {route_id} not found")
+
+    _require_send_permission(user, route)
+    _require_route_matches_entity(route, entity)
+    await _require_object_access(entity_type, entity, user, session)
+    await _require_ai_report_permitted(route, entity, include_ai_report, session)
+
+    event = build_manual_event(entity_type=entity_type, entity_id=entity_id, entity=entity, user=user)
+    body, _template_error = _render_body(route, event)
+    return body
+
+
+async def send_manual(
+    *,
+    entity_type: str,
+    entity_id: int,
+    route_id: int,
+    user: Any,
+    session: AsyncSession,
+    include_ai_report: bool = False,
+) -> DispatchOutcome:
+    """Send one alert or case to one route, now.
+
+    Order matters: every check runs before anything leaves the process, and each
+    failure is an HTTPException the caller surfaces rather than a logged
+    dispatch — a refused send is a permissions answer, not a delivery outcome.
+    """
+    entity = await _load_entity(entity_type, entity_id, session)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"{entity_type} {entity_id} not found")
+
+    route = await _load_route(route_id, session)
+    if route is None:
+        raise HTTPException(status_code=404, detail=f"Route {route_id} not found")
+
+    _require_send_permission(user, route)
+    _require_route_matches_entity(route, entity)
+    await _require_object_access(entity_type, entity, user, session)
+    await _require_ai_report_permitted(route, entity, include_ai_report, session)
+
+    event = build_manual_event(entity_type=entity_type, entity_id=entity_id, entity=entity, user=user)
+    logger.info(
+        f"Manual send: {entity_type}#{entity_id} -> route {route.id} ({route.channel}, {route.scope}) "
+        f"by {getattr(user, 'username', 'unknown')}",
+    )
+
+    result = await _deliver(route, event, session)
+    return DispatchOutcome(
+        route_id=route.id,
+        route_name=route.name,
+        channel=route.channel,
+        status=DispatchStatus(result.status),
+        error_message=result.error_message,
+        latency_ms=result.latency_ms,
+        provider_reference=result.provider_reference,
+    )

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -784,6 +784,8 @@ async def _record_log(
     latency_ms: Optional[int],
     payload_preview: Optional[str],
     provider_reference: Optional[str] = None,
+    triggered_by: Optional[str] = None,
+    trigger_source: str = "automatic",
 ) -> bool:
     """Record a dispatch outcome. Returns False ONLY when the dispatch
     has already been recorded as `sent` — i.e. a true idempotency hit
@@ -850,6 +852,8 @@ async def _record_log(
         latency_ms=latency_ms,
         payload_preview=payload_preview[:500] if payload_preview else None,
         provider_reference=provider_reference,
+        triggered_by=triggered_by or event.actor_username,
+        trigger_source=trigger_source,
     )
     session.add(log)
     try:
@@ -905,37 +909,39 @@ def _sample_event_for(route: CustomerNotificationRoute) -> NotificationEvent:
     )
 
 
-async def send_test_notification(route: CustomerNotificationRoute, session: AsyncSession) -> DispatchOutcome:
-    """Deliver one test message through the route's real provider.
+async def deliver_one(
+    route: CustomerNotificationRoute,
+    event: NotificationEvent,
+    session: AsyncSession,
+    *,
+    trigger_source: str = "manual",
+) -> SendResult:
+    """Send one event through one route's provider, and log the outcome.
 
-    Uses the normal send path rather than a bespoke per-provider probe, because
-    a probe tests the wrong thing: the Resend key in use here is send-only
-    restricted, so an account-state check 401s while sending works fine. What an
-    operator wants to know is "will a real notification arrive", and only a real
-    send answers that.
+    The shared core of every "deliver this specific thing now" path — the test
+    button and manual send (#1010) — as distinct from `dispatch_event`, which
+    matches an event against many routes. Both need identical behaviour on
+    rendering, failure containment and logging, so they share it rather than
+    drifting.
 
-    The outcome IS logged. A test send consumes provider quota exactly like a
-    real one — leaving it out of the dispatch log would make the Resend monthly
-    counter under-report, and hide test traffic from the audit trail.
+    Never raises: a provider that blows up becomes a `failed` result, because
+    both callers report an outcome rather than an exception.
+
+    The outcome IS logged. These sends consume provider quota exactly like an
+    automatic one — omitting them would make the Resend monthly counter
+    under-report and hide hand-sent traffic from the audit trail.
     """
     provider = get_channel(route.channel)
     if provider is None:
-        return DispatchOutcome(
-            route_id=route.id,
-            route_name=route.name,
-            channel=route.channel,
-            status=DispatchStatus.FAILED,
-            error_message=f"Unsupported channel: {route.channel}",
-        )
+        return SendResult.failed(f"Unsupported channel: {route.channel}")
 
-    event = _sample_event_for(route)
     ctx = DispatchContext(session=session, event=event)
     body, template_error = _render_body(route, event)
 
     try:
         result = await provider.send(route=route, event=event, rendered_body=body, ctx=ctx)
-    except Exception as e:  # noqa: BLE001 — a test must report, never 500
-        logger.exception(f"Test dispatch raised for route {route.id}: {e!r}")
+    except Exception as e:  # noqa: BLE001 — report, never 500 the caller
+        logger.exception(f"Dispatch raised for route {route.id}: {e!r}")
         result = SendResult.failed(f"Dispatcher exception: {type(e).__name__}: {e}")
 
     await _record_log(
@@ -951,8 +957,21 @@ async def send_test_notification(route: CustomerNotificationRoute, session: Asyn
         latency_ms=result.latency_ms,
         payload_preview=body[:500],
         provider_reference=result.provider_reference,
+        trigger_source=trigger_source,
     )
+    return result
 
+
+async def send_test_notification(route: CustomerNotificationRoute, session: AsyncSession) -> DispatchOutcome:
+    """Deliver one test message through the route's real provider.
+
+    Uses the normal send path rather than a bespoke per-provider probe, because
+    a probe tests the wrong thing: the Resend key in use here is send-only
+    restricted, so an account-state check 401s while sending works fine. What an
+    operator wants to know is "will a real notification arrive", and only a real
+    send answers that.
+    """
+    result = await deliver_one(route, _sample_event_for(route), session, trigger_source="test")
     return DispatchOutcome(
         route_id=route.id,
         route_name=route.name,

--- a/backend/tests/test_notification_manual_send_authz.py
+++ b/backend/tests/test_notification_manual_send_authz.py
@@ -1,0 +1,256 @@
+"""Guardrails on manually sending an alert or case to a notification channel.
+
+**Written before the endpoint existed**, deliberately. Prose saying "enforce this
+server-side" decays into "the UI hides it"; a red test does not.
+
+Manual send is a **data egress control point**, not a convenience feature.
+Someone with the button can push a customer's alert to an outside channel on
+demand, bypassing the trigger and severity filters that govern automatic
+notifications. Every check below must hold in the service layer, independently of
+what the route form chooses to offer — the cross-tenant case in particular is
+something the UI would never present, which is exactly why it needs a test.
+
+Unit tests with mocked sessions — no DB, no network.
+
+Run with: cd backend && python -m pytest tests/test_notification_manual_send_authz.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+
+import app.notifications.services.manual_send as ms  # noqa: E402
+
+ADMIN, ANALYST, CUSTOMER_USER = 1, 2, 4
+OWNER, OTHER = "TENANT_A", "TENANT_B"
+
+
+def _user(role_id=ANALYST, username="analyst_one"):
+    return SimpleNamespace(id=7, username=username, role_id=role_id)
+
+
+def _alert(alert_id=42, customer_code=OWNER):
+    return SimpleNamespace(
+        id=alert_id,
+        alert_name="Mimikatz signature",
+        customer_code=customer_code,
+        severity="Critical",
+        assigned_to=None,
+    )
+
+
+def _route(route_id=1, scope="customer", customer_code=OWNER, channel="webhook"):
+    return SimpleNamespace(
+        id=route_id,
+        name="SOC webhook",
+        channel=channel,
+        scope=scope,
+        customer_code=customer_code,
+        trigger="alert_created",
+        min_severity="Informational",
+        destination="",
+        format_template=None,
+        config=json.dumps({"url": "https://example.invalid/hook"}),
+        shuffle_integration_id=None,
+        notify_on_self_assign=False,
+        created_by="admin",
+    )
+
+
+def _session(alert=None, route=None):
+    """Mocked session returning `alert` then `route` from successive lookups."""
+    session = AsyncMock()
+    results = []
+    for obj in (alert, route):
+        r = MagicMock()
+        r.scalars.return_value.first.return_value = obj
+        results.append(r)
+    session.execute = AsyncMock(side_effect=results * 4)
+    return session
+
+
+def _send(user, alert, route, *, tag_ok=True, customer_ok=True, ai_enabled=True, include_ai_report=False):
+    sent = AsyncMock(return_value=SimpleNamespace(status="sent", error_message=None, latency_ms=5, provider_reference="r"))
+    with (
+        patch.object(ms, "_load_entity", AsyncMock(return_value=alert)),
+        patch.object(ms, "_load_route", AsyncMock(return_value=route)),
+        patch("app.incidents.middleware.tag_access.tag_access_handler.can_user_access_alert", AsyncMock(return_value=tag_ok)),
+        patch("app.middleware.customer_access.customer_access_handler.check_customer_access", AsyncMock(return_value=customer_ok)),
+        patch.object(ms, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)),
+        patch.object(ms, "_deliver", sent),
+    ):
+        outcome = asyncio.run(
+            ms.send_manual(
+                entity_type="alert",
+                entity_id=alert.id if alert else 1,
+                route_id=route.id if route else 1,
+                user=user,
+                session=AsyncMock(),
+                include_ai_report=include_ai_report,
+            ),
+        )
+    return outcome, sent
+
+
+def _expect_denied(**kw):
+    with pytest.raises(HTTPException) as exc:
+        _send(**kw)
+    return exc.value
+
+
+# ── who may send where ────────────────────────────────────────────────────
+
+
+def test_an_analyst_cannot_send_to_a_customer_facing_route():
+    """Sending out to an end customer bypasses the severity and trigger filters
+    by definition, so it gets a second pair of eyes."""
+    err = _expect_denied(user=_user(ANALYST), alert=_alert(), route=_route(scope="customer"))
+    assert err.status_code == 403
+
+
+def test_an_admin_may_send_to_a_customer_facing_route():
+    outcome, sent = _send(user=_user(ADMIN), alert=_alert(), route=_route(scope="customer"))
+    assert outcome.status.value == "sent"
+    assert sent.await_count == 1
+
+
+def test_an_analyst_may_send_to_an_internal_route():
+    """Routine internal sharing stays frictionless."""
+    outcome, sent = _send(user=_user(ANALYST), alert=_alert(), route=_route(scope="internal", customer_code=None))
+    assert outcome.status.value == "sent"
+
+
+def test_a_customer_user_may_never_send():
+    """Portal users have no business pushing data anywhere."""
+    err = _expect_denied(user=_user(CUSTOMER_USER), alert=_alert(), route=_route(scope="internal", customer_code=None))
+    assert err.status_code == 403
+
+
+# ── tenancy ───────────────────────────────────────────────────────────────
+
+
+def test_a_route_belonging_to_another_customer_is_refused():
+    """The UI would never offer this pairing — which is exactly why the server
+    must reject it rather than trust the submitted route_id."""
+    err = _expect_denied(
+        user=_user(ADMIN),
+        alert=_alert(customer_code=OWNER),
+        route=_route(scope="customer", customer_code=OTHER),
+    )
+    assert err.status_code == 400
+    assert "customer" in err.detail.lower()
+
+
+def test_an_internal_route_is_not_bound_to_the_entitys_customer():
+    """Internal routes belong to no tenant, so the cross-tenant check must not
+    reject them for having no customer_code."""
+    outcome, _sent = _send(user=_user(ADMIN), alert=_alert(), route=_route(scope="internal", customer_code=None))
+    assert outcome.status.value == "sent"
+
+
+# ── object-level authorization ────────────────────────────────────────────
+
+
+def test_an_alert_the_user_cannot_see_is_refused():
+    """Without this, manual send becomes a read primitive: sending an alert to a
+    channel you can read is a way to view alerts the tag rules deny you."""
+    err = _expect_denied(user=_user(ADMIN), alert=_alert(), route=_route(), tag_ok=False)
+    assert err.status_code == 403
+
+
+def test_a_customer_the_user_cannot_access_is_refused():
+    err = _expect_denied(user=_user(ADMIN), alert=_alert(), route=_route(), customer_ok=False)
+    assert err.status_code == 403
+
+
+def test_a_missing_entity_is_a_404_not_a_500():
+    with patch.object(ms, "_load_entity", AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                ms.send_manual(
+                    entity_type="alert",
+                    entity_id=999,
+                    route_id=1,
+                    user=_user(ADMIN),
+                    session=AsyncMock(),
+                    include_ai_report=False,
+                ),
+            )
+    assert exc.value.status_code == 404
+
+
+# ── the AI opt-out gate ───────────────────────────────────────────────────
+
+
+def test_ai_report_cannot_be_attached_when_the_customer_opted_out():
+    """Otherwise this button is the hole in the opt-out that #1014 established —
+    an analyst could hand-deliver AI findings to a customer who declined them."""
+    err = _expect_denied(
+        user=_user(ADMIN),
+        alert=_alert(),
+        route=_route(scope="customer"),
+        ai_enabled=False,
+        include_ai_report=True,
+    )
+    assert err.status_code == 400
+    assert "ai" in err.detail.lower()
+
+
+def test_a_send_without_the_ai_report_is_unaffected_by_the_gate():
+    """The gate governs AI-written content, not every notification."""
+    outcome, _sent = _send(
+        user=_user(ADMIN),
+        alert=_alert(),
+        route=_route(scope="customer"),
+        ai_enabled=False,
+        include_ai_report=False,
+    )
+    assert outcome.status.value == "sent"
+
+
+def test_the_gate_does_not_apply_to_internal_routes():
+    """Keeping AI findings in-house is a supported configuration."""
+    outcome, _sent = _send(
+        user=_user(ADMIN),
+        alert=_alert(),
+        route=_route(scope="internal", customer_code=None),
+        ai_enabled=False,
+        include_ai_report=True,
+    )
+    assert outcome.status.value == "sent"
+
+
+# ── repeatability ─────────────────────────────────────────────────────────
+
+
+def test_every_manual_send_gets_a_unique_dedupe_key():
+    """DELIBERATE EXCEPTION to the engine's core idempotency rule.
+
+    Every other trigger dedupes so a repeat is a no-op. Manual send must be
+    repeatable — clicking "send" twice on purpose has to send twice — so the key
+    carries a uuid and each click is its own audit row.
+
+    If a future reader "fixes" this to match the other triggers, repeat sends
+    break silently. That is why this test exists.
+    """
+    first = ms.build_manual_event(entity_type="alert", entity_id=42, entity=_alert(), user=_user())
+    second = ms.build_manual_event(entity_type="alert", entity_id=42, entity=_alert(), user=_user())
+
+    assert first.dedupe_key != second.dedupe_key
+    assert first.dedupe_key.startswith("alert:42:manual:")
+
+
+def test_the_manual_event_records_who_sent_it():
+    """Who pushed which customer's data where is a compliance question."""
+    event = ms.build_manual_event(entity_type="alert", entity_id=42, entity=_alert(), user=_user(username="alice"))
+    assert event.actor_username == "alice"

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -1,6 +1,7 @@
 import type { FlaskBaseResponse } from "@/types/flask"
 import type {
 	DispatchOutcome,
+	ManualSendPayload,
 	NotificationChannelDescriptor,
 	NotificationDispatchLogEntry,
 	NotificationRoute,
@@ -43,6 +44,19 @@ export default {
 
 	deleteRoute(customerCode: string, routeId: number) {
 		return HttpClient.delete<FlaskBaseResponse>(`/customers/${customerCode}/notification_routes/${routeId}`)
+	},
+
+	// Pushes a specific alert or case to a route on demand. Sends a REAL
+	// notification: consumes quota, lands in the dispatch log, and is refused
+	// server-side if the caller lacks permission — the UI's greying-out is a
+	// courtesy, not the control.
+	manualSend(payload: ManualSendPayload) {
+		return HttpClient.post<FlaskBaseResponse & DispatchOutcome>(`/notifications/send`, payload)
+	},
+	// Renders what manualSend would deliver, without sending. Runs the same
+	// authorization, so it can't reveal an item the caller may not see.
+	manualSendPreview(payload: ManualSendPayload) {
+		return HttpClient.post<FlaskBaseResponse & { body: string }>(`/notifications/send/preview`, payload)
 	},
 
 	// Sends a REAL notification through the route — consumes provider quota and

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationDispatchLog.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationDispatchLog.vue
@@ -78,6 +78,18 @@ const columns = computed<DataTableColumns<DispatchLogEntry>>(() => [
 		render: row => String(formatDate(row.dispatched_at, dFormats.datetime))
 	},
 	{
+		// Manual and test sends consume the same quota and reach the same
+		// customers as automatic ones, so "who hand-sent data where" has to be
+		// answerable from this table rather than inferred from the trigger.
+		title: "Source",
+		key: "trigger_source",
+		width: 130,
+		render: row =>
+			row.trigger_source === "automatic"
+				? "automatic"
+				: `${row.trigger_source}${row.triggered_by ? ` · ${row.triggered_by}` : ""}`
+	},
+	{
 		// Entity rather than Alert: the log now records case and case-task
 		// events too, which carry no alert_id.
 		title: "Entity",

--- a/frontend/src/components/incidentManagement/alerts/AlertOverview.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertOverview.vue
@@ -157,6 +157,20 @@
 			>
 				<AlertCreateCaseButton v-if="!linkedCases.length" :alert @updated="updateAlert" />
 
+				<n-button size="small" secondary @click="showManualSend = true">
+					<template #icon>
+						<Icon :name="SendIcon" :size="14" />
+					</template>
+					Send to channel…
+				</n-button>
+
+				<ManualSendDialog
+					v-model:show="showManualSend"
+					entity-type="alert"
+					:entity-id="alert.id"
+					:customer-code="alert.customer_code"
+				/>
+
 				<AlertMergeCaseButton v-if="!linkedCases.length" :alerts="[alert]" @updated="updateAlert" />
 
 				<div v-if="linkedCases.length" class="flex flex-wrap items-center gap-3">
@@ -193,6 +207,7 @@ import Api from "@/api"
 import CardKV from "@/components/common/cards/CardKV.vue"
 import EntityDetailsButton from "@/components/common/EntityDetailsButton.vue"
 import Icon from "@/components/common/Icon.vue"
+import ManualSendDialog from "@/components/notifications/ManualSendDialog.vue"
 import { useNavigation } from "@/composables/useNavigation"
 import { getApiErrorMessage } from "@/utils"
 import AssigneeIcon from "../common/AssigneeIcon.vue"
@@ -212,6 +227,9 @@ const AlertMergeCaseButton = defineAsyncComponent(() => import("./AlertMergeCase
 const AlertLinkedCases = defineAsyncComponent(() => import("./AlertLinkedCases.vue"))
 
 const { alert } = toRefs(props)
+
+const SendIcon = "carbon:send-alt"
+const showManualSend = ref(false)
 
 const TrashIcon = "carbon:trash-can"
 const LinkIcon = "carbon:launch"

--- a/frontend/src/components/incidentManagement/cases/CaseItem.vue
+++ b/frontend/src/components/incidentManagement/cases/CaseItem.vue
@@ -180,6 +180,24 @@
 										size="tiny"
 										@invoked="getCase(caseEntity.id)"
 									/>
+									<!--
+										Distinct from the button above, which fires the LEGACY
+										per-customer Shuffle workflow with no channel choice.
+										That one is deliberately untouched; this one targets the
+										notification routes.
+									-->
+									<n-button quaternary size="tiny" @click="showManualSend = true">
+										<template #icon>
+											<Icon :name="SendIcon" :size="13" />
+										</template>
+										Send to channel…
+									</n-button>
+									<ManualSendDialog
+										v-model:show="showManualSend"
+										entity-type="case"
+										:entity-id="caseEntity.id"
+										:customer-code="caseEntity.customer_code"
+									/>
 								</div>
 							</template>
 							<div class="flex flex-col gap-2">
@@ -243,6 +261,7 @@ import Badge from "@/components/common/Badge.vue"
 import CardEntity from "@/components/common/cards/CardEntity.vue"
 import EntityDetailsButton from "@/components/common/EntityDetailsButton.vue"
 import Icon from "@/components/common/Icon.vue"
+import ManualSendDialog from "@/components/notifications/ManualSendDialog.vue"
 import { useNavigation } from "@/composables/useNavigation"
 import { useSettingsStore } from "@/stores/settings"
 import { getApiErrorMessage } from "@/utils"
@@ -274,7 +293,10 @@ const emit = defineEmits<{
 const { caseData, caseId, compact, embedded, detailsOnMounted, highlight } = toRefs(props)
 
 const LinkIcon = "carbon:launch"
+const SendIcon = "carbon:send-alt"
 const EditIcon = "uil:edit-alt"
+
+const showManualSend = ref(false)
 
 const { routeCustomer, routeIncidentManagementCases } = useNavigation()
 const dialog = useDialog()

--- a/frontend/src/components/notifications/ManualSendDialog.vue
+++ b/frontend/src/components/notifications/ManualSendDialog.vue
@@ -1,0 +1,228 @@
+<template>
+	<n-modal
+		v-model:show="visible"
+		preset="card"
+		:title="`Send ${entityLabel} to a channel`"
+		class="max-w-2xl"
+		:bordered="false"
+		segmented
+	>
+		<n-spin :show="loadingRoutes">
+			<div class="flex flex-col gap-4">
+				<n-alert type="info" :bordered="false">
+					This sends a <strong>real notification</strong> now — it consumes provider quota and is recorded
+					in the dispatch log, exactly like an automatic one.
+				</n-alert>
+
+				<n-form-item label="Send to" :show-feedback="false">
+					<n-select
+						v-model:value="routeId"
+						:options="routeOptions"
+						:loading="loadingRoutes"
+						placeholder="Pick a configured route"
+						@update:value="onRouteChange"
+					/>
+				</n-form-item>
+
+				<!--
+					Customer routes are shown-but-disabled for non-admins rather than
+					hidden: the capability stays discoverable, and someone who needs it
+					knows to ask. The server enforces this regardless.
+				-->
+				<div v-if="!isAdmin" class="text-secondary text-xs">
+					Sending to a customer-facing route requires admin. Internal routes are available to you.
+				</div>
+
+				<div v-if="!loadingRoutes && !routeOptions.length" class="text-secondary text-sm">
+					No routes are configured yet. Add one under
+					<strong>Customers → Notifications</strong>
+					or
+					<strong>Internal Notifications</strong>.
+				</div>
+
+				<n-form-item v-if="selectedRoute" :show-feedback="false">
+					<n-checkbox v-model:checked="includeAiReport">Include the AI investigation report</n-checkbox>
+				</n-form-item>
+
+				<div v-if="preview !== null" class="flex flex-col gap-1">
+					<div class="text-secondary text-xs uppercase">Preview — exactly what will be sent</div>
+					<n-input
+						:value="preview"
+						type="textarea"
+						readonly
+						:autosize="{ minRows: 4, maxRows: 14 }"
+						class="font-mono text-xs!"
+					/>
+				</div>
+
+				<n-alert v-if="previewError" type="warning" :bordered="false">{{ previewError }}</n-alert>
+			</div>
+		</n-spin>
+
+		<template #footer>
+			<div class="flex items-center justify-end gap-2">
+				<n-button @click="visible = false">Cancel</n-button>
+				<n-button secondary :disabled="!routeId" :loading="previewing" @click="loadPreview">
+					Preview
+				</n-button>
+				<n-button type="primary" :disabled="!routeId" :loading="sending" @click="send">
+					<template #icon>
+						<Icon :name="SendIcon" :size="14" />
+					</template>
+					Send now
+				</n-button>
+			</div>
+		</template>
+	</n-modal>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { NotificationRoute } from "@/types/notifications"
+import { NAlert, NButton, NCheckbox, NFormItem, NInput, NModal, NSelect, NSpin, useMessage } from "naive-ui"
+import { computed, ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { useAuthStore } from "@/stores/auth"
+import { getApiErrorMessage } from "@/utils"
+
+// One dialog for both alerts and cases — they differ only in what is being sent,
+// so a second component would be the same code with one string changed.
+//
+// Everything enforced here is ALSO enforced server-side: the customer/internal
+// split, the admin requirement, the tenant match, and the AI opt-out. This is
+// affordance, not access control — see app/notifications/services/manual_send.py.
+
+const props = defineProps<{
+	entityType: "alert" | "case"
+	entityId: number
+	// Used to narrow the route list. An item's own customer plus internal routes
+	// are the only valid targets; the server re-checks the one that's submitted.
+	customerCode?: string | null
+}>()
+
+const visible = defineModel<boolean>("show", { default: false })
+
+const SendIcon = "carbon:send-alt"
+
+const message = useMessage()
+const authStore = useAuthStore()
+
+const routes = ref<NotificationRoute[]>([])
+const routeId = ref<number | null>(null)
+const includeAiReport = ref(false)
+const preview = ref<string | null>(null)
+const previewError = ref<string | null>(null)
+const loadingRoutes = ref(false)
+const previewing = ref(false)
+const sending = ref(false)
+
+const isAdmin = computed(() => authStore.isAdmin)
+const entityLabel = computed(() => (props.entityType === "alert" ? "alert" : "case"))
+const selectedRoute = computed(() => routes.value.find(r => r.id === routeId.value) ?? null)
+
+const routeOptions = computed(() =>
+	routes.value.map(route => {
+		const isCustomerRoute = route.scope === "customer"
+		// Disabled rather than absent, with the reason in the label — a missing
+		// option looks like a bug, a disabled one explains itself.
+		const blocked = isCustomerRoute && !isAdmin.value
+		return {
+			label: `${route.name} · ${route.channel}${isCustomerRoute ? "" : " (internal)"}${blocked ? " — admin only" : ""}`,
+			value: route.id,
+			disabled: blocked || !route.enabled
+		}
+	})
+)
+
+async function loadRoutes() {
+	loadingRoutes.value = true
+	routes.value = []
+	try {
+		// An item can only target its own customer's routes plus internal ones.
+		// Both lists are fetched because they live at different endpoints —
+		// internal routes belong to no tenant and sit outside /customers/.
+		const requests: Promise<NotificationRoute[]>[] = []
+
+		if (props.customerCode) {
+			requests.push(
+				Api.notifications
+					.listRoutes(props.customerCode)
+					.then(res => (res.data.success ? res.data.routes : []))
+					.catch(() => [])
+			)
+		}
+		requests.push(
+			Api.notifications
+				.getInternalRoutes()
+				.then(res => (res.data.success ? res.data.routes : []))
+				// Non-admins are refused this endpoint; an empty list is the right
+				// outcome, not an error worth showing.
+				.catch(() => [])
+		)
+
+		routes.value = (await Promise.all(requests)).flat()
+	} finally {
+		loadingRoutes.value = false
+	}
+}
+
+function onRouteChange() {
+	// A preview belongs to one route; keeping a stale one would show the operator
+	// something other than what they're about to send.
+	preview.value = null
+	previewError.value = null
+}
+
+function payload() {
+	return {
+		entity_type: props.entityType,
+		entity_id: props.entityId,
+		route_id: routeId.value as number,
+		include_ai_report: includeAiReport.value
+	}
+}
+
+async function loadPreview() {
+	previewing.value = true
+	previewError.value = null
+	try {
+		const res = await Api.notifications.manualSendPreview(payload())
+		preview.value = res.data.body
+	} catch (err) {
+		preview.value = null
+		previewError.value = getApiErrorMessage(err as ApiError) || "Could not render a preview."
+	} finally {
+		previewing.value = false
+	}
+}
+
+async function send() {
+	sending.value = true
+	try {
+		const res = await Api.notifications.manualSend(payload())
+		if (res.data.status === "sent") {
+			message.success(`Sent via ${res.data.channel} in ${res.data.latency_ms ?? "?"}ms`)
+			visible.value = false
+		} else {
+			// A refused or failed delivery is information, not an exception — the
+			// endpoint reports the outcome and the reason belongs on screen.
+			message.warning(res.data.error_message || `Send ${res.data.status}`)
+		}
+	} catch (err) {
+		message.error(getApiErrorMessage(err as ApiError) || "Failed to send.")
+	} finally {
+		sending.value = false
+	}
+}
+
+watch(visible, isOpen => {
+	if (isOpen) {
+		routeId.value = null
+		includeAiReport.value = false
+		preview.value = null
+		previewError.value = null
+		loadRoutes()
+	}
+})
+</script>

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -62,6 +62,17 @@ export interface ResendChannelConfig extends ChannelConfig {
 	max_per_hour?: number | null
 }
 
+export type NotificationTriggerSource = "automatic" | "manual" | "test"
+
+export interface ManualSendPayload {
+	entity_type: "alert" | "case"
+	entity_id: number
+	// Always a configured route. There is deliberately no free-text destination:
+	// routes are admin-managed and carry validated config.
+	route_id: number
+	include_ai_report?: boolean
+}
+
 export interface DispatchOutcome {
 	route_id: number
 	route_name: string
@@ -172,6 +183,9 @@ export interface NotificationDispatchLogEntry {
 	payload_preview: string | null
 	// Vendor-side delivery id — Shuffle execution id, Resend message id, etc.
 	provider_reference: string | null
+	// Who caused this, when a person did. Null for automatic dispatches.
+	triggered_by: string | null
+	trigger_source: NotificationTriggerSource
 }
 
 // ----- Shuffle integrations (Phase 2) -----


### PR DESCRIPTION
Closes #1010. Two commits — backend guardrails, then the UI that mirrors them.

Lets an analyst push a specific alert or case to a configured route on demand. Every other notification is *triggered*; this one is *chosen*, and bypasses the trigger and severity filters that govern everything else.

## This is a data egress control point

Not a convenience feature. Someone with the button can push a customer's alert outward. The guardrails are the substance of the change:

| Guard | Why |
|---|---|
| **Configured routes only** | No free-text destination field exists. A "send to this address" box would make this an arbitrary exfiltration tool. |
| **Admin for customer-facing targets** | Sending outward skips the filters by definition. Internal sharing stays open to analysts; portal users are refused outright. |
| **`route_id` re-validated against the item's tenant** | The picker only offers matching routes, but the id arrives from the client. The cross-tenant pairing the UI would never present is exactly the one worth checking. |
| **Object-level authorization on the item** | Without it this is a *read primitive* — sending an alert to a channel you can read reveals alerts the tag rules deny you. |
| **The #1014 AI opt-out applies** | Otherwise this is the hole in that control: an analyst hand-delivering AI findings to a customer who declined them. |

All enforced **in the service**, not in a route dependency — so they hold for any caller and sit in one auditable place.

## The tests were written first

Against a module that didn't exist. I confirmed they failed with `ModuleNotFoundError` before writing a line of the service.

The issue insisted on this, and it was right: prose saying "enforce server-side" decays into "the UI hides it". A red test does not.

## The dedupe exception

Manual send carries a **uuid in its dedupe key** — a deliberate exception to the engine's core idempotency rule. Every other trigger dedupes so a repeat is a no-op; manual send must be repeatable, because clicking send twice on purpose has to send twice.

The comment saying *don't "fix" this* ships in the same commit as the bypass and names the test that catches it.

## Preview

Runs **identical authorization** to the send. A preview that skipped the checks would be its own read primitive — showing an alert's contents to someone who may not see the alert.

It renders the route's own template against the **real item**, not a sample event. For an egress action, seeing the actual payload is the point.

## Audit

Adds `triggered_by` and `trigger_source` to the dispatch log (migration `d1a7c4e2f905`, additive, existing rows backfilled to `automatic`).

"Who sent which customer's data where" is a compliance question the log previously couldn't answer — every row looked alike whether fired by an alert landing or a person clicking a button. The viewer now shows `manual · taylor` against `automatic`.

## Refactor worth noting

`deliver_one` is **extracted rather than duplicated**. Send-test and manual send now share one delivery path, so they can't drift on rendering, failure containment or logging.

## UI decisions

- **Customer routes are shown disabled for non-admins, not hidden**, labelled "admin only". A missing option reads as a bug; a disabled one explains itself and keeps the capability discoverable.
- **The dialog says up front that this sends a real notification** consuming quota, rather than letting someone discover that after clicking.
- **On the case view the new button sits beside the legacy** *Invoke Customer Notification*, with a comment marking the distinction. That one fires the old per-customer Shuffle workflow and stays untouched, as agreed in #1000 §M.

One shared dialog serves both entity types — they differ only in what's being sent.

## Verified against the dev database

With the provider stubbed, so nothing left the process; the log rows are real:

```
analyst -> customer-facing route     refused 403
genuinely mismatched alert/route     refused 400   <- caught on real data,
                                                      not a fixture
preview (admin)                      rendered the route's stored template
                                     against the real alert
send #1 / send #2 (repeat)           both sent, DISTINCT dedupe keys,
                                     two audit rows, triggered_by=taylor
```

That repeat-send line is the idempotency exception working — every other trigger would have made the second click a no-op.

## Testing

```
14 new     tests/test_notification_manual_send_authz.py
346 passed backend tests/
type-check exit 0 · eslint clean · pre-commit clean
```

The authz file covers who may send where, cross-tenant refusal, both object-access paths, the AI gate on and off, internal routes being exempt from it, 404 on a missing entity, and the unique-key-per-send contract.
