### PR TITLE
feat(notifications): named, reusable message templates

### DIFF
--- a/backend/alembic/versions/e5b8f31d0c47_add_notification_template.py
+++ b/backend/alembic/versions/e5b8f31d0c47_add_notification_template.py
@@ -1,0 +1,95 @@
+"""add notification_template and route.template_id
+
+Revision ID: e5b8f31d0c47
+Revises: d1a7c4e2f905
+Create Date: 2026-08-02 18:20:00.000000
+
+#1037 made route.format_template real Jinja, but it stays per-route: every route
+re-pastes its own copy, with no reuse and no way to offer per-language variants.
+This adds the shared, named version.
+
+See issue #1038.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e5b8f31d0c47"
+down_revision: Union[str, None] = "d1a7c4e2f905"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_template",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("description", sa.String(length=512), nullable=True),
+        # NULL = usable with any trigger. Set = only offered for that one, so a
+        # template written around {{assignee}} can't be attached to a trigger
+        # where that variable is always empty.
+        sa.Column("trigger", sa.String(length=64), nullable=True),
+        # No server_default on this or `is_default`: the table is new, so there
+        # are no existing rows to backfill, and the model carries Python-side
+        # defaults. (The previous revision needed one only because it added a
+        # NOT NULL column to a populated table.)
+        sa.Column("format", sa.String(length=16), nullable=False),
+        # First-class rather than smuggled into the body: email needs a subject
+        # and Teams needs a card title, and neither is derivable from body text.
+        sa.Column("subject_template", sa.Text(), nullable=True),
+        sa.Column("body_template", sa.Text(), nullable=False),
+        # NULL = shared with every customer, set = that tenant only. Same
+        # convention as custom_dashboard_templates. varchar(64) against a
+        # varchar(50) parent, matching the AiAnalyst* tables — MySQL only
+        # requires compatible string types for an FK, not identical lengths.
+        sa.Column("customer_code", sa.String(length=64), nullable=True),
+        sa.Column("is_default", sa.Boolean(), nullable=False),
+        sa.Column("created_by", sa.String(length=128), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["customer_code"], ["customers.customer_code"]),
+    )
+    op.create_index("ix_notification_template_trigger", "notification_template", ["trigger"])
+    op.create_index("ix_notification_template_customer_code", "notification_template", ["customer_code"])
+    op.create_index("ix_notification_template_created_at", "notification_template", ["created_at"])
+
+    # Nullable FK with NO cascade, deliberately. Deleting a template must not
+    # delete the routes using it — `delete_template` clears the reference and
+    # reports how many routes were affected, so those routes fall back to their
+    # inline template or the channel default rather than vanishing.
+    op.add_column(
+        "customer_notification_route",
+        sa.Column("template_id", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_customer_notification_route_template_id", "customer_notification_route", ["template_id"])
+    op.create_foreign_key(
+        "fk_notification_route_template",
+        "customer_notification_route",
+        "notification_template",
+        ["template_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    """Drops the FK first, then the column, then the table — reverse dependency
+    order, or MySQL refuses to drop a table another still references.
+
+    Lossy only for templates themselves. Routes keep their inline
+    `format_template` and channel defaults, so notifications continue after a
+    downgrade; they simply stop using any shared template.
+    """
+    op.drop_constraint("fk_notification_route_template", "customer_notification_route", type_="foreignkey")
+    op.drop_index("ix_customer_notification_route_template_id", table_name="customer_notification_route")
+    op.drop_column("customer_notification_route", "template_id")
+
+    op.drop_index("ix_notification_template_created_at", table_name="notification_template")
+    op.drop_index("ix_notification_template_customer_code", table_name="notification_template")
+    op.drop_index("ix_notification_template_trigger", table_name="notification_template")
+    op.drop_table("notification_template")

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -963,6 +963,12 @@ class CustomerNotificationRoute(SQLModel, table=True):
     # management. Populated from the auth context in the route handler.
     created_by: Optional[str] = Field(default=None, max_length=128)
 
+    # A named template from `notification_template`, or NULL to use the inline
+    # `format_template` / channel default. Plain nullable FK: deleting a template
+    # must not cascade away the routes using it, so the CRUD layer clears this
+    # instead — see `delete_template`.
+    template_id: Optional[int] = Field(default=None, foreign_key="notification_template.id", index=True)
+
     # Per-channel settings, as a JSON string validated against the provider's
     # declared `config_schema`. This replaced a column-per-channel-per-setting
     # scheme that required a migration for every new channel; adding one is now
@@ -999,6 +1005,59 @@ class CustomerNotificationRoute(SQLModel, table=True):
     # (`session.get(...)`) when we need them.
     dispatches: list["NotificationDispatchLog"] = Relationship(sa_relationship_kwargs={"overlaps": "route"})
     shuffle_integration: Optional["CustomerShuffleIntegration"] = Relationship(sa_relationship_kwargs={"overlaps": "routes"})
+
+
+class NotificationTemplate(SQLModel, table=True):
+    """A named, reusable message template.
+
+    #1037 made `customer_notification_route.format_template` real Jinja, but it
+    stays per-route: every route re-pastes its own copy, with no reuse and no way
+    to offer per-language variants. This is the shared version.
+
+    Precedence at render time is inline -> named -> channel default. The inline
+    field survives as a per-route one-off override, so a template attached here
+    can still be overridden for a single route without editing the shared copy.
+    """
+
+    __tablename__ = "notification_template"
+
+    id: Optional[int] = Field(primary_key=True)
+    name: str = Field(max_length=128, nullable=False)
+    description: Optional[str] = Field(default=None, max_length=512)
+
+    # NULL = usable with any trigger. Set = only offered for that one, so a
+    # template written around {{assignee}} isn't attachable to alert_created
+    # where that variable is empty.
+    #
+    # Also what lets #999 (temporary-password emails) reuse this table later as
+    # a second event source rather than building a parallel one.
+    trigger: Optional[str] = Field(default=None, max_length=64, index=True)
+
+    # html | text | markdown | json. Drives autoescaping and which channels can
+    # accept the template — a Teams card can't render an HTML body.
+    format: str = Field(default="text", max_length=16, nullable=False)
+
+    # First-class rather than smuggled into the body: email needs a subject and
+    # Teams needs a card title, and neither is derivable from message text.
+    subject_template: Optional[str] = Field(sa_column=Column(Text), default=None)
+    body_template: str = Field(sa_column=Column(Text, nullable=False))
+
+    # NULL = shared with every customer, set = that tenant only. Same convention
+    # as custom_dashboard_templates.
+    customer_code: Optional[str] = Field(
+        default=None,
+        foreign_key="customers.customer_code",
+        max_length=64,
+        index=True,
+    )
+
+    # Seeded built-ins. Kept as data rather than code so an operator can copy one
+    # as a starting point instead of writing a template from a blank box.
+    is_default: bool = Field(default=False, nullable=False)
+
+    created_by: Optional[str] = Field(default=None, max_length=128)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: Optional[datetime] = Field(default=None)
 
 
 class NotificationDispatchLog(SQLModel, table=True):

--- a/backend/app/notifications/channels/base.py
+++ b/backend/app/notifications/channels/base.py
@@ -59,6 +59,39 @@ class SendResult(BaseModel):
         return cls(status="skipped", error_message=message, latency_ms=latency_ms)
 
 
+class RenderedMessage(BaseModel):
+    """What the dispatch loop hands a provider to deliver.
+
+    Was a bare ``rendered_body`` string until named templates (#1038) gave a
+    message two more properties a channel has to know about: its ``format``
+    (only email can render HTML; a chat card would show the markup) and an
+    optional ``subject`` from the template's own subject line, which overrides
+    whatever the channel would have composed.
+
+    One object rather than three keyword arguments, so a channel that later
+    needs a fourth property doesn't change every provider signature again.
+    """
+
+    body: str
+
+    #: 'text' | 'markdown' | 'html' | 'json'. Providers declare what they accept
+    #: via ``ChannelProvider.template_formats``; this is what was actually
+    #: rendered, which for the channel default is always plain text.
+    format: str = "text"
+
+    #: From the named template's ``subject_template``. None means the provider
+    #: composes its own — the pre-#1038 behaviour, which every route without a
+    #: named template still gets.
+    subject: Optional[str] = None
+
+    #: Whether ``body`` is operator-authored rather than the channel default.
+    #: Teams and webhook branch on this — a hand-written body is sent verbatim
+    #: instead of being restructured into a card or a JSON envelope. Providers
+    #: used to derive it from ``route.format_template``, which named templates
+    #: made wrong: a route can now have a custom body with that column empty.
+    is_custom: bool = False
+
+
 class DispatchContext:
     """Per-dispatch-call shared state.
 
@@ -128,6 +161,12 @@ class ChannelProvider(ABC):
     #: #1020; declared here so providers own the classification.
     secret_fields: ClassVar[Set[str]] = set()
 
+    #: Named-template formats (#1038) this channel can actually render. Chat
+    #: channels take text or markdown; only email renders HTML. Declared so
+    #: attaching an unrenderable template is a 400 at save time rather than a
+    #: route that silently falls back to the default forever.
+    template_formats: ClassVar[Set[str]] = {"text", "markdown"}
+
     def parse_config(self, route: Any) -> ChannelConfig:
         """Validate and return this route's config.
 
@@ -152,7 +191,7 @@ class ChannelProvider(ABC):
         *,
         route: Any,
         event: NotificationEvent,
-        rendered_body: str,
+        message: RenderedMessage,
         ctx: DispatchContext,
     ) -> SendResult:
         """Deliver one notification.

--- a/backend/app/notifications/channels/resend.py
+++ b/backend/app/notifications/channels/resend.py
@@ -31,6 +31,7 @@ from app.connectors.utils import get_connector_info_from_db
 from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import dispatch_resend
@@ -121,13 +122,17 @@ class ResendChannel(ChannelProvider):
     supports_recipient_modes = {"static", "assignee"}
     # Empty: the API key is on the connector row, not in route config.
     secret_fields = set()
+    # The only channel that renders HTML: an `html` template is posted as both
+    # the `html` and `text` parts, so it arrives formatted and still degrades to
+    # readable text. A chat card would show the markup instead.
+    template_formats = {"text", "markdown", "html"}
 
     async def send(
         self,
         *,
         route: Any,
         event: NotificationEvent,
-        rendered_body: str,
+        message: RenderedMessage,
         ctx: DispatchContext,
     ) -> SendResult:
         # Read every attribute before the first await — an expired ORM object
@@ -170,7 +175,15 @@ class ResendChannel(ChannelProvider):
                     f"Rate limit reached for this route ({recent}/{cfg.max_per_hour} in the last hour).",
                 )
 
-        subject = self._subject(cfg, event)
+        # A named template's subject line wins over the composed one — an
+        # operator who wrote a subject meant it. `subject_prefix` still applies,
+        # so deployment-wide inbox filtering on "[CoPilot]" keeps working.
+        subject = self._subject(cfg, event, override=message.subject)
+
+        # Email is the only channel that can render HTML, so an `html` template
+        # is sent as the HTML part with the same source as the text fallback.
+        # Clients that refuse HTML still get something readable.
+        is_html = message.format == "html"
 
         status, error_message, latency_ms, message_id = await dispatch_resend(
             base_url=base_url,
@@ -180,7 +193,8 @@ class ResendChannel(ChannelProvider):
             cc=cfg.cc or None,
             reply_to=cfg.reply_to,
             subject=subject,
-            text_body=rendered_body,
+            text_body=message.body,
+            html_body=message.body if is_html else None,
         )
         return SendResult(
             status=status,
@@ -221,12 +235,17 @@ class ResendChannel(ChannelProvider):
             return ([], SendResult.failed(f"Assignee '{username}' has no email address on their account."))
         return ([str(email)], None)
 
-    def _subject(self, cfg: ResendConfig, event: NotificationEvent) -> str:
+    def _subject(self, cfg: ResendConfig, event: NotificationEvent, *, override: Optional[str] = None) -> str:
         """Prefix + the event's one-line subject, with severity for scanability.
 
         Kept here rather than in the body renderer because a subject line is an
         email-specific concern — no other channel has one.
+
+        `override` is a named template's rendered `subject_template`. It replaces
+        the composed core but keeps the prefix: the prefix is a deployment-wide
+        inbox-filtering convention, and letting a per-customer template drop it
+        would silently break those filters.
         """
         prefix = (cfg.subject_prefix or "").strip()
-        core = f"{event.severity.value}: {event.subject}".strip()
+        core = (override or f"{event.severity.value}: {event.subject}").strip()
         return f"{prefix} {core}".strip() if prefix else core

--- a/backend/app/notifications/channels/shuffle.py
+++ b/backend/app/notifications/channels/shuffle.py
@@ -25,6 +25,7 @@ from app.db.universal_models import CustomerShuffleIntegration
 from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import dispatch_shuffle
@@ -92,7 +93,7 @@ class ShuffleChannel(ChannelProvider):
         *,
         route: Any,
         event: NotificationEvent,
-        rendered_body: str,
+        message: RenderedMessage,
         ctx: DispatchContext,
     ) -> SendResult:
         # Read every attribute before the first await — an expired ORM object
@@ -140,7 +141,7 @@ class ShuffleChannel(ChannelProvider):
 
         # Shuffle's input_text is natural language. We prepend a
         # "send to {destination}" hint so the app agent knows where to deliver.
-        input_text = f"Send to {destination}: {rendered_body}" if destination else rendered_body
+        input_text = f"Send to {destination}: {message.body}" if destination else message.body
 
         status, error_message, latency_ms, execution_id = await dispatch_shuffle(
             base_url=base_url,

--- a/backend/app/notifications/channels/teams.py
+++ b/backend/app/notifications/channels/teams.py
@@ -34,6 +34,7 @@ from pydantic import field_validator
 from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import TEAMS_MAX_PAYLOAD_BYTES
@@ -89,7 +90,7 @@ class TeamsChannel(ChannelProvider):
         *,
         route: Any,
         event: NotificationEvent,
-        rendered_body: str,
+        message: RenderedMessage,
         ctx: DispatchContext,
     ) -> SendResult:
         # Read attributes before the first await — an expired ORM object would
@@ -103,8 +104,8 @@ class TeamsChannel(ChannelProvider):
         if not cfg.webhook_url:
             return SendResult.failed("Route config has no webhook_url (data integrity issue)")
 
-        card = self._build_card(event, rendered_body, raw_body=has_template)
-        card = self._fit_within_size_limit(card, event, rendered_body)
+        card = self._build_card(event, message.body, raw_body=has_template)
+        card = self._fit_within_size_limit(card, event, message.body)
 
         status, error_message, latency_ms, _ = await dispatch_teams(webhook_url=cfg.webhook_url, card=card)
         return SendResult(status=status, error_message=error_message, latency_ms=latency_ms)

--- a/backend/app/notifications/channels/webhook.py
+++ b/backend/app/notifications/channels/webhook.py
@@ -20,6 +20,7 @@ from pydantic import field_validator
 from app.notifications.channels.base import ChannelConfig
 from app.notifications.channels.base import ChannelProvider
 from app.notifications.channels.base import DispatchContext
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import dispatch_webhook
@@ -100,12 +101,12 @@ class WebhookChannel(ChannelProvider):
         *,
         route: Any,
         event: NotificationEvent,
-        rendered_body: str,
+        message: RenderedMessage,
         ctx: DispatchContext,
     ) -> SendResult:
         # Read every attribute before the first await — an expired ORM object
         # would otherwise trigger a synchronous refresh and MissingGreenlet.
-        has_template = bool(route.format_template)
+        has_template = message.is_custom
         try:
             cfg = self.parse_config(route)
         except ValueError as e:
@@ -130,7 +131,7 @@ class WebhookChannel(ChannelProvider):
             "severity": event.severity.value,
             "summary": event.summary,
             "report_url": event.link_url,
-            "text": rendered_body,
+            "text": message.body,
         }
 
         # Two mutually-exclusive body modes (enforced in the UI, guarded here):
@@ -145,7 +146,7 @@ class WebhookChannel(ChannelProvider):
             if report_fields is not None:
                 structured_payload.update(report_fields)
         elif has_template:
-            rendered_template = rendered_body
+            rendered_template = message.body
             if "{{report}}" in rendered_template:
                 report_fields = await self._report(event, ctx)
                 rendered_template = rendered_template.replace(

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -43,6 +43,11 @@ from app.notifications.schema.notifications import NotificationRouteListResponse
 from app.notifications.schema.notifications import NotificationRouteRead
 from app.notifications.schema.notifications import NotificationRouteResponse
 from app.notifications.schema.notifications import NotificationRouteUpdate
+from app.notifications.schema.notifications import NotificationTemplateCreate
+from app.notifications.schema.notifications import NotificationTemplateListResponse
+from app.notifications.schema.notifications import NotificationTemplateRead
+from app.notifications.schema.notifications import NotificationTemplateResponse
+from app.notifications.schema.notifications import NotificationTemplateUpdate
 from app.notifications.schema.notifications import ResendQuotaResponse
 from app.notifications.schema.notifications import ShuffleAppListResponse
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
@@ -52,7 +57,10 @@ from app.notifications.schema.notifications import ShuffleIntegrationResponse
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
 from app.notifications.schema.notifications import ShuffleOrgListResponse
 from app.notifications.schema.notifications import ShuffleVerifyResponse
+from app.notifications.schema.notifications import TemplatePreviewRequest
+from app.notifications.schema.notifications import TemplatePreviewResponse
 from app.notifications.services import notifications as svc
+from app.notifications.services import templates as templates_svc
 
 notifications_router = APIRouter()
 
@@ -228,7 +236,7 @@ async def manual_send_preview_route(
 ):
     from app.notifications.services.manual_send import preview_manual
 
-    body = await preview_manual(
+    rendered = await preview_manual(
         entity_type=payload.entity_type,
         entity_id=payload.entity_id,
         route_id=payload.route_id,
@@ -236,7 +244,14 @@ async def manual_send_preview_route(
         session=session,
         include_ai_report=payload.include_ai_report,
     )
-    return {"success": True, "message": "Preview rendered", "body": body}
+    return {
+        "success": True,
+        "message": "Preview rendered",
+        "body": rendered.body,
+        # Null unless a named template set one; the provider composes its own
+        # in that case, which this preview deliberately does not guess at.
+        "subject": rendered.subject,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +346,7 @@ async def list_channels_route() -> ChannelListResponse:
             supports_recipient_modes=sorted(provider.supports_recipient_modes),
             supports_internal_scope=provider.supports_internal_scope,
             secret_fields=sorted(provider.secret_fields),
+            template_formats=sorted(provider.template_formats),
         )
         for provider in CHANNEL_REGISTRY.values()
     ]
@@ -574,3 +590,146 @@ async def dispatch_route(
         f"severity {payload.severity_assessment.value}",
     )
     return await svc.dispatch(payload, session)
+
+
+# ---------------------------------------------------------------------------
+# Named message templates (#1038)
+# ---------------------------------------------------------------------------
+#
+# Deployment-level rather than nested under /customers/{code}: a template with a
+# null customer_code is shared with every tenant, so there is no one customer it
+# belongs under. The optional `customer_code` query param filters the list to
+# one customer's own templates plus the shared ones.
+
+
+@notifications_router.get(
+    "/notifications/templates",
+    response_model=NotificationTemplateListResponse,
+    description=(
+        "List reusable message templates. Filter to a customer (returns their own plus the shared ones) "
+        "and/or to a trigger (returns templates scoped to it plus the trigger-agnostic ones)."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def list_templates_route(
+    customer_code: Optional[str] = None,
+    trigger: Optional[str] = None,
+    session: AsyncSession = Depends(get_db),
+) -> NotificationTemplateListResponse:
+    templates = await templates_svc.list_templates(session, customer_code=customer_code, trigger=trigger)
+    return NotificationTemplateListResponse(
+        success=True,
+        message=f"{len(templates)} template(s) retrieved",
+        templates=[NotificationTemplateRead.model_validate(t) for t in templates],
+    )
+
+
+@notifications_router.post(
+    "/notifications/templates/preview",
+    response_model=TemplatePreviewResponse,
+    description=(
+        "Render template source against a sample event without saving it. Takes the source inline so the "
+        "editor can preview unsaved edits. A render failure is returned in `error`, not raised."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def preview_template_route(
+    payload: TemplatePreviewRequest,
+    session: AsyncSession = Depends(get_db),
+) -> TemplatePreviewResponse:
+    result = await templates_svc.preview(payload, session)
+    return TemplatePreviewResponse(
+        success=result["error"] is None,
+        message="Rendered" if result["error"] is None else "Template failed to render",
+        **result,
+    )
+
+
+# Static paths above, wildcards below — a `/{template_id}` declared first would
+# swallow `/preview` and 422 on parsing it as an int. See CLAUDE.md.
+
+
+@notifications_router.get(
+    "/notifications/templates/{template_id}",
+    response_model=NotificationTemplateResponse,
+    description="Fetch one template.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def get_template_route(
+    template_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> NotificationTemplateResponse:
+    template = await templates_svc.get_template(template_id, session)
+    return NotificationTemplateResponse(
+        success=True,
+        message="Template retrieved",
+        template=NotificationTemplateRead.model_validate(template),
+    )
+
+
+@notifications_router.post(
+    "/notifications/templates",
+    response_model=NotificationTemplateResponse,
+    description="Create a reusable message template. Leave customer_code empty to share it with every customer.",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def create_template_route(
+    payload: NotificationTemplateCreate,
+    session: AsyncSession = Depends(get_db),
+    current_user: User = Depends(AuthHandler().get_current_user),
+) -> NotificationTemplateResponse:
+    created_by = getattr(current_user, "username", None) or str(current_user.id)
+    logger.info(f"User {created_by} creating notification template {payload.name!r}")
+    template = await templates_svc.create_template(payload, created_by, session)
+    return NotificationTemplateResponse(
+        success=True,
+        message="Template created",
+        template=NotificationTemplateRead.model_validate(template),
+    )
+
+
+@notifications_router.patch(
+    "/notifications/templates/{template_id}",
+    response_model=NotificationTemplateResponse,
+    description=(
+        "Update a template. Rejected if the change would break a route already using it, and built-in "
+        "templates cannot be edited — duplicate one instead."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def update_template_route(
+    template_id: int,
+    payload: NotificationTemplateUpdate,
+    session: AsyncSession = Depends(get_db),
+) -> NotificationTemplateResponse:
+    template = await templates_svc.update_template(template_id, payload, session)
+    return NotificationTemplateResponse(
+        success=True,
+        message="Template updated",
+        template=NotificationTemplateRead.model_validate(template),
+    )
+
+
+@notifications_router.delete(
+    "/notifications/templates/{template_id}",
+    response_model=NotificationTemplateResponse,
+    description=(
+        "Delete a template. Routes using it are detached rather than deleted — they fall back to their "
+        "inline template or the channel default, so notifications keep flowing."
+    ),
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def delete_template_route(
+    template_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> NotificationTemplateResponse:
+    template = await templates_svc.get_template(template_id, session)
+    # Snapshot before deletion: the ORM row is unusable for a response once the
+    # session has expunged it.
+    read = NotificationTemplateRead.model_validate(template)
+    detached = await templates_svc.delete_template(template_id, session)
+    return NotificationTemplateResponse(
+        success=True,
+        message=("Template deleted" + (f"; {detached} route(s) fell back to their channel default" if detached else "")),
+        template=read,
+    )

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -216,6 +216,13 @@ class NotificationRouteBase(BaseModel):
         default=None,
         description="Optional Jinja override for the message body. Leave empty to use the channel default.",
     )
+    # Precedence at render time is inline `format_template` -> this -> the
+    # channel default. The inline field stays as a per-route override so one
+    # route can deviate without forking the shared template.
+    template_id: Optional[int] = Field(
+        default=None,
+        description="ID of a named notification_template to render with. Ignored when format_template is set.",
+    )
     enabled: bool = True
 
     # Which audience this route serves. 'customer' delivers to the end
@@ -387,6 +394,10 @@ class NotificationRouteUpdate(BaseModel):
     destination: Optional[str] = None
     min_severity: Optional[NotificationSeverity] = None
     format_template: Optional[str] = None
+    # Nullable is meaningful: an explicit null detaches the named template and
+    # the route falls back to the channel default. `__fields_set__` is what
+    # distinguishes that from the field being omitted.
+    template_id: Optional[int] = None
     enabled: Optional[bool] = None
     scope: Optional[NotificationScope] = None
     recipient_mode: Optional[RecipientMode] = None
@@ -547,6 +558,10 @@ class ChannelDescriptor(BaseModel):
     supports_recipient_modes: List[str]
     supports_internal_scope: bool
     secret_fields: List[str]
+    # Named-template formats this channel can render. Advertised so the route
+    # form filters the template picker itself, rather than offering a template
+    # the server would then refuse.
+    template_formats: List[str] = []
 
 
 class ResendQuotaResponse(BaseModel):
@@ -668,3 +683,122 @@ class DispatchResponse(BaseModel):
     skipped: int
     failed: int
     outcomes: List[DispatchOutcome]
+
+
+# ---------------------------------------------------------------------------
+# Named message templates (#1038)
+# ---------------------------------------------------------------------------
+
+
+class TemplateFormat(str, Enum):
+    """How a template's output should be treated.
+
+    Only `resend` renders HTML — a chat card would show the markup — so a
+    provider declares what it accepts via `ChannelProvider.template_formats`
+    and attaching a mismatch is rejected at save time.
+    """
+
+    TEXT = "text"
+    MARKDOWN = "markdown"
+    HTML = "html"
+    JSON = "json"
+
+
+class NotificationTemplateBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=128, description="Human label shown in the route form's picker.")
+    description: Optional[str] = Field(default=None, max_length=512)
+
+    # Null means usable with any trigger. Setting it stops a template written
+    # around `{{assignee}}` from being attached where that variable is always
+    # empty — checked when it is attached, not when it fires.
+    trigger: Optional[NotificationTrigger] = Field(
+        default=None,
+        description="Restrict this template to one trigger. Leave empty to allow any.",
+    )
+    format: TemplateFormat = TemplateFormat.TEXT
+
+    # Separate from the body because it is not derivable from it: email needs a
+    # subject and a Teams card needs a title.
+    subject_template: Optional[str] = Field(
+        default=None,
+        description="Optional Jinja subject line. Channels that have no subject ignore it.",
+    )
+    body_template: str = Field(..., min_length=1, description="Jinja source for the message body.")
+
+    # Null means shared with every customer, matching custom_dashboard_templates.
+    customer_code: Optional[str] = Field(
+        default=None,
+        max_length=64,
+        description="Scope this template to one customer. Leave empty to share it with all of them.",
+    )
+
+
+class NotificationTemplateCreate(NotificationTemplateBase):
+    """Body for POST /notifications/templates."""
+
+
+class NotificationTemplateUpdate(BaseModel):
+    """Body for PATCH — every field optional.
+
+    `exclude_unset` in the service is what makes an omitted field mean "leave
+    it alone" rather than "set it to null", so clearing `trigger` back to
+    any-trigger requires sending an explicit null.
+    """
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=128)
+    description: Optional[str] = None
+    trigger: Optional[NotificationTrigger] = None
+    format: Optional[TemplateFormat] = None
+    subject_template: Optional[str] = None
+    body_template: Optional[str] = Field(default=None, min_length=1)
+    customer_code: Optional[str] = Field(default=None, max_length=64)
+
+
+class NotificationTemplateRead(NotificationTemplateBase):
+    id: int
+    # Built-ins are seeded at startup and are read-only: editing or deleting one
+    # is a 400, because the next startup would recreate it anyway.
+    is_default: bool = False
+    created_by: Optional[str] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class NotificationTemplateListResponse(BaseModel):
+    templates: List[NotificationTemplateRead] = []
+    success: bool
+    message: str
+
+
+class NotificationTemplateResponse(BaseModel):
+    template: NotificationTemplateRead
+    success: bool
+    message: str
+
+
+class TemplatePreviewRequest(BaseModel):
+    """Render a template against a sample event, without saving it.
+
+    Takes the source inline rather than a template id so the editor can preview
+    unsaved edits — the same reason the custom-dashboard builder previews an
+    unsaved panel set.
+    """
+
+    body_template: str = Field(..., min_length=1)
+    subject_template: Optional[str] = None
+    format: TemplateFormat = TemplateFormat.TEXT
+    trigger: NotificationTrigger = NotificationTrigger.ALERT_CREATED
+    # Drives the sample event's branding, so a template using `{{ branding.* }}`
+    # previews with the colours that customer would really receive.
+    customer_code: Optional[str] = None
+
+
+class TemplatePreviewResponse(BaseModel):
+    body: str
+    subject: Optional[str] = None
+    # Non-null when rendering failed. The preview reports it rather than 400-ing
+    # so the editor can show the error beside the template being written.
+    error: Optional[str] = None
+    success: bool
+    message: str

--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -218,15 +218,17 @@ async def dispatch_resend(
     text_body: str,
     cc: Optional[List[str]] = None,
     reply_to: Optional[str] = None,
+    html_body: Optional[str] = None,
 ) -> ResendDispatchResult:
     """Send one email via Resend's REST API.
 
     Returns (status, error_message, latency_ms, message_id). Never raises —
     the provider turns the result into a dispatch-log row.
 
-    Body is plain text only for now. Resend accepts `html` too, but the message
-    body CoPilot renders today is markdown-ish plain text; sending it as HTML
-    would show the markup. Real HTML arrives with templates (#1009).
+    `text_body` is always sent. `html_body` is set only for a named template
+    declaring `format="html"` (#1038); the default body is markdown-ish plain
+    text, and sending that as HTML would show the markup. When both are present
+    Resend delivers a multipart message and the client picks.
     """
     payload: Dict[str, Any] = {
         "from": from_address,
@@ -234,6 +236,8 @@ async def dispatch_resend(
         "subject": subject,
         "text": text_body,
     }
+    if html_body:
+        payload["html"] = html_body
     if cc:
         payload["cc"] = cc
     if reply_to:

--- a/backend/app/notifications/services/manual_send.py
+++ b/backend/app/notifications/services/manual_send.py
@@ -46,6 +46,7 @@ from app.db.universal_models import CustomerNotificationRoute
 from app.incidents.models import Alert
 from app.incidents.models import Case
 from app.incidents.services.alert_severity import severity_of
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.schema.events import EntityType
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.schema.notifications import DispatchOutcome
@@ -214,7 +215,7 @@ async def preview_manual(
     user: Any,
     session: AsyncSession,
     include_ai_report: bool = False,
-) -> str:
+) -> RenderedMessage:
     """Render what a send would deliver, without delivering it.
 
     Runs the **same authorization** as `send_manual`. A preview that skipped the
@@ -241,8 +242,11 @@ async def preview_manual(
     await _require_ai_report_permitted(route, entity, include_ai_report, session)
 
     event = build_manual_event(entity_type=entity_type, entity_id=entity_id, entity=entity, user=user)
-    body, _template_error = _render_body(route, event)
-    return body
+    message, _template_error = await _render_body(route, event, session)
+    # The whole message, not just the body: a named template can carry a
+    # subject, and a preview that hid it would misrepresent what an email
+    # recipient actually sees.
+    return message
 
 
 async def send_manual(

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -34,9 +36,11 @@ from app.customer_portal.services.ai_reports import is_ai_reports_enabled
 from app.db.universal_models import CustomerNotificationRoute
 from app.db.universal_models import CustomerShuffleIntegration
 from app.db.universal_models import NotificationDispatchLog
+from app.db.universal_models import NotificationTemplate
 from app.notifications.channels import DispatchContext
 from app.notifications.channels import SendResult
 from app.notifications.channels import get_channel
+from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.shuffle import get_shuffle_connector
 from app.notifications.schema.events import EntityType
 from app.notifications.schema.events import NotificationEvent
@@ -68,6 +72,9 @@ from app.notifications.services.dispatchers import (
     verify_shuffle_org as verify_shuffle_org_client,
 )
 from app.notifications.services.rendering import render_body
+from app.notifications.services.templates import assert_template_usable
+from app.notifications.services.templates import build_branding_context
+from app.notifications.services.templates import resolve_template_for_route
 
 # ---------------------------------------------------------------------------
 # CRUD
@@ -174,6 +181,15 @@ async def create_internal_route(
     if payload.scope != NotificationScope.INTERNAL:
         raise HTTPException(status_code=400, detail="This endpoint creates internal-scope routes only.")
 
+    if payload.template_id:
+        await assert_template_usable(
+            payload.template_id,
+            channel=payload.channel.value,
+            trigger=payload.trigger.value,
+            customer_code=None,
+            session=session,
+        )
+
     route = CustomerNotificationRoute(
         customer_code=None,
         scope=NotificationScope.INTERNAL.value,
@@ -185,6 +201,7 @@ async def create_internal_route(
         destination=payload.destination or "",
         min_severity=payload.min_severity.value,
         format_template=payload.format_template,
+        template_id=payload.template_id,
         enabled=payload.enabled,
         created_by=created_by,
         shuffle_integration_id=None,
@@ -238,6 +255,20 @@ async def update_internal_route(
                 ),
             )
 
+    # An explicit null detaches the template; only a real id needs checking.
+    # Re-checked when the channel or trigger changes too, because either can
+    # invalidate an attachment that was valid when it was made.
+    effective_template_id = data.get("template_id", route.template_id)
+    if effective_template_id and {"template_id", "channel", "trigger"} & data.keys():
+        new_trigger = data.get("trigger")
+        await assert_template_usable(
+            effective_template_id,
+            channel=new_channel_value,
+            trigger=new_trigger.value if hasattr(new_trigger, "value") else (new_trigger or route.trigger),
+            customer_code=None,
+            session=session,
+        )
+
     for field, value in data.items():
         if hasattr(value, "value"):
             value = value.value
@@ -273,6 +304,15 @@ async def create_route(
 
     resolved_code = _enforce_scope_invariant(payload.scope.value, customer_code)
 
+    if payload.template_id:
+        await assert_template_usable(
+            payload.template_id,
+            channel=payload.channel.value,
+            trigger=payload.trigger.value,
+            customer_code=resolved_code,
+            session=session,
+        )
+
     route = CustomerNotificationRoute(
         customer_code=resolved_code,
         scope=payload.scope.value,
@@ -286,6 +326,7 @@ async def create_route(
         destination=payload.destination or "",
         min_severity=payload.min_severity.value,
         format_template=payload.format_template,
+        template_id=payload.template_id,
         enabled=payload.enabled,
         created_by=created_by,
         shuffle_integration_id=payload.shuffle_integration_id,
@@ -359,6 +400,19 @@ async def update_route(
         data["customer_code"] = _enforce_scope_invariant(
             new_scope_value,
             None if new_scope_value == NotificationScope.INTERNAL.value else (route.customer_code or customer_code),
+        )
+
+    # Same rule as the internal path: an explicit null detaches, a real id is
+    # re-checked whenever the channel or trigger moves under it.
+    effective_template_id = data.get("template_id", route.template_id)
+    if effective_template_id and {"template_id", "channel", "trigger"} & data.keys():
+        new_trigger = data.get("trigger")
+        await assert_template_usable(
+            effective_template_id,
+            channel=new_channel_value,
+            trigger=new_trigger.value if hasattr(new_trigger, "value") else (new_trigger or route.trigger),
+            customer_code=data.get("customer_code", route.customer_code),
+            session=session,
         )
 
     for field, value in data.items():
@@ -752,12 +806,23 @@ def _format_default_body(event: NotificationEvent) -> str:
     return "\n".join(parts)
 
 
-def _render_body(route: CustomerNotificationRoute, event: NotificationEvent) -> Tuple[str, Optional[str]]:
-    """Render this route's message body.
+async def _render_body(
+    route: CustomerNotificationRoute,
+    event: NotificationEvent,
+    session: AsyncSession,
+    *,
+    ctx: Optional[DispatchContext] = None,
+) -> Tuple[RenderedMessage, Optional[str]]:
+    """Render this route's message.
 
-    Returns `(body, template_error)`. The error is non-None only when a custom
+    Returns `(message, template_error)`. The error is non-None only when a custom
     template failed and the channel default was sent instead — it is appended to
     the dispatch-log row so a broken template is visible without reproducing it.
+
+    **Precedence is inline → named → channel default.** The inline
+    `format_template` still wins so a single route can deviate without forking
+    the shared template, and so every route that worked before #1038 renders
+    byte-for-byte the same message.
 
     Templates are real Jinja since #1037: conditionals, loops over an alert's
     IOCs, filters. The original token names remain top-level context with
@@ -771,7 +836,77 @@ def _render_body(route: CustomerNotificationRoute, event: NotificationEvent) -> 
     already broken, just silently.
     """
     fallback = _format_default_body(event)
-    return render_body(route.format_template, event, fallback)
+
+    inline = route.format_template
+    if inline:
+        body, error = render_body(inline, event, fallback)
+        return (RenderedMessage(body=body, is_custom=error is None), error)
+
+    template = await resolve_template_for_route(route, session)
+    if template is None:
+        return (RenderedMessage(body=fallback), None)
+
+    autoescape = template.format == "html"
+    extra = await _branding_context(template, event, session, ctx=ctx)
+
+    body, error = render_body(template.body_template, event, fallback, autoescape=autoescape, extra_context=extra)
+    if error:
+        # The named template failed, so the channel default went out instead —
+        # which is plain text with no subject, whatever the template declared.
+        return (RenderedMessage(body=body), error)
+
+    subject, subject_error = render_body(
+        template.subject_template,
+        event,
+        # A failed subject falls back to the provider composing its own, which
+        # is what a route with no named template already does.
+        "",
+        autoescape=autoescape,
+        extra_context=extra,
+    )
+    return (
+        RenderedMessage(
+            body=body,
+            format=template.format,
+            # Subjects are single-line by definition; collapsing whitespace stops
+            # a template with a newline in it producing a header-shaped string.
+            subject=" ".join(subject.split()) or None,
+            is_custom=True,
+        ),
+        subject_error,
+    )
+
+
+async def _branding_context(
+    template: NotificationTemplate,
+    event: NotificationEvent,
+    session: AsyncSession,
+    *,
+    ctx: Optional[DispatchContext] = None,
+) -> Dict[str, Any]:
+    """Resolve `branding` for a template that asks for it, and only then.
+
+    The substring check is sound rather than a heuristic: Jinja resolves a name
+    from the context by its literal spelling, so a template cannot reach
+    `branding` without the word appearing in its source. Skipping the lookup
+    otherwise keeps the common case — a plain-text chat template — at zero extra
+    queries on the ingest hot path.
+
+    Memoized on the dispatch context when there is one, so a batch of routes
+    sharing a customer resolves branding once.
+    """
+    source = f"{template.body_template}{template.subject_template or ''}"
+    if "branding" not in source:
+        return {}
+
+    customer_code = event.customer_code
+    if ctx is None:
+        return {"branding": await build_branding_context(customer_code, session)}
+    branding = await ctx.memoize(
+        f"branding:{customer_code}",
+        lambda: build_branding_context(customer_code, session),
+    )
+    return {"branding": branding}
 
 
 async def _record_log(
@@ -936,10 +1071,10 @@ async def deliver_one(
         return SendResult.failed(f"Unsupported channel: {route.channel}")
 
     ctx = DispatchContext(session=session, event=event)
-    body, template_error = _render_body(route, event)
+    message, template_error = await _render_body(route, event, session, ctx=ctx)
 
     try:
-        result = await provider.send(route=route, event=event, rendered_body=body, ctx=ctx)
+        result = await provider.send(route=route, event=event, message=message, ctx=ctx)
     except Exception as e:  # noqa: BLE001 — report, never 500 the caller
         logger.exception(f"Dispatch raised for route {route.id}: {e!r}")
         result = SendResult.failed(f"Dispatcher exception: {type(e).__name__}: {e}")
@@ -955,7 +1090,7 @@ async def deliver_one(
             else (result.error_message or template_error)
         ),
         latency_ms=result.latency_ms,
-        payload_preview=body[:500],
+        payload_preview=message.body[:500],
         provider_reference=result.provider_reference,
         trigger_source=trigger_source,
     )
@@ -1121,8 +1256,8 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
         route_name = route.name
         route_channel = route.channel
 
-        body, template_error = _render_body(route, event)
-        body_preview = body[:500]
+        message, template_error = await _render_body(route, event, session, ctx=ctx)
+        body_preview = message.body[:500]
 
         latency_ms: Optional[int] = None
         result_status = "sent"
@@ -1146,7 +1281,7 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
                 result = await provider.send(
                     route=route,
                     event=event,
-                    rendered_body=body,
+                    message=message,
                     ctx=ctx,
                 )
                 result_status = result.status

--- a/backend/app/notifications/services/rendering.py
+++ b/backend/app/notifications/services/rendering.py
@@ -27,6 +27,7 @@ alert.
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -91,7 +92,19 @@ def build_context(event: NotificationEvent) -> Dict[str, Any]:
     `event` is also exposed whole, so a template can reach parts of the envelope
     that have no flat alias — `{{ event.context.iocs }}`, for instance.
     """
-    ctx = event.context or {}
+    # `context` is the one place StrictUndefined is wrong, so missing keys read
+    # as "" instead of raising. The top-level names above are a fixed contract
+    # and a typo in one is a bug worth failing on; `context` is a free-form
+    # per-event bag where the SAME trigger legitimately carries different keys —
+    # `asset_name` is present on one alert and absent on the next. Under strict
+    # lookup, `{% if context.asset_name %}` renders fine in preview (the sample
+    # event is fully populated) and then falls back to the channel default on a
+    # sparse real event. Preview passing while production silently degrades is
+    # the worst failure mode available here.
+    #
+    # A copy, because defaultdict inserts on read and the event's own dict must
+    # not accumulate keys as a side effect of rendering.
+    ctx = defaultdict(str, event.context or {})
     return {
         # Original tokens — unchanged semantics.
         "customer_code": event.customer_code or "",
@@ -125,14 +138,26 @@ def compile_template(source: str, *, autoescape: bool = False) -> None:
     env.from_string(source)
 
 
-def render(source: str, event: NotificationEvent, *, autoescape: bool = False) -> str:
+def render(
+    source: str,
+    event: NotificationEvent,
+    *,
+    autoescape: bool = False,
+    extra_context: Optional[Dict[str, Any]] = None,
+) -> str:
     """Render `source` against `event`. Raises on any failure.
 
     Callers that must not fail should use `render_body`, which falls back.
+
+    `extra_context` adds variables beyond the event — named templates (#1038)
+    use it for `branding`. It is merged *under* nothing: the event context wins
+    on a key collision, so an extra can never shadow `severity` or `summary` and
+    change what an existing template means.
     """
     env = _ENV_AUTOESCAPE if autoescape else _ENV
     template = env.from_string(source)
-    output = template.render(**build_context(event))
+    context = {**(extra_context or {}), **build_context(event)}
+    output = template.render(**context)
 
     if len(output.encode("utf-8")) > MAX_RENDERED_BYTES:
         raise TemplateTooLargeError(
@@ -148,6 +173,7 @@ def render_body(
     fallback: str,
     *,
     autoescape: bool = False,
+    extra_context: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, Optional[str]]:
     """Render a template, falling back to `fallback` on any error.
 
@@ -162,7 +188,7 @@ def render_body(
         return (fallback, None)
 
     try:
-        return (render(source, event, autoescape=autoescape), None)
+        return (render(source, event, autoescape=autoescape, extra_context=extra_context), None)
     except TemplateError as e:
         message = f"Template render failed ({type(e).__name__}: {e}); sent the channel default instead."
         logger.warning(f"{message} trigger={event.trigger.value} entity={event.entity_type}#{event.entity_id}")

--- a/backend/app/notifications/services/template_seeds.py
+++ b/backend/app/notifications/services/template_seeds.py
@@ -1,0 +1,185 @@
+"""Built-in message templates, seeded at startup.
+
+Named templates are useless with an empty list — an operator opening the picker
+would see nothing and have to write Jinja from scratch to find out what the
+feature does. These give every deployment a working starting point and, more
+usefully, a set of worked examples: conditionals, loops over IOCs, filters, and
+`{{ branding.* }}` in an HTML email.
+
+**Built-ins are read-only.** `update_template` and `delete_template` refuse them
+because the next startup would recreate them anyway; the UI offers *Duplicate*
+instead, which produces a normal editable row.
+
+**Seeding is by name and idempotent.** A row is inserted only when no built-in
+with that name exists, so restarts don't multiply them. Existing built-ins are
+deliberately NOT overwritten with the current source: a deployment that has been
+running for a year keeps sending exactly what it sent yesterday, and changing
+these strings never silently rewrites live notifications. Renaming one here
+therefore creates a new template rather than editing the old one — which is the
+safe direction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.universal_models import NotificationTemplate
+
+#: Each entry becomes one `notification_template` row with `is_default=True` and
+#: `customer_code=None` (shared with every customer).
+BUILTIN_TEMPLATES: List[Dict[str, Any]] = [
+    {
+        "name": "Alert — concise",
+        "description": "One-line summary with severity and a link. Good for high-volume chat channels.",
+        "trigger": "alert_created",
+        "format": "markdown",
+        "subject_template": "{{ severity }} alert on {{ customer_code }}: {{ alert_name }}",
+        "body_template": (
+            "*{{ severity }}* — {{ alert_name }}\n"
+            "Customer: `{{ customer_code }}`"
+            "{% if context.asset_name %} · Asset: {{ context.asset_name }}{% endif %}\n"
+            "{% if link_url %}<{{ link_url }}|Open in CoPilot>{% endif %}"
+        ),
+    },
+    {
+        "name": "Alert — detailed with IOCs",
+        "description": "Full context including any indicators the investigation extracted.",
+        "trigger": "alert_created",
+        "format": "markdown",
+        "subject_template": "{{ severity }} alert on {{ customer_code }}: {{ alert_name }}",
+        # `context.iocs` is absent on most events, so the loop is guarded rather
+        # than relying on a default — StrictUndefined makes an unguarded
+        # reference an error, which would fall back to the channel default.
+        "body_template": (
+            "*New alert* — severity: *{{ severity }}*\n\n"
+            "Customer: `{{ customer_code }}`\n"
+            "Alert: #{{ alert_id }}{% if alert_name %} — {{ alert_name }}{% endif %}\n"
+            "{% if context.asset_name %}Asset: {{ context.asset_name }}\n{% endif %}"
+            "{% if context.rule_level is not none %}Rule level: {{ context.rule_level }}\n{% endif %}"
+            "\n{{ summary }}\n"
+            "{% if context.iocs %}\n*Indicators*\n"
+            "{% for ioc in context.iocs %}• `{{ ioc.value }}` ({{ ioc.type }})\n{% endfor %}"
+            "{% endif %}"
+            "{% if link_url %}\nOpen in CoPilot: {{ link_url }}{% endif %}"
+        ),
+    },
+    {
+        "name": "Assignment — who and what",
+        "description": "For internal routes: who picked something up, and what it was.",
+        # Deliberately unscoped: the three assignment triggers share a shape, and
+        # scoping to one would mean three near-identical built-ins.
+        "trigger": None,
+        "format": "markdown",
+        "subject_template": "{{ entity_type | replace('_', ' ') | title }} #{{ entity_id }} assigned to {{ assignee }}",
+        "body_template": (
+            "*{{ entity_type | replace('_', ' ') | title }} assigned* — {{ assignee or 'unassigned' }}\n\n"
+            "{{ entity_type | replace('_', ' ') | title }}: #{{ entity_id }}"
+            "{% if context.title %} — {{ context.title }}{% endif %}\n"
+            "{% if customer_code %}Customer: `{{ customer_code }}`\n{% endif %}"
+            "{% if actor %}Assigned by: {{ actor }}\n{% endif %}"
+            "{% if summary %}\n{{ summary }}\n{% endif %}"
+            "{% if link_url %}\nOpen in CoPilot: {{ link_url }}{% endif %}"
+        ),
+    },
+    {
+        "name": "AI investigation — customer summary",
+        "description": "Plain-language wrap-up of an AI investigation, written for the end customer.",
+        "trigger": "investigation_complete",
+        "format": "markdown",
+        "subject_template": "Security investigation complete — {{ severity }} finding",
+        "body_template": (
+            "We completed an automated investigation of activity on your environment.\n\n"
+            "*Severity:* {{ severity }}\n"
+            "*What we saw:* {{ alert_name }}\n"
+            "{% if context.asset_name %}*Where:* {{ context.asset_name }}\n{% endif %}"
+            "\n{{ summary }}\n"
+            "{% if link_url %}\nThe full report is available here: {{ link_url }}{% endif %}"
+        ),
+    },
+    {
+        "name": "Branded email — HTML",
+        "description": (
+            "HTML email in the customer's brand colours. Email channels only. "
+            "The logo is embedded as a data URI, which some email clients block — the colours always apply."
+        ),
+        "trigger": None,
+        "format": "html",
+        "subject_template": "{{ severity }} security notification — {{ alert_name }}",
+        # `branding` comes from the same resolver the PDF reports use, so this
+        # inherits per-customer overrides and their field-by-field global
+        # fallbacks. Keys are that theme's own: `logo` (a data URI, possibly
+        # None), `accent_strong` (the raw brand colour), `accent_text` (legible
+        # on it), `title`. Every access is guarded — `branding` is {} when the
+        # lookup fails, and StrictUndefined turns a bare miss into a render
+        # error that would drop the message to the channel default.
+        "body_template": (
+            '<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;'
+            'max-width:600px;margin:0 auto;padding:24px">'
+            "{% if branding.logo %}"
+            '<img src="{{ branding.logo }}" alt="{{ branding.title | default("") }}" '
+            'style="max-height:48px;margin-bottom:24px">'
+            "{% endif %}"
+            '<h2 style="color:{{ branding.accent | default("#1f2937") }};margin:0 0 8px">{{ alert_name }}</h2>'
+            '<p style="color:#6b7280;margin:0 0 24px">Severity: <strong>{{ severity }}</strong>'
+            "{% if customer_code %} · {{ customer_code }}{% endif %}</p>"
+            '<div style="line-height:1.6;color:#374151">{{ summary }}</div>'
+            "{% if link_url %}"
+            '<p style="margin-top:32px">'
+            '<a href="{{ link_url }}" style="background:{{ branding.accent_strong | default("#2563eb") }};'
+            'color:{{ branding.accent_text | default("#ffffff") }};padding:10px 20px;border-radius:6px;'
+            'text-decoration:none;display:inline-block">View in CoPilot</a></p>'
+            "{% endif %}"
+            "</div>"
+        ),
+    },
+]
+
+
+async def seed_builtin_templates(async_engine) -> int:
+    """Insert any missing built-in templates. Returns how many were added.
+
+    Takes the engine and opens its own session, matching the other startup
+    seeders in `db_setup.py`.
+
+    Never raises: templates are a convenience, and a failure here must not stop
+    the app from booting — every notification path works without them.
+    """
+    added = 0
+    try:
+        async with AsyncSession(async_engine) as session:
+            result = await session.execute(
+                select(NotificationTemplate.name).where(NotificationTemplate.is_default.is_(True)),
+            )
+            existing = set(result.scalars().all())
+
+            for spec in BUILTIN_TEMPLATES:
+                if spec["name"] in existing:
+                    continue
+                session.add(
+                    NotificationTemplate(
+                        name=spec["name"],
+                        description=spec["description"],
+                        trigger=spec["trigger"],
+                        format=spec["format"],
+                        subject_template=spec["subject_template"],
+                        body_template=spec["body_template"],
+                        customer_code=None,
+                        is_default=True,
+                        created_by="system",
+                    ),
+                )
+                added += 1
+
+            if added:
+                await session.commit()
+                logger.info(f"Seeded {added} built-in notification template(s).")
+    except Exception as e:  # noqa: BLE001 — never block startup
+        logger.warning(f"Could not seed built-in notification templates: {type(e).__name__}: {e}")
+        return 0
+    return added

--- a/backend/app/notifications/services/templates.py
+++ b/backend/app/notifications/services/templates.py
@@ -1,0 +1,447 @@
+"""Named, reusable message templates.
+
+#1037 made `route.format_template` real Jinja. This makes templates shareable:
+write one, attach it to many routes, edit it once.
+
+**Precedence at render time is inline → named → channel default.** The inline
+field survives deliberately as a per-route override, so a single route can
+deviate without forking the shared copy — and so nothing that worked before this
+existed changes behaviour.
+
+Two decisions worth knowing:
+
+**Deleting a template does not delete the routes using it.** The FK has no
+cascade; `delete_template` clears the reference and reports how many routes were
+affected. Those routes fall back to their inline template or the channel
+default, so notifications keep flowing rather than silently stopping.
+
+**Compatibility is checked when a template is attached, not when it fires.** A
+template scoped to `alert_assigned` references `{{assignee}}`, which is empty on
+`alert_created`; a template in `html` cannot render as a Teams card. Catching
+that at attach time is a 400 the operator sees, rather than a route that
+degrades to the channel default forever.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from fastapi import HTTPException
+from jinja2 import TemplateError
+from loguru import logger
+from sqlalchemy import desc
+from sqlalchemy import or_
+from sqlalchemy import select
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.universal_models import CustomerNotificationRoute
+from app.db.universal_models import NotificationTemplate
+from app.notifications.schema.events import NotificationEvent
+from app.notifications.services.rendering import compile_template
+
+#: Formats a template can declare. `html` autoescapes; `json` is validated to
+#: parse after rendering; `text` and `markdown` pass through.
+TEMPLATE_FORMATS = ("text", "markdown", "html", "json")
+
+_HTML_FORMATS = {"html"}
+
+
+async def list_templates(
+    session: AsyncSession,
+    *,
+    customer_code: Optional[str] = None,
+    trigger: Optional[str] = None,
+) -> List[NotificationTemplate]:
+    """Templates available to a customer: their own plus the shared ones.
+
+    A NULL `customer_code` means shared, so the filter is deliberately an OR
+    rather than an equality — omitting the shared ones would hide every built-in
+    default from every customer.
+    """
+    stmt = select(NotificationTemplate)
+    if customer_code:
+        stmt = stmt.where(
+            or_(
+                NotificationTemplate.customer_code == customer_code,
+                NotificationTemplate.customer_code.is_(None),
+            ),
+        )
+    if trigger:
+        # A trigger-agnostic template (NULL) is usable everywhere.
+        stmt = stmt.where(
+            or_(NotificationTemplate.trigger == trigger, NotificationTemplate.trigger.is_(None)),
+        )
+    result = await session.execute(stmt.order_by(desc(NotificationTemplate.created_at)))
+    return result.scalars().all()
+
+
+async def get_template(template_id: int, session: AsyncSession) -> NotificationTemplate:
+    result = await session.execute(select(NotificationTemplate).where(NotificationTemplate.id == template_id))
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Template {template_id} not found")
+    return template
+
+
+def _validate(name: str, fmt: str, body: str, subject: Optional[str]) -> None:
+    """Reject a template that cannot work, at save time.
+
+    Compilation catches syntax errors. Undefined variables are not checked here:
+    they depend on the event, and a template valid for one trigger may reference
+    fields another doesn't carry — those degrade to the channel default at send
+    time with the reason recorded.
+    """
+    if not name or not name.strip():
+        raise HTTPException(status_code=400, detail="A template needs a name.")
+    if fmt not in TEMPLATE_FORMATS:
+        raise HTTPException(status_code=400, detail=f"format must be one of {TEMPLATE_FORMATS}")
+    if not body or not body.strip():
+        raise HTTPException(status_code=400, detail="A template needs a body.")
+
+    autoescape = fmt in _HTML_FORMATS
+    for label, source in (("body_template", body), ("subject_template", subject)):
+        if not source:
+            continue
+        try:
+            compile_template(source, autoescape=autoescape)
+        except TemplateError as e:
+            raise HTTPException(status_code=400, detail=f"{label} is not valid Jinja: {e}") from e
+
+
+async def create_template(payload: Any, created_by: Optional[str], session: AsyncSession) -> NotificationTemplate:
+    fmt = payload.format.value if hasattr(payload.format, "value") else payload.format
+    _validate(payload.name, fmt, payload.body_template, payload.subject_template)
+
+    template = NotificationTemplate(
+        name=payload.name.strip(),
+        description=payload.description,
+        trigger=payload.trigger.value if hasattr(payload.trigger, "value") else payload.trigger,
+        format=fmt,
+        subject_template=payload.subject_template,
+        body_template=payload.body_template,
+        customer_code=payload.customer_code,
+        # Only the seeder creates built-ins; an operator-created template is
+        # always editable and deletable.
+        is_default=False,
+        created_by=created_by,
+    )
+    session.add(template)
+    await session.commit()
+    await session.refresh(template)
+    return template
+
+
+async def update_template(template_id: int, payload: Any, session: AsyncSession) -> NotificationTemplate:
+    template = await get_template(template_id, session)
+
+    if template.is_default:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Built-in templates cannot be edited. Duplicate it first — the copy is yours to change, "
+                "and the original stays available as a reference."
+            ),
+        )
+
+    data = payload.model_dump(exclude_unset=True)
+    new_format = data.get("format", template.format)
+    _validate(
+        data.get("name", template.name),
+        new_format.value if hasattr(new_format, "value") else new_format,
+        data.get("body_template", template.body_template),
+        data.get("subject_template", template.subject_template),
+    )
+
+    for field, value in data.items():
+        if hasattr(value, "value"):
+            value = value.value
+        setattr(template, field, value)
+    template.updated_at = datetime.utcnow()
+
+    # Changing `format`, `trigger` or `customer_code` can invalidate an
+    # attachment that was legal when it was made — narrowing a shared template
+    # to one customer, or switching it to HTML while a Teams route uses it.
+    # Without this the attach-time check would only hold until the first edit.
+    conflicts = await _attached_route_conflicts(template, session)
+    if conflicts:
+        await session.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "That change would break "
+                + ("a route" if len(conflicts) == 1 else f"{len(conflicts)} routes")
+                + " already using this template: "
+                + "; ".join(conflicts)
+            ),
+        )
+
+    await session.commit()
+    await session.refresh(template)
+    return template
+
+
+async def _attached_route_conflicts(template: NotificationTemplate, session: AsyncSession) -> List[str]:
+    """Routes that this template — as edited — could no longer serve.
+
+    Returns one human-readable line per conflict so the operator sees which
+    routes to fix rather than a bare refusal.
+    """
+    result = await session.execute(
+        select(CustomerNotificationRoute).where(CustomerNotificationRoute.template_id == template.id),
+    )
+    conflicts: List[str] = []
+    for route in result.scalars().all():
+        problem = _incompatibility(
+            template,
+            channel=route.channel,
+            trigger=route.trigger,
+            customer_code=route.customer_code,
+        )
+        if problem:
+            conflicts.append(f"{route.name!r} — {problem}")
+    return conflicts
+
+
+async def delete_template(template_id: int, session: AsyncSession) -> int:
+    """Delete a template, detaching it from any routes using it.
+
+    Returns how many routes were affected so the caller can say so.
+
+    The FK deliberately has no cascade: deleting a template must not delete the
+    routes referencing it. Those routes fall back to their inline template or
+    the channel default, so notifications keep flowing — losing a template is an
+    inconvenience, losing a route is an outage.
+    """
+    template = await get_template(template_id, session)
+
+    if template.is_default:
+        raise HTTPException(status_code=400, detail="Built-in templates cannot be deleted.")
+
+    result = await session.execute(
+        update(CustomerNotificationRoute).where(CustomerNotificationRoute.template_id == template_id).values(template_id=None),
+    )
+    detached = result.rowcount or 0
+
+    await session.delete(template)
+    await session.commit()
+
+    if detached:
+        logger.info(f"Deleted template {template_id}; detached from {detached} route(s), which fall back to their channel default.")
+    return detached
+
+
+async def assert_template_usable(
+    template_id: int,
+    *,
+    channel: str,
+    trigger: str,
+    customer_code: Optional[str],
+    session: AsyncSession,
+) -> None:
+    """Refuse a template the route being saved cannot actually render.
+
+    Takes the route's properties rather than the ORM row, so route creation
+    (where no row exists yet) and PATCH (where the effective values are a merge
+    of the payload and the stored row) can both call it.
+
+    Checked when the template is attached rather than when it fires. A mismatch
+    caught at send time is a route that silently degrades to the channel default
+    forever; caught here it is a 400 the operator can act on.
+    """
+    template = await get_template(template_id, session)
+    problem = _incompatibility(template, channel=channel, trigger=trigger, customer_code=customer_code)
+    if problem:
+        raise HTTPException(status_code=400, detail=problem)
+
+
+def _incompatibility(
+    template: NotificationTemplate,
+    *,
+    channel: str,
+    trigger: str,
+    customer_code: Optional[str],
+) -> Optional[str]:
+    """Why this template cannot serve a route with these properties, or None.
+
+    Pure and route-shaped rather than a raiser, because it is asked in two
+    directions: when a route attaches a template, and when a template is edited
+    while routes already point at it. Both need the same rules or the attach-time
+    guarantee is worthless.
+    """
+    from app.notifications.channels import get_channel
+
+    if template.customer_code and customer_code and template.customer_code != customer_code:
+        return f"That template belongs to customer {template.customer_code!r}, but the route serves {customer_code!r}."
+
+    # A shared template on an internal route is fine — it belongs to no tenant
+    # either. A customer-scoped one is not: it would render a specific
+    # customer's branding into a message that goes to the SOC.
+    if template.customer_code and customer_code is None:
+        return f"That template is scoped to customer {template.customer_code!r}, so it cannot be used on an internal route."
+
+    if template.trigger and template.trigger != trigger:
+        return (
+            f"That template is scoped to the {template.trigger!r} trigger, but the route fires on "
+            f"{trigger!r}. A template written around one trigger's variables renders empty on another."
+        )
+
+    provider = get_channel(channel)
+    if provider is not None and template.format not in provider.template_formats:
+        return f"The {channel!r} channel cannot render a {template.format!r} template (supports {sorted(provider.template_formats)})."
+
+    return None
+
+
+#: Returned when branding can't be resolved. Every key the resolver produces and
+#: a template is likely to touch is present, because `StrictUndefined` turns a
+#: missing key into a render error — and a template guarding each access would
+#: be unreadable. Keeping the shape stable means `{{ branding.logo }}` is always
+#: safe to write, whether or not the lookup succeeded.
+_FALLBACK_BRANDING: Dict[str, Any] = {
+    "logo": None,
+    "title": "CoPilot",
+    "footer_brand": "CoPilot",
+    "accent": "#1f2937",
+    "accent_strong": "#2563eb",
+    "accent_text": "#ffffff",
+    "accent_soft": "#e5e7eb",
+}
+
+
+async def build_branding_context(customer_code: Optional[str], session: AsyncSession) -> Dict[str, Any]:
+    """The customer's logo and colours, for templates that want them.
+
+    Reuses the report branding resolver rather than reading the tables directly,
+    so a templated email inherits exactly the branding a generated PDF would —
+    including the field-by-field fallback to global defaults.
+
+    Note the logo is a data URI. That renders in a browser preview and in some
+    mail clients, but Gmail and Outlook block data-URI images — the colours
+    always apply, the logo may not.
+
+    Never raises: branding is decoration, and a notification must not fail
+    because a logo lookup did.
+    """
+    try:
+        from app.incidents.services.customer_report_branding import resolve_theme
+
+        theme = await resolve_theme(session, "customer", customer_code)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Could not resolve branding for {customer_code!r}: {type(e).__name__}: {e}")
+        return dict(_FALLBACK_BRANDING)
+    # Union rather than the raw theme: a resolver that ever stops emitting a key
+    # would otherwise break every template referencing it.
+    return {**_FALLBACK_BRANDING, **(theme or {})}
+
+
+async def resolve_template_for_route(
+    route: CustomerNotificationRoute,
+    session: AsyncSession,
+) -> Optional[NotificationTemplate]:
+    """The named template a route should use, if any.
+
+    Returns None when the route has no `template_id` — the caller then falls
+    back to the inline `format_template` or the channel default, which is the
+    precedence chain this module exists to implement.
+    """
+    if not getattr(route, "template_id", None):
+        return None
+    result = await session.execute(select(NotificationTemplate).where(NotificationTemplate.id == route.template_id))
+    template = result.scalars().first()
+    if template is None:
+        # A dangling reference should not stop the notification. The route falls
+        # back, and the mismatch is visible in the log.
+        logger.warning(f"Route {route.id} references template {route.template_id}, which no longer exists.")
+    return template
+
+
+def sample_event(trigger: str, customer_code: Optional[str]) -> NotificationEvent:
+    """A realistic event for previewing an unsaved template.
+
+    Populated for every trigger rather than only the one being previewed, so a
+    template that references `{{assignee}}` renders something even while the
+    editor's trigger selector says `alert_created`. The alternative — undefined,
+    which `StrictUndefined` turns into an error — would make the editor look
+    broken while someone is halfway through writing.
+    """
+    from app.notifications.schema.events import EntityType
+    from app.notifications.schema.notifications import NotificationSeverity
+    from app.notifications.schema.notifications import NotificationTrigger
+
+    parsed = NotificationTrigger(trigger) if trigger in {t.value for t in NotificationTrigger} else NotificationTrigger.ALERT_CREATED
+
+    entity_type = EntityType.ALERT
+    if parsed == NotificationTrigger.CASE_ASSIGNED:
+        entity_type = EntityType.CASE
+    elif parsed == NotificationTrigger.CASE_TASK_ASSIGNED:
+        entity_type = EntityType.CASE_TASK
+
+    return NotificationEvent(
+        customer_code=customer_code or "ACME",
+        trigger=parsed,
+        severity=NotificationSeverity.HIGH,
+        subject="Suspicious PowerShell execution on WKSTN-014",
+        summary=(
+            "An encoded PowerShell command was executed by a non-administrative user. "
+            "The parent process was winword.exe, which is consistent with a malicious document."
+        ),
+        entity_type=entity_type,
+        entity_id=4821,
+        dedupe_key="preview",
+        link_url="https://copilot.example.com/alerts/4821",
+        assignee_username="jdoe",
+        actor_username="asmith",
+        context={
+            "alert_name": "Suspicious PowerShell execution on WKSTN-014",
+            "title": "Suspicious PowerShell execution on WKSTN-014",
+            "asset_name": "WKSTN-014",
+            "rule_level": 12,
+            "iocs": [
+                {"value": "185.199.108.153", "type": "ip"},
+                {"value": "a1b2c3d4e5f6", "type": "hash"},
+            ],
+        },
+    )
+
+
+async def preview(payload: Any, session: AsyncSession) -> Dict[str, Any]:
+    """Render template source against a sample event, without saving.
+
+    Takes the source inline so the editor previews *unsaved* edits — the same
+    reason the custom-dashboard builder previews an unsaved panel set, and what
+    stops the preview and the real send from drifting.
+
+    Errors are returned rather than raised: the editor shows them beside the
+    template being written, which is more useful than a 400 that clears the form.
+    """
+    from app.notifications.services.rendering import render
+
+    fmt = payload.format.value if hasattr(payload.format, "value") else payload.format
+    trigger = payload.trigger.value if hasattr(payload.trigger, "value") else payload.trigger
+
+    event = sample_event(trigger, payload.customer_code)
+    autoescape = fmt in _HTML_FORMATS
+
+    extra: Dict[str, Any] = {}
+    source = f"{payload.body_template}{payload.subject_template or ''}"
+    if "branding" in source:
+        extra["branding"] = await build_branding_context(payload.customer_code, session)
+
+    try:
+        body = render(payload.body_template, event, autoescape=autoescape, extra_context=extra)
+    except Exception as e:  # noqa: BLE001 — the message IS the useful output here
+        return {"body": "", "subject": None, "error": f"{type(e).__name__}: {e}"}
+
+    subject = None
+    if payload.subject_template:
+        try:
+            subject = " ".join(render(payload.subject_template, event, autoescape=autoescape, extra_context=extra).split())
+        except Exception as e:  # noqa: BLE001
+            return {"body": body, "subject": None, "error": f"Subject: {type(e).__name__}: {e}"}
+
+    return {"body": body, "subject": subject, "error": None}

--- a/backend/copilot.py
+++ b/backend/copilot.py
@@ -39,6 +39,7 @@ from app.middleware.exception_handlers import custom_http_exception_handler
 from app.middleware.exception_handlers import validation_exception_handler
 from app.middleware.exception_handlers import value_error_handler
 from app.middleware.integrity import run_integrity_check
+from app.notifications.services.template_seeds import seed_builtin_templates
 
 # from app.routers import ask_socfortress
 from app.routers import active_response
@@ -129,6 +130,9 @@ async def lifespan(_app: FastAPI):
     await create_available_network_connectors(async_engine)
     await ensure_admin_user(async_engine)
     await ensure_scheduler_user(async_engine)
+    # Built-in message templates (#1038). Idempotent by name, and never fatal —
+    # notifications work without them, they just start from a blank editor.
+    await seed_builtin_templates(async_engine)
 
     # Initialize the scheduler
     scheduler = await init_scheduler()

--- a/backend/tests/test_notification_channel_registry.py
+++ b/backend/tests/test_notification_channel_registry.py
@@ -35,6 +35,7 @@ from app.notifications.channels import channel_keys  # noqa: E402
 from app.notifications.channels import get_channel  # noqa: E402
 from app.notifications.channels.base import ChannelProvider  # noqa: E402
 from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.channels.base import RenderedMessage  # noqa: E402
 from app.notifications.schema.events import event_from_dispatch_request  # noqa: E402
 from app.notifications.schema.notifications import DispatchRequest  # noqa: E402
 from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
@@ -123,9 +124,15 @@ def test_unknown_channel_returns_none_rather_than_raising():
 # ── webhook: the payload is an external contract ──────────────────────────
 
 
-def _run_webhook(route, req=None, report=None):
+def _run_webhook(route, req=None, report=None, is_custom=False):
     """Invoke the webhook provider with the HTTP dispatcher stubbed, returning
-    the kwargs it was called with."""
+    the kwargs it was called with.
+
+    `is_custom` is what tells the provider the body was operator-authored rather
+    than the channel default. It rides on the message rather than being derived
+    from `route.format_template`, because a route can now get a custom body from
+    a named template with that column empty (#1038).
+    """
     event = event_from_dispatch_request(req or _request())
     sent = AsyncMock(return_value=("sent", None, 12, None))
     with (
@@ -136,7 +143,7 @@ def _run_webhook(route, req=None, report=None):
             CHANNEL_REGISTRY["webhook"].send(
                 route=route,
                 event=event,
-                rendered_body="RENDERED BODY",
+                message=RenderedMessage(body="RENDERED BODY", is_custom=is_custom),
                 ctx=_ctx(event),
             ),
         )
@@ -208,6 +215,7 @@ def test_webhook_template_body_passes_through_untouched_without_the_token():
     _result, kwargs = _run_webhook(
         _webhook_route(format_template="see something"),
         report={"report_id": 9, "iocs": []},
+        is_custom=True,
     )
     assert kwargs["rendered_template"] == "RENDERED BODY"
 
@@ -224,7 +232,7 @@ def test_webhook_template_report_token_substitutes_when_present_in_body():
             CHANNEL_REGISTRY["webhook"].send(
                 route=_webhook_route(format_template="x"),
                 event=event,
-                rendered_body="prefix {{report}} suffix",
+                message=RenderedMessage(body="prefix {{report}} suffix", is_custom=True),
                 ctx=_ctx(event),
             ),
         )
@@ -297,7 +305,7 @@ def _run_shuffle(route, integration, creds=("https://shuffler.io", "key")):
             CHANNEL_REGISTRY["shuffle"].send(
                 route=route,
                 event=event,
-                rendered_body="RENDERED BODY",
+                message=RenderedMessage(body="RENDERED BODY"),
                 ctx=_ctx(event, session),
             ),
         )
@@ -391,7 +399,7 @@ def test_connector_is_read_once_across_routes_in_one_dispatch():
                 CHANNEL_REGISTRY["shuffle"].send(
                     route=_shuffle_route(),
                     event=event,
-                    rendered_body="B",
+                    message=RenderedMessage(body="B"),
                     ctx=ctx,
                 ),
             )
@@ -414,7 +422,7 @@ def test_report_is_read_once_across_routes_in_one_dispatch():
                 CHANNEL_REGISTRY["webhook"].send(
                     route=_webhook_route(config={"include_full_report": True}),
                     event=event,
-                    rendered_body="B",
+                    message=RenderedMessage(body="B"),
                     ctx=ctx,
                 ),
             )

--- a/backend/tests/test_notification_internal_routes.py
+++ b/backend/tests/test_notification_internal_routes.py
@@ -70,6 +70,8 @@ def _existing(route_id=1, channel="resend", scope="internal"):
         customer_code=None,
         recipient_mode="assignee",
         config=json.dumps({"to": []}),
+        template_id=None,
+        trigger="alert_assigned",
         updated_at=None,
     )
 

--- a/backend/tests/test_notification_resend_channel.py
+++ b/backend/tests/test_notification_resend_channel.py
@@ -36,6 +36,7 @@ from fastapi import HTTPException  # noqa: E402
 import app.notifications.channels.resend as resend_mod  # noqa: E402
 from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
 from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.channels.base import RenderedMessage  # noqa: E402
 from app.notifications.channels.resend import ResendConfig  # noqa: E402
 from app.notifications.schema.events import NotificationEvent  # noqa: E402
 from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
@@ -91,7 +92,7 @@ def _send(route, event=None, creds=CREDS, recent_sends=0, user=...):
             CHANNEL_REGISTRY["resend"].send(
                 route=route,
                 event=ev,
-                rendered_body="RENDERED BODY",
+                message=RenderedMessage(body="RENDERED BODY"),
                 ctx=DispatchContext(session=AsyncMock(), event=ev),
             ),
         )

--- a/backend/tests/test_notification_teams_channel.py
+++ b/backend/tests/test_notification_teams_channel.py
@@ -29,6 +29,7 @@ os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-defaul
 import app.notifications.channels.teams as teams_mod  # noqa: E402
 from app.notifications.channels import CHANNEL_REGISTRY  # noqa: E402
 from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.channels.base import RenderedMessage  # noqa: E402
 from app.notifications.channels.teams import TeamsConfig  # noqa: E402
 from app.notifications.schema.events import NotificationEvent  # noqa: E402
 from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
@@ -67,7 +68,7 @@ def _send(route, event=None, body="RENDERED BODY", result=("sent", None, 12, Non
             CHANNEL_REGISTRY["teams"].send(
                 route=route,
                 event=ev,
-                rendered_body=body,
+                message=RenderedMessage(body=body),
                 ctx=DispatchContext(session=AsyncMock(), event=ev),
             ),
         )

--- a/backend/tests/test_notification_templates.py
+++ b/backend/tests/test_notification_templates.py
@@ -1,0 +1,521 @@
+"""Named, reusable message templates (#1038).
+
+What's actually at risk here isn't the CRUD — it's the three places this feature
+can quietly change what a customer receives:
+
+1. **Precedence.** Inline `format_template` → named template → channel default.
+   Every route that existed before #1038 has no `template_id`, so it must render
+   byte-for-byte what it rendered yesterday. A precedence bug is invisible in
+   tests that only exercise the new path.
+
+2. **Detachment on delete.** The FK has no cascade on purpose. Deleting a
+   template must strand the routes' reference, not the routes — losing a
+   template is an inconvenience, losing a route is an outage.
+
+3. **`context.*` under StrictUndefined.** The preview renders against a fully
+   populated sample event; a real alert often carries a sparse `context`. Under
+   strict lookup a template that previews perfectly falls back to the channel
+   default in production, which is the worst failure mode available. The
+   regression test for that is `test_a_missing_context_key_renders_empty`.
+
+Unit tests with fake sessions — no DB.
+
+Run with: cd backend && python -m pytest tests/test_notification_templates.py
+"""
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+
+import app.notifications.services.notifications as svc  # noqa: E402
+import app.notifications.services.templates as templates_svc  # noqa: E402
+from app.notifications.schema.events import EntityType  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import (  # noqa: E402
+    NotificationTemplateUpdate,
+)
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.rendering import render  # noqa: E402
+from app.notifications.services.template_seeds import BUILTIN_TEMPLATES  # noqa: E402
+from app.notifications.services.templates import _FALLBACK_BRANDING  # noqa: E402
+from app.notifications.services.templates import sample_event  # noqa: E402
+
+CUSTOMER = "ACME"
+
+
+def _event(**over):
+    base = dict(
+        customer_code=CUSTOMER,
+        trigger=NotificationTrigger.ALERT_CREATED,
+        severity=NotificationSeverity.HIGH,
+        subject="Mimikatz signature",
+        summary="Credential dumping detected.",
+        entity_type=EntityType.ALERT,
+        entity_id=42,
+        dedupe_key="k",
+        link_url="https://copilot.invalid/42",
+        assignee_username=None,
+        actor_username=None,
+        context={"alert_name": "Mimikatz signature", "asset_name": "SRV-01"},
+    )
+    base.update(over)
+    return NotificationEvent(**base)
+
+
+def _route(channel="webhook", **over):
+    base = dict(
+        id=1,
+        name="a route",
+        channel=channel,
+        scope="customer",
+        customer_code=CUSTOMER,
+        enabled=True,
+        trigger="alert_created",
+        min_severity="Informational",
+        destination="",
+        format_template=None,
+        template_id=None,
+        config=json.dumps({"url": "https://example.invalid/hook"}),
+        shuffle_integration_id=None,
+        notify_on_self_assign=False,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _template(**over):
+    base = dict(
+        id=7,
+        name="Shared",
+        description=None,
+        trigger=None,
+        format="text",
+        subject_template=None,
+        body_template="named: {{ alert_name }}",
+        customer_code=None,
+        is_default=False,
+        created_by="admin",
+        updated_at=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _session(first=None, all_=None):
+    """A session whose every execute() returns the same scalars result."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = first
+    result.scalars.return_value.all.return_value = all_ or []
+    result.rowcount = len(all_ or [])
+    session.execute = AsyncMock(return_value=result)
+    session.add = MagicMock()
+    session.refresh = AsyncMock()
+    session.delete = AsyncMock()
+    return session
+
+
+def _render(route, event, session):
+    return asyncio.run(svc._render_body(route, event, session))
+
+
+# ── precedence ────────────────────────────────────────────────────────────
+
+
+def test_no_template_at_all_gives_the_channel_default():
+    """The pre-#1038 route shape. Must be untouched."""
+    session = _session()
+    message, err = _render(_route(), _event(), session)
+
+    assert err is None
+    assert message.body.startswith("*New alert*")
+    assert message.is_custom is False, "the channel default is not operator-authored"
+    assert session.execute.await_count == 0, "a route with no template_id must not hit the DB"
+
+
+def test_an_inline_template_wins_over_the_named_one():
+    """The inline field stays a per-route override so one route can deviate
+    without forking the shared template."""
+    session = _session(first=_template(body_template="NAMED"))
+    route = _route(format_template="INLINE {{ alert_name }}", template_id=7)
+
+    message, err = _render(route, _event(), session)
+
+    assert err is None
+    assert message.body == "INLINE Mimikatz signature"
+    assert session.execute.await_count == 0, "the named template must not even be fetched"
+
+
+def test_a_named_template_is_used_when_there_is_no_inline_one():
+    session = _session(first=_template())
+    message, err = _render(_route(template_id=7), _event(), session)
+
+    assert err is None
+    assert message.body == "named: Mimikatz signature"
+    assert message.is_custom is True
+
+
+def test_a_dangling_template_reference_falls_back_rather_than_failing():
+    """A template deleted out from under a route (or a stale id) must not stop
+    the notification."""
+    session = _session(first=None)
+    message, err = _render(_route(template_id=999), _event(), session)
+
+    assert err is None
+    assert message.body.startswith("*New alert*")
+
+
+def test_a_broken_named_template_degrades_to_the_default_and_says_so():
+    session = _session(first=_template(body_template="{{ nope }}"))
+    message, err = _render(_route(template_id=7), _event(), session)
+
+    assert message.body.startswith("*New alert*"), "a broken template must not drop the notification"
+    assert err is not None and "nope" in err
+    assert message.is_custom is False
+
+
+# ── subject and format ────────────────────────────────────────────────────
+
+
+def test_a_template_subject_reaches_the_message():
+    session = _session(first=_template(subject_template="{{ severity }} — {{ alert_name }}"))
+    message, _err = _render(_route(template_id=7), _event(), session)
+
+    assert message.subject == "High — Mimikatz signature"
+
+
+def test_a_multiline_subject_is_collapsed_to_one_line():
+    """A newline in a subject would produce a header-shaped string."""
+    session = _session(first=_template(subject_template="line one\nline two"))
+    message, _err = _render(_route(template_id=7), _event(), session)
+
+    assert message.subject == "line one line two"
+
+
+def test_no_subject_template_leaves_the_provider_to_compose_one():
+    session = _session(first=_template())
+    message, _err = _render(_route(template_id=7), _event(), session)
+
+    assert message.subject is None
+
+
+def test_the_declared_format_travels_with_the_message():
+    session = _session(first=_template(format="html", body_template="<p>{{ alert_name }}</p>"))
+    message, _err = _render(_route(channel="resend", template_id=7), _event(), session)
+
+    assert message.format == "html"
+
+
+def test_html_templates_autoescape():
+    """Only the HTML format escapes — doing it globally would turn every `&` in
+    a Slack message into `&amp;`."""
+    session = _session(first=_template(format="html", body_template="<p>{{ alert_name }}</p>"))
+    event = _event(context={"alert_name": "<script>x</script>"})
+    message, err = _render(_route(channel="resend", template_id=7), event, session)
+
+    assert err is None
+    assert "<script>" not in message.body
+    assert "&lt;script&gt;" in message.body
+
+
+def test_text_templates_do_not_escape():
+    session = _session(first=_template(body_template="{{ alert_name }}"))
+    event = _event(context={"alert_name": "A & B"})
+    message, _err = _render(_route(template_id=7), event, session)
+
+    assert message.body == "A & B"
+
+
+# ── branding ──────────────────────────────────────────────────────────────
+
+
+def test_branding_is_not_resolved_unless_the_template_asks_for_it():
+    """The lookup is a DB read on the ingest hot path; skipping it for the
+    common plain-text template is the whole point of the substring check."""
+    session = _session(first=_template(body_template="plain body, no theming"))
+    calls = []
+
+    async def _spy(customer_code, sess):
+        calls.append(customer_code)
+        return dict(_FALLBACK_BRANDING)
+
+    original = svc.build_branding_context
+    svc.build_branding_context = _spy
+    try:
+        _render(_route(template_id=7), _event(), session)
+    finally:
+        svc.build_branding_context = original
+
+    assert calls == []
+
+
+def test_branding_is_resolved_when_the_template_references_it():
+    session = _session(first=_template(body_template="{{ branding.title }}"))
+    calls = []
+
+    async def _spy(customer_code, sess):
+        calls.append(customer_code)
+        return {**_FALLBACK_BRANDING, "title": "Acme Security"}
+
+    original = svc.build_branding_context
+    svc.build_branding_context = _spy
+    try:
+        message, err = _render(_route(template_id=7), _event(), session)
+    finally:
+        svc.build_branding_context = original
+
+    assert err is None
+    assert calls == [CUSTOMER]
+    assert message.body == "Acme Security"
+
+
+def test_branding_never_shadows_an_event_variable():
+    """A branding key colliding with `severity` must not change what an existing
+    template means."""
+
+    async def _spy(customer_code, sess):
+        # A full theme plus a key that collides with an event variable.
+        return {**_FALLBACK_BRANDING, "severity": "Informational"}
+
+    # `branding` appears in the source, so the lookup runs.
+    session = _session(first=_template(body_template="{{ severity }}{{ branding.title }}"))
+    original = svc.build_branding_context
+    svc.build_branding_context = _spy
+    try:
+        message, _err = _render(_route(template_id=7), _event(), session)
+    finally:
+        svc.build_branding_context = original
+
+    assert message.body.startswith("High")
+
+
+# ── the StrictUndefined trap ──────────────────────────────────────────────
+
+
+def test_a_missing_context_key_renders_empty():
+    """The regression this feature would otherwise have shipped.
+
+    `context` is a free-form per-event bag: `asset_name` is present on one alert
+    and absent on the next. Under strict lookup a template guarding on it renders
+    fine against the fully-populated preview event and then falls back to the
+    channel default on a sparse real one — passing preview while silently
+    degrading in production.
+    """
+    sparse = _event(context={})
+    out = render("[{% if context.asset_name %}{{ context.asset_name }}{% endif %}]", sparse)
+    assert out == "[]"
+
+
+def test_a_missing_top_level_variable_still_raises():
+    """Strictness stays where it belongs: the top-level names are a fixed
+    contract, and a typo in one is a bug worth failing on."""
+    with pytest.raises(Exception) as exc:
+        render("{{ summry }}", _event())
+    assert "summry" in str(exc.value)
+
+
+def test_rendering_does_not_mutate_the_event_context():
+    """The defaultdict inserts on read; it must be a copy."""
+    event = _event(context={"alert_name": "x"})
+    render("{{ context.nothing_here }}", event)
+    assert event.context == {"alert_name": "x"}
+
+
+# ── built-in seeds ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("spec", BUILTIN_TEMPLATES, ids=lambda s: s["name"])
+def test_every_builtin_renders_against_a_populated_event(spec):
+    event = sample_event(spec["trigger"] or "alert_created", CUSTOMER)
+    extra = {"branding": dict(_FALLBACK_BRANDING)}
+    for field in ("body_template", "subject_template"):
+        if spec[field]:
+            render(spec[field], event, autoescape=spec["format"] == "html", extra_context=extra)
+
+
+@pytest.mark.parametrize("spec", BUILTIN_TEMPLATES, ids=lambda s: s["name"])
+def test_every_builtin_renders_against_a_bare_event(spec):
+    """The case the sample event hides: empty context, no link, no assignee."""
+    bare = _event(
+        subject="",
+        summary="",
+        link_url=None,
+        context={},
+        trigger=NotificationTrigger(spec["trigger"]) if spec["trigger"] else NotificationTrigger.ALERT_CREATED,
+    )
+    extra = {"branding": dict(_FALLBACK_BRANDING)}
+    for field in ("body_template", "subject_template"):
+        if spec[field]:
+            render(spec[field], bare, autoescape=spec["format"] == "html", extra_context=extra)
+
+
+def test_builtin_names_are_unique():
+    """Seeding is idempotent by name; duplicates would insert forever."""
+    names = [s["name"] for s in BUILTIN_TEMPLATES]
+    assert len(names) == len(set(names))
+
+
+def test_html_builtins_are_only_offered_to_channels_that_render_html():
+    from app.notifications.channels import CHANNEL_REGISTRY
+
+    for spec in BUILTIN_TEMPLATES:
+        if spec["format"] != "html":
+            continue
+        accepting = [k for k, p in CHANNEL_REGISTRY.items() if "html" in p.template_formats]
+        assert accepting == ["resend"], "a chat card would show the markup"
+
+
+# ── compatibility rules ───────────────────────────────────────────────────
+
+
+def _assert_usable(template, **route_props):
+    props = dict(channel="webhook", trigger="alert_created", customer_code=CUSTOMER)
+    props.update(route_props)
+    return asyncio.run(
+        templates_svc.assert_template_usable(template.id, session=_session(first=template), **props),
+    )
+
+
+def test_a_shared_template_works_anywhere():
+    _assert_usable(_template())
+
+
+def test_a_customer_scoped_template_is_refused_on_another_customers_route():
+    with pytest.raises(HTTPException) as exc:
+        _assert_usable(_template(customer_code="OTHER"))
+    assert exc.value.status_code == 400
+    assert "OTHER" in exc.value.detail
+
+
+def test_a_customer_scoped_template_is_refused_on_an_internal_route():
+    """It would render one customer's branding into a message going to the SOC."""
+    with pytest.raises(HTTPException) as exc:
+        _assert_usable(_template(customer_code="OTHER"), customer_code=None)
+    assert exc.value.status_code == 400
+    assert "internal route" in exc.value.detail
+
+
+def test_a_trigger_scoped_template_is_refused_on_a_different_trigger():
+    with pytest.raises(HTTPException) as exc:
+        _assert_usable(_template(trigger="alert_assigned"))
+    assert exc.value.status_code == 400
+    assert "alert_assigned" in exc.value.detail
+
+
+def test_an_html_template_is_refused_on_a_chat_channel():
+    with pytest.raises(HTTPException) as exc:
+        _assert_usable(_template(format="html"), channel="teams")
+    assert exc.value.status_code == 400
+
+
+def test_an_html_template_is_accepted_on_email():
+    _assert_usable(_template(format="html"), channel="resend")
+
+
+# ── lifecycle ─────────────────────────────────────────────────────────────
+
+
+def test_deleting_a_template_detaches_routes_rather_than_deleting_them():
+    """The FK has no cascade on purpose: losing a template is an inconvenience,
+    losing a route is an outage."""
+    session = _session(first=_template())
+    session.execute.return_value.rowcount = 3
+
+    detached = asyncio.run(templates_svc.delete_template(7, session))
+
+    assert detached == 3
+    session.delete.assert_awaited_once()
+    # The UPDATE that clears the reference, not a DELETE against routes.
+    statements = [str(c.args[0]) for c in session.execute.await_args_list]
+    assert any("UPDATE customer_notification_route" in s for s in statements)
+    assert not any("DELETE FROM customer_notification_route" in s for s in statements)
+
+
+def test_builtin_templates_cannot_be_deleted():
+    session = _session(first=_template(is_default=True))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(templates_svc.delete_template(7, session))
+    assert exc.value.status_code == 400
+    session.delete.assert_not_awaited()
+
+
+def test_builtin_templates_cannot_be_edited():
+    """The next startup would recreate them anyway; the UI offers Duplicate."""
+    session = _session(first=_template(is_default=True))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(templates_svc.update_template(7, NotificationTemplateUpdate(name="mine"), session))
+    assert exc.value.status_code == 400
+    assert "Duplicate" in exc.value.detail
+
+
+def test_malformed_jinja_is_rejected_at_save_time():
+    session = _session(first=_template())
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(templates_svc.update_template(7, NotificationTemplateUpdate(body_template="{% if %}"), session))
+    assert exc.value.status_code == 400
+    assert "not valid Jinja" in exc.value.detail
+
+
+def test_an_edit_that_would_break_an_attached_route_is_refused():
+    """Otherwise the attach-time compatibility check only holds until the first
+    edit."""
+    template = _template()
+    attached = _route(channel="teams", name="Teams SOC")
+    session = _session(first=template, all_=[attached])
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(templates_svc.update_template(7, NotificationTemplateUpdate(format="html"), session))
+
+    assert exc.value.status_code == 400
+    assert "Teams SOC" in exc.value.detail
+    session.commit.assert_not_awaited()
+
+
+def test_an_edit_that_breaks_nothing_goes_through():
+    session = _session(first=_template(), all_=[_route()])
+    asyncio.run(templates_svc.update_template(7, NotificationTemplateUpdate(name="Renamed"), session))
+    session.commit.assert_awaited()
+
+
+# ── preview ───────────────────────────────────────────────────────────────
+
+
+def _preview(**over):
+    from app.notifications.schema.notifications import TemplatePreviewRequest
+
+    base = dict(body_template="{{ alert_name }}", customer_code=CUSTOMER)
+    base.update(over)
+    return asyncio.run(templates_svc.preview(TemplatePreviewRequest(**base), _session()))
+
+
+def test_preview_renders_against_a_populated_sample():
+    assert _preview()["body"] == "Suspicious PowerShell execution on WKSTN-014"
+
+
+def test_preview_returns_errors_rather_than_raising():
+    """The editor shows the error beside the template being written; a 400 would
+    clear the form."""
+    result = _preview(body_template="{{ nope }}")
+    assert result["error"] is not None
+    assert result["body"] == ""
+
+
+def test_preview_renders_the_subject_too():
+    result = _preview(subject_template="{{ severity }}!")
+    assert result["subject"] == "High!"
+
+
+def test_preview_populates_assignment_variables_for_any_trigger():
+    """So a half-written template referencing {{assignee}} previews instead of
+    looking broken."""
+    assert _preview(body_template="{{ assignee }}")["body"] == "jdoe"

--- a/backend/tests/test_notification_triggers.py
+++ b/backend/tests/test_notification_triggers.py
@@ -54,6 +54,7 @@ def _route(trigger, scope, route_id=1, notify_on_self_assign=False, min_severity
         min_severity=min_severity,
         destination="",
         format_template=None,
+        template_id=None,
         config='{"url": "https://example.invalid/hook"}',
         shuffle_integration_id=None,
         notify_on_self_assign=notify_on_self_assign,
@@ -260,14 +261,26 @@ def test_existing_template_tokens_still_render():
     """Stored format_templates predate the envelope and must keep working."""
     route = _route("alert_created", "customer")
     route.format_template = "{{severity}} on {{customer_code}} alert {{alert_id}}: {{alert_name}}"
-    body, err = svc._render_body(route, alert_created_event(alert_id=9, customer_code=CUSTOMER, alert_title="X", severity="High"))
-    assert body == f"High on {CUSTOMER} alert 9: X"
+    message, err = asyncio.run(
+        svc._render_body(
+            route,
+            alert_created_event(alert_id=9, customer_code=CUSTOMER, alert_title="X", severity="High"),
+            session=None,
+        ),
+    )
+    assert message.body == f"High on {CUSTOMER} alert 9: X"
     assert err is None, "an existing template must render cleanly under Jinja"
 
 
 def test_new_assignment_tokens_are_available():
     route = _route("alert_assigned", "internal")
     route.format_template = "{{assignee}} <- {{actor}} ({{entity_type}}#{{entity_id}})"
-    body, err = svc._render_body(route, alert_assigned_event(alert_id=3, title="t", assignee="bob", actor="alice"))
-    assert body == "bob <- alice (alert#3)"
+    message, err = asyncio.run(
+        svc._render_body(
+            route,
+            alert_assigned_event(alert_id=3, title="t", assignee="bob", actor="alice"),
+            session=None,
+        ),
+    )
+    assert message.body == "bob <- alice (alert#3)"
     assert err is None

--- a/frontend/src/api/endpoints/notifications.ts
+++ b/frontend/src/api/endpoints/notifications.ts
@@ -7,13 +7,18 @@ import type {
 	NotificationRoute,
 	NotificationRoutePayload,
 	NotificationRouteUpdatePayload,
+	NotificationTemplate,
+	NotificationTemplatePayload,
+	NotificationTemplateUpdatePayload,
 	ResendQuota,
 	ShuffleApp,
 	ShuffleIntegration,
 	ShuffleIntegrationPayload,
 	ShuffleIntegrationUpdatePayload,
 	ShuffleOrg,
-	ShuffleVerifyResult
+	ShuffleVerifyResult,
+	TemplatePreviewPayload,
+	TemplatePreviewResult
 } from "@/types/notifications"
 import { HttpClient } from "../http-client"
 
@@ -56,7 +61,12 @@ export default {
 	// Renders what manualSend would deliver, without sending. Runs the same
 	// authorization, so it can't reveal an item the caller may not see.
 	manualSendPreview(payload: ManualSendPayload) {
-		return HttpClient.post<FlaskBaseResponse & { body: string }>(`/notifications/send/preview`, payload)
+		// `subject` is non-null only when the route uses a named template that
+		// sets one; otherwise the provider composes its own at send time.
+		return HttpClient.post<FlaskBaseResponse & { body: string; subject: string | null }>(
+			`/notifications/send/preview`,
+			payload
+		)
 	},
 
 	// Sends a REAL notification through the route — consumes provider quota and
@@ -160,5 +170,59 @@ export default {
 	// connector) has access to every org we can attach.
 	listShuffleOrgs() {
 		return HttpClient.get<FlaskBaseResponse & { orgs: ShuffleOrg[] }>(`/notifications/shuffle/orgs`)
+	},
+
+	// ----- Named message templates (#1038) -----
+	//
+	// Deployment-level rather than nested under a customer: a template with a
+	// null customer_code is shared with every tenant, so there's no one customer
+	// it belongs under. `customerCode` filters the list to that customer's own
+	// templates PLUS the shared ones.
+
+	listTemplates(params?: { customerCode?: string | null; trigger?: string | null }) {
+		return HttpClient.get<FlaskBaseResponse & { templates: NotificationTemplate[] }>(`/notifications/templates`, {
+			params: {
+				customer_code: params?.customerCode || undefined,
+				trigger: params?.trigger || undefined
+			}
+		})
+	},
+
+	getTemplate(templateId: number) {
+		return HttpClient.get<FlaskBaseResponse & { template: NotificationTemplate }>(
+			`/notifications/templates/${templateId}`
+		)
+	},
+
+	createTemplate(payload: NotificationTemplatePayload) {
+		return HttpClient.post<FlaskBaseResponse & { template: NotificationTemplate }>(
+			`/notifications/templates`,
+			payload
+		)
+	},
+
+	updateTemplate(templateId: number, payload: NotificationTemplateUpdatePayload) {
+		return HttpClient.patch<FlaskBaseResponse & { template: NotificationTemplate }>(
+			`/notifications/templates/${templateId}`,
+			payload
+		)
+	},
+
+	// Routes using the template are DETACHED, not deleted — they fall back to
+	// their inline template or the channel default. The response message says
+	// how many were affected.
+	deleteTemplate(templateId: number) {
+		return HttpClient.delete<FlaskBaseResponse & { template: NotificationTemplate }>(
+			`/notifications/templates/${templateId}`
+		)
+	},
+
+	// Renders unsaved source against a sample event. A render failure comes back
+	// in `error` rather than as a non-2xx, so the editor shows it inline.
+	previewTemplate(payload: TemplatePreviewPayload) {
+		return HttpClient.post<FlaskBaseResponse & TemplatePreviewResult>(
+			`/notifications/templates/preview`,
+			payload
+		)
 	}
 }

--- a/frontend/src/app-layouts/common/Navbar/items.tsx
+++ b/frontend/src/app-layouts/common/Navbar/items.tsx
@@ -4,7 +4,7 @@ import { renderIcon } from "@/utils"
 
 import { agentsItem } from "./items/agents"
 import { healthcheckItem } from "./items/healthcheck"
-import { routerLinkItem } from "./items/helpers"
+import { parentMenuItem, routerLinkItem } from "./items/helpers"
 import { incidentManagementItem } from "./items/incident-management"
 import { logManagementItem } from "./items/log-management"
 import { reportCreationItem } from "./items/report-creation"
@@ -35,12 +35,14 @@ export default function getItems(): MenuMixedOption[] {
 			...routerLinkItem("Customers", "Customers"),
 			icon: renderIcon(CustomersIcon)
 		},
-		{
-			// Deployment-wide: where the SOC's own assignment notifications go.
-			// Distinct from a customer's routes, which live on the customer.
-			...routerLinkItem("Internal Notifications", "InternalNotifications"),
-			icon: renderIcon(InternalNotificationsIcon)
-		},
+		// Deployment-wide notification config: where the SOC's own assignment
+		// notifications go, and the shared message templates every route can
+		// render with. Both are distinct from a customer's own routes, which
+		// live on the customer.
+		parentMenuItem("Notifications", "Notifications", InternalNotificationsIcon, [
+			routerLinkItem("Internal Routes", "InternalNotifications"),
+			routerLinkItem("Message Templates", "NotificationTemplates")
+		]),
 		siemItem,
 		incidentManagementItem,
 		agentsItem,

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -223,6 +223,22 @@
 			/>
 		</template>
 
+		<n-form-item label="Shared template (optional)" :show-feedback="false">
+			<n-select
+				v-model:value="form.template_id"
+				:options="templateOptions"
+				:loading="loadingTemplates"
+				:disabled="templateDisabled"
+				clearable
+				placeholder="Use the channel default"
+			/>
+		</n-form-item>
+		<div class="text-secondary mb-2 text-xs">
+			Only templates this route can actually render are listed — a template scoped to another trigger or
+			customer, or in a format this channel can't render, is left out.
+			<router-link :to="{ name: 'NotificationTemplates' }" class="underline">Manage templates</router-link>
+		</div>
+
 		<n-form-item label="Custom message template (optional)" path="format_template" :show-feedback="false">
 			<n-input
 				v-model:value="form.format_template"
@@ -264,9 +280,13 @@
 				).
 			</template>
 			<template v-else>
-				Leave empty to use the default. Substitutions:
+				Leave empty to use the shared template above, or the channel default when there is none.
+				Substitutions:
 				<code>{{ substitutionTokens }}</code>
 			</template>
+		</div>
+		<div v-if="overridesSharedTemplate" class="text-secondary mb-2 text-xs italic">
+			This one-off template overrides the shared one for this route only.
 		</div>
 
 		<n-form-item>
@@ -302,6 +322,7 @@ import type {
 	NotificationRoutePayload,
 	NotificationScope,
 	NotificationSeverity,
+	NotificationTemplate,
 	NotificationTrigger,
 	ResendQuota,
 	ShuffleApp,
@@ -369,6 +390,7 @@ const form = reactive<NotificationRoutePayload>({
 	destination: props.editingRoute?.destination ?? "",
 	min_severity: props.editingRoute?.min_severity ?? ("Medium" as NotificationSeverity),
 	format_template: props.editingRoute?.format_template ?? "",
+	template_id: props.editingRoute?.template_id ?? null,
 	enabled: props.editingRoute?.enabled ?? true,
 	scope: props.editingRoute?.scope ?? "customer",
 	recipient_mode: props.editingRoute?.recipient_mode ?? "static",
@@ -497,6 +519,59 @@ async function loadQuota() {
 // the report — the box for the structured payload, the {{report}} token
 // for the template.
 const templateDisabled = computed(() => isWebhook.value && Boolean(cfg.include_full_report))
+
+// ----- Shared templates (#1038) -----
+//
+// Precedence at send time is: this route's inline `format_template`, then the
+// shared template picked here, then the channel default. The picker filters
+// client-side using the same rules the server enforces on save, so an operator
+// never picks something that's then refused.
+const templates = ref<NotificationTemplate[]>([])
+const loadingTemplates = ref(false)
+
+async function loadTemplates() {
+	loadingTemplates.value = true
+	try {
+		// Not filtered by trigger server-side: the trigger can change while the
+		// form is open, and re-fetching on every change would be a round trip
+		// per keystroke-equivalent. Filtering happens in `templateOptions`.
+		const res = await Api.notifications.listTemplates({ customerCode: props.customerCode })
+		templates.value = res.data.success ? res.data.templates : []
+	} catch {
+		// A failed list only costs the picker — the route is still saveable
+		// with an inline template or the channel default.
+		templates.value = []
+	} finally {
+		loadingTemplates.value = false
+	}
+}
+
+const templateOptions = computed(() =>
+	templates.value
+		.filter(t => {
+			// Trigger-agnostic templates work anywhere; a scoped one only on its
+			// own trigger, since it's written around that event's variables.
+			if (t.trigger && t.trigger !== form.trigger) return false
+			// An internal route belongs to no tenant, so a customer-scoped
+			// template would leak that customer's branding to the SOC.
+			if (t.customer_code && isInternalScope.value) return false
+			if (t.customer_code && props.customerCode && t.customer_code !== props.customerCode) return false
+			// Only email renders HTML; a chat card would show the markup.
+			const formats = activeDescriptor.value?.template_formats
+			if (formats?.length && !formats.includes(t.format)) return false
+			return true
+		})
+		.map(t => ({
+			label: t.customer_code ? `${t.name} (${t.customer_code})` : t.name,
+			value: t.id
+		}))
+)
+
+// The inline box wins over the picker, so say so rather than letting the
+// operator wonder which one is in effect.
+const overridesSharedTemplate = computed(
+	() => Boolean(form.template_id) && Boolean(form.format_template?.trim())
+)
 const fullReportDisabled = computed(() => isWebhook.value && Boolean(form.format_template?.trim()))
 // Shown literally in the help text. Kept as a constant so the template
 // doesn't nest {{ }} inside an interpolation (Vue can't parse that).
@@ -784,6 +859,9 @@ async function submit() {
 			channel: form.channel,
 			min_severity: form.min_severity,
 			format_template: sendTemplate,
+			// Explicit null rather than omitted, so clearing the picker detaches
+			// the template instead of silently leaving the old one attached.
+			template_id: form.template_id ?? null,
 			enabled: form.enabled,
 			scope: props.scope ?? "customer",
 			recipient_mode: form.recipient_mode,
@@ -867,6 +945,7 @@ async function submit() {
 
 onBeforeMount(async () => {
 	loadChannels()
+	loadTemplates()
 	loadLegacyWorkflowState()
 	await loadIntegrations()
 	// If editing a Shuffle route, prefetch the apps for its integration

--- a/frontend/src/components/notifications/ManualSendDialog.vue
+++ b/frontend/src/components/notifications/ManualSendDialog.vue
@@ -46,6 +46,11 @@
 
 				<div v-if="preview !== null" class="flex flex-col gap-1">
 					<div class="text-secondary text-xs uppercase">Preview — exactly what will be sent</div>
+					<!-- Only present when the route's template sets one. -->
+					<div v-if="previewSubject" class="mb-1 text-xs">
+						<span class="text-secondary">Subject:</span>
+						<span class="font-mono">{{ previewSubject }}</span>
+					</div>
 					<n-input
 						:value="preview"
 						type="textarea"
@@ -112,6 +117,7 @@ const routes = ref<NotificationRoute[]>([])
 const routeId = ref<number | null>(null)
 const includeAiReport = ref(false)
 const preview = ref<string | null>(null)
+const previewSubject = ref<string | null>(null)
 const previewError = ref<string | null>(null)
 const loadingRoutes = ref(false)
 const previewing = ref(false)
@@ -171,6 +177,7 @@ function onRouteChange() {
 	// A preview belongs to one route; keeping a stale one would show the operator
 	// something other than what they're about to send.
 	preview.value = null
+	previewSubject.value = null
 	previewError.value = null
 }
 
@@ -189,8 +196,10 @@ async function loadPreview() {
 	try {
 		const res = await Api.notifications.manualSendPreview(payload())
 		preview.value = res.data.body
+		previewSubject.value = res.data.subject
 	} catch (err) {
 		preview.value = null
+		previewSubject.value = null
 		previewError.value = getApiErrorMessage(err as ApiError) || "Could not render a preview."
 	} finally {
 		previewing.value = false
@@ -221,6 +230,7 @@ watch(visible, isOpen => {
 		routeId.value = null
 		includeAiReport.value = false
 		preview.value = null
+		previewSubject.value = null
 		previewError.value = null
 		loadRoutes()
 	}

--- a/frontend/src/components/notifications/NotificationTemplateForm.vue
+++ b/frontend/src/components/notifications/NotificationTemplateForm.vue
@@ -1,0 +1,374 @@
+<template>
+	<n-form ref="formRef" :model="form" :rules class="flex flex-col gap-1">
+		<div class="flex flex-wrap gap-4">
+			<n-form-item label="Name" path="name" class="grow" :show-feedback="!!fieldErrors.name">
+				<n-input v-model:value="form.name" placeholder="e.g. Alert — concise" />
+			</n-form-item>
+
+			<n-form-item label="Format" path="format" :show-feedback="false" class="min-w-40">
+				<n-select v-model:value="form.format" :options="formatOptions" />
+			</n-form-item>
+		</div>
+
+		<div class="text-secondary mb-3 text-xs">
+			<template v-if="form.format === 'html'">
+				Only <strong>email</strong> renders HTML — a chat card would show the markup — so this template can
+				only be attached to email routes. Values are escaped automatically.
+			</template>
+			<template v-else-if="form.format === 'json'">
+				Sent as a raw JSON body. Use the
+				<code>| tojson</code>
+				filter on any value you interpolate, or the result won't parse.
+			</template>
+			<template v-else>
+				Plain text with light markdown. Renders as-is in chat, email and a Teams card.
+			</template>
+		</div>
+
+		<n-form-item label="Description (optional)" :show-feedback="false">
+			<n-input v-model:value="form.description" placeholder="What this template is for" />
+		</n-form-item>
+
+		<div class="mt-4 flex flex-wrap gap-4">
+			<n-form-item label="Trigger" :show-feedback="false" class="grow">
+				<n-select v-model:value="form.trigger" :options="triggerOptions" clearable />
+			</n-form-item>
+
+			<n-form-item label="Customer" :show-feedback="false" class="grow">
+				<n-select
+					v-model:value="form.customer_code"
+					:options="customerOptions"
+					:loading="loadingCustomers"
+					clearable
+					filterable
+					placeholder="Shared with all customers"
+				/>
+			</n-form-item>
+		</div>
+
+		<div class="text-secondary mb-4 text-xs">
+			Leaving <strong>Trigger</strong> empty makes this usable anywhere. Setting it stops the template being
+			attached to a route whose event never carries the variables it references. Leaving
+			<strong>Customer</strong> empty shares it with every customer.
+		</div>
+
+		<n-form-item label="Subject (optional)" :show-feedback="false">
+			<n-input v-model:value="form.subject_template" placeholder="{{ severity }} alert on {{ customer_code }}" />
+		</n-form-item>
+		<div class="text-secondary mb-4 text-xs">
+			Used as the email subject and the Teams card title. Channels without a subject ignore it.
+		</div>
+
+		<n-form-item label="Body" path="body_template" :show-feedback="!!fieldErrors.body_template">
+			<n-input
+				v-model:value="form.body_template"
+				type="textarea"
+				:autosize="{ minRows: 10, maxRows: 26 }"
+				placeholder="Write the message. Jinja syntax — see the variables below."
+				class="font-mono text-xs!"
+			/>
+		</n-form-item>
+
+		<!--
+			Snippets insert at the end rather than at the cursor: a textarea
+			caret position is unreliable once the field has been re-rendered,
+			and appending is predictable.
+		-->
+		<div class="mb-4 flex flex-wrap items-center gap-2">
+			<span class="text-secondary text-xs">Insert:</span>
+			<n-button v-for="snippet of SNIPPETS" :key="snippet.label" size="tiny" secondary @click="append(snippet.source)">
+				{{ snippet.label }}
+			</n-button>
+		</div>
+
+		<n-collapse class="mb-4">
+			<n-collapse-item title="Available variables" name="vars">
+				<div class="text-secondary mb-2 text-xs">
+					For
+					<strong>{{ form.trigger ? triggerLabel(form.trigger) : "any trigger" }}</strong>
+					. Wrap in
+					<code>{{ mustache }}</code>
+					to output a value.
+				</div>
+				<n-table size="small" :bordered="false" :single-line="false">
+					<tbody>
+						<tr v-for="variable of variables" :key="variable.name">
+							<td class="w-48 align-top">
+								<code class="text-xs">{{ variable.name }}</code>
+							</td>
+							<td class="text-secondary align-top text-xs">
+								{{ variable.description }}
+								<template v-if="variable.example">
+									<br />
+									<span class="opacity-70">e.g. {{ variable.example }}</span>
+								</template>
+							</td>
+						</tr>
+					</tbody>
+				</n-table>
+			</n-collapse-item>
+		</n-collapse>
+
+		<div class="mb-2 flex items-center justify-between gap-4">
+			<h4 class="m-0">Preview</h4>
+			<n-button size="small" secondary :loading="previewing" :disabled="!form.body_template" @click="loadPreview">
+				<template #icon>
+					<Icon :name="RefreshIcon" :size="14" />
+				</template>
+				Refresh
+			</n-button>
+		</div>
+
+		<!--
+			Rendered against a sample event, not this customer's real data — the
+			editor must work before any matching alert exists.
+		-->
+		<n-alert v-if="preview?.error" type="warning" :bordered="false" class="mb-4">
+			{{ preview.error }}
+		</n-alert>
+		<div v-else-if="preview" class="mb-4 flex flex-col gap-2">
+			<div v-if="preview.subject" class="text-xs">
+				<span class="text-secondary uppercase">Subject</span>
+				<div class="font-mono">{{ preview.subject }}</div>
+			</div>
+			<!--
+				A sandboxed iframe, not v-html. The body is operator-authored and
+				renders in an admin's browser, so v-html would let a template
+				author run script in the previewer's session. `sandbox` with no
+				allow-* tokens blocks scripts, forms and navigation while still
+				showing the real layout — which is also a truer preview, since
+				an email client won't run scripts either.
+			-->
+			<iframe
+				v-if="form.format === 'html'"
+				:srcdoc="preview.body"
+				sandbox=""
+				title="HTML preview"
+				class="h-80 w-full rounded border bg-white"
+			/>
+			<n-input
+				v-else
+				:value="preview.body"
+				type="textarea"
+				readonly
+				:autosize="{ minRows: 4, maxRows: 20 }"
+				class="font-mono text-xs!"
+			/>
+		</div>
+		<div v-else class="text-secondary mb-4 text-xs">
+			Renders against a sample event, so you can write a template before any matching alert exists.
+		</div>
+
+		<n-alert v-if="submitError" type="error" :bordered="false" class="mb-2">{{ submitError }}</n-alert>
+
+		<div class="flex flex-wrap items-center justify-end gap-2">
+			<n-button @click="$emit('close')">Cancel</n-button>
+			<n-button type="primary" :loading="submitting" @click="submit">
+				{{ editing ? "Save changes" : "Create template" }}
+			</n-button>
+		</div>
+	</n-form>
+</template>
+
+<script setup lang="ts">
+import type { FormInst, FormRules } from "naive-ui"
+import type { ApiError } from "@/types/common"
+import type {
+	NotificationTemplate,
+	NotificationTemplateFormat,
+	NotificationTemplatePayload,
+	NotificationTrigger,
+	TemplatePreviewResult
+} from "@/types/notifications"
+import {
+	NAlert,
+	NButton,
+	NCollapse,
+	NCollapseItem,
+	NForm,
+	NFormItem,
+	NInput,
+	NSelect,
+	NTable,
+	useMessage
+} from "naive-ui"
+import { computed, onBeforeMount, reactive, ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+import { SNIPPETS, variablesForTrigger } from "./templateVariables"
+
+// The editor for a named, reusable template.
+//
+// The preview is the load-bearing part: it renders the UNSAVED source against a
+// sample event, which is what stops "it looked right in the editor" from
+// diverging from what actually goes out. It also renders errors inline rather
+// than as a failed request, because a half-written template is expected to be
+// broken and clearing the form on every keystroke-in-progress would be hostile.
+
+const props = defineProps<{
+	editingTemplate?: NotificationTemplate | null
+}>()
+
+const emit = defineEmits<{
+	(e: "submitted", template: NotificationTemplate): void
+	(e: "close"): void
+}>()
+
+const RefreshIcon = "carbon:renew"
+// Shown literally in the help text. A constant because Vue can't parse nested
+// {{ }} inside an interpolation — same reason the route form holds `reportToken`.
+const mustache = "{{ }}"
+
+const message = useMessage()
+const formRef = ref<FormInst | null>(null)
+
+// Keyed on the id, not the object: a Duplicate arrives as a populated template
+// with id 0, and must CREATE. Branching on the object being present would make
+// it overwrite template 0.
+const editing = computed(() => !!props.editingTemplate?.id)
+
+const form = reactive<NotificationTemplatePayload>({
+	name: props.editingTemplate?.name ?? "",
+	description: props.editingTemplate?.description ?? "",
+	trigger: props.editingTemplate?.trigger ?? null,
+	format: props.editingTemplate?.format ?? ("text" as NotificationTemplateFormat),
+	subject_template: props.editingTemplate?.subject_template ?? "",
+	body_template: props.editingTemplate?.body_template ?? "",
+	customer_code: props.editingTemplate?.customer_code ?? null
+})
+
+const fieldErrors = reactive<Partial<Record<"name" | "body_template", string>>>({})
+const submitError = ref<string | null>(null)
+const submitting = ref(false)
+const previewing = ref(false)
+const preview = ref<TemplatePreviewResult | null>(null)
+
+const customers = ref<{ customer_code: string; customer_name: string }[]>([])
+const loadingCustomers = ref(false)
+
+const formatOptions = [
+	{ label: "Plain text", value: "text" },
+	{ label: "Markdown", value: "markdown" },
+	{ label: "HTML (email only)", value: "html" },
+	{ label: "JSON", value: "json" }
+]
+
+const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
+	alert_created: "Alert created",
+	investigation_complete: "AI investigation complete",
+	alert_assigned: "Alert assigned",
+	case_assigned: "Case assigned",
+	case_task_assigned: "Case task assigned"
+}
+
+function triggerLabel(trigger: NotificationTrigger): string {
+	return TRIGGER_LABELS[trigger] ?? trigger
+}
+
+const triggerOptions = Object.entries(TRIGGER_LABELS).map(([value, label]) => ({ label, value }))
+
+const customerOptions = computed(() =>
+	customers.value.map(c => ({ label: `${c.customer_name} (${c.customer_code})`, value: c.customer_code }))
+)
+
+const variables = computed(() => variablesForTrigger(form.trigger ?? null))
+
+const rules: FormRules = {
+	name: { required: true, message: "A template needs a name", trigger: ["blur", "input"] },
+	body_template: { required: true, message: "A template needs a body", trigger: ["blur", "input"] }
+}
+
+function append(source: string) {
+	form.body_template = form.body_template ? `${form.body_template}\n${source}` : source
+}
+
+async function loadCustomers() {
+	loadingCustomers.value = true
+	try {
+		const res = await Api.customers.getCustomers()
+		customers.value = res.data.customers ?? []
+	} catch {
+		// A failed customer list only costs the scoping dropdown; the template
+		// is still writable and shared-with-all is the default anyway.
+		customers.value = []
+	} finally {
+		loadingCustomers.value = false
+	}
+}
+
+async function loadPreview() {
+	if (!form.body_template) return
+	previewing.value = true
+	try {
+		const res = await Api.notifications.previewTemplate({
+			body_template: form.body_template,
+			subject_template: form.subject_template || null,
+			format: form.format,
+			trigger: form.trigger ?? undefined,
+			customer_code: form.customer_code
+		})
+		preview.value = { body: res.data.body, subject: res.data.subject, error: res.data.error }
+	} catch (err) {
+		preview.value = {
+			body: "",
+			subject: null,
+			error: getApiErrorMessage(err as ApiError) || "Could not render a preview."
+		}
+	} finally {
+		previewing.value = false
+	}
+}
+
+// Debounced rather than on every keystroke: each preview is a round trip, and a
+// template mid-edit is usually invalid anyway.
+let previewTimer: ReturnType<typeof setTimeout> | undefined
+watch(
+	() => [form.body_template, form.subject_template, form.format, form.trigger, form.customer_code],
+	() => {
+		clearTimeout(previewTimer)
+		previewTimer = setTimeout(loadPreview, 600)
+	}
+)
+
+async function submit() {
+	submitError.value = null
+	try {
+		await formRef.value?.validate()
+	} catch {
+		return
+	}
+
+	submitting.value = true
+	try {
+		const payload: NotificationTemplatePayload = {
+			name: form.name,
+			description: form.description || null,
+			trigger: form.trigger ?? null,
+			format: form.format,
+			subject_template: form.subject_template || null,
+			body_template: form.body_template,
+			customer_code: form.customer_code ?? null
+		}
+
+		const existingId = props.editingTemplate?.id
+		const res = existingId
+			? await Api.notifications.updateTemplate(existingId, payload)
+			: await Api.notifications.createTemplate(payload)
+
+		message.success(editing.value ? "Template updated" : "Template created")
+		emit("submitted", res.data.template)
+	} catch (err) {
+		// Includes the "this change would break N routes" refusal, which names
+		// the routes — worth showing in full rather than as a toast that fades.
+		submitError.value = getApiErrorMessage(err as ApiError) || "Could not save the template."
+	} finally {
+		submitting.value = false
+	}
+}
+
+onBeforeMount(() => {
+	loadCustomers()
+	if (form.body_template) loadPreview()
+})
+</script>

--- a/frontend/src/components/notifications/NotificationTemplateItem.vue
+++ b/frontend/src/components/notifications/NotificationTemplateItem.vue
@@ -1,0 +1,165 @@
+<template>
+	<CardEntity hoverable embedded>
+		<template #headerMain>
+			<div class="flex items-center gap-2">
+				<Icon :name="FormatIcon" :size="16" />
+				<span class="font-medium">{{ template.name }}</span>
+			</div>
+		</template>
+
+		<template #headerExtra>
+			<Badge v-if="template.is_default" type="splitted" size="small">
+				<template #label>built-in</template>
+				<template #value>read-only</template>
+			</Badge>
+		</template>
+
+		<template #default>
+			<div class="flex flex-col gap-3 text-sm">
+				<div v-if="template.description" class="text-secondary">{{ template.description }}</div>
+
+				<!-- The first few lines, so the list is scannable without opening each one. -->
+				<code class="text-secondary block overflow-hidden text-xs leading-relaxed whitespace-pre-wrap">{{ excerpt }}</code>
+
+				<div class="flex flex-wrap items-center gap-2">
+					<Badge type="splitted" size="small">
+						<template #label>format</template>
+						<template #value>{{ template.format }}</template>
+					</Badge>
+					<Badge type="splitted" size="small">
+						<template #label>trigger</template>
+						<template #value>{{ template.trigger ? triggerLabel : "any" }}</template>
+					</Badge>
+					<Badge type="splitted" size="small">
+						<template #label>scope</template>
+						<template #value>{{ template.customer_code ?? "all customers" }}</template>
+					</Badge>
+					<Badge v-if="template.subject_template" type="splitted" size="small">
+						<template #label>subject</template>
+						<template #value>set</template>
+					</Badge>
+				</div>
+			</div>
+		</template>
+
+		<template #footerMain>
+			<div class="flex flex-wrap items-center gap-2">
+				<Badge v-if="template.created_by" type="splitted">
+					<template #label>owner</template>
+					<template #value>{{ template.created_by }}</template>
+				</Badge>
+				<Badge type="splitted">
+					<template #label>updated</template>
+					<template #value>
+						{{ formatDate(template.updated_at ?? template.created_at, dFormats.datetime) }}
+					</template>
+				</Badge>
+			</div>
+		</template>
+
+		<template #footerExtra>
+			<div class="flex items-center justify-end gap-2">
+				<!--
+					Built-ins are read-only because the next startup would recreate
+					them anyway. Duplicate is offered in their place: the copy is a
+					normal row the operator owns.
+				-->
+				<n-button size="tiny" quaternary @click="$emit('duplicate')">
+					<template #icon>
+						<Icon :name="CopyIcon" :size="14" />
+					</template>
+					Duplicate
+				</n-button>
+
+				<n-button v-if="!template.is_default" size="tiny" quaternary @click="$emit('edit')">
+					<template #icon>
+						<Icon :name="EditIcon" :size="14" />
+					</template>
+					Edit
+				</n-button>
+
+				<n-popconfirm v-if="!template.is_default" to="body" @positive-click="confirmDelete">
+					<template #trigger>
+						<n-button size="tiny" quaternary :loading="loadingDelete">
+							<template #icon>
+								<Icon :name="DeleteIcon" :size="14" />
+							</template>
+							Delete
+						</n-button>
+					</template>
+					Delete this template? Any route using it keeps working — it falls back to its own template or the
+					channel default.
+				</n-popconfirm>
+			</div>
+		</template>
+	</CardEntity>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { NotificationTemplate, NotificationTrigger } from "@/types/notifications"
+import { NButton, NPopconfirm, useMessage } from "naive-ui"
+import { computed, ref } from "vue"
+import Api from "@/api"
+import Badge from "@/components/common/Badge.vue"
+import CardEntity from "@/components/common/cards/CardEntity.vue"
+import Icon from "@/components/common/Icon.vue"
+import { useSettingsStore } from "@/stores/settings"
+import { getApiErrorMessage } from "@/utils"
+import { formatDate } from "@/utils/format"
+
+const props = defineProps<{
+	template: NotificationTemplate
+}>()
+
+const emit = defineEmits<{
+	(e: "edit"): void
+	(e: "duplicate"): void
+	(e: "deleted"): void
+}>()
+
+const FormatIcon = "carbon:document-blank"
+const EditIcon = "uil:edit-alt"
+const DeleteIcon = "ph:trash"
+const CopyIcon = "carbon:copy"
+
+const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
+	alert_created: "Alert created",
+	investigation_complete: "AI investigation complete",
+	alert_assigned: "Alert assigned",
+	case_assigned: "Case assigned",
+	case_task_assigned: "Case task assigned"
+}
+
+const message = useMessage()
+const loadingDelete = ref(false)
+const dFormats = useSettingsStore().dateFormat
+
+const triggerLabel = computed(() =>
+	props.template.trigger ? (TRIGGER_LABELS[props.template.trigger] ?? props.template.trigger) : "any"
+)
+
+const excerpt = computed(() => {
+	const lines = props.template.body_template.split("\n").slice(0, 3)
+	const truncated = props.template.body_template.split("\n").length > 3
+	return lines.join("\n") + (truncated ? "\n…" : "")
+})
+
+function confirmDelete() {
+	loadingDelete.value = true
+	Api.notifications
+		.deleteTemplate(props.template.id)
+		.then(res => {
+			// The message names how many routes were detached — worth surfacing,
+			// since those routes just changed what they send.
+			message.success(res.data.message || "Template deleted")
+			emit("deleted")
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "Could not delete the template")
+		})
+		.finally(() => {
+			loadingDelete.value = false
+		})
+}
+</script>

--- a/frontend/src/components/notifications/templateVariables.ts
+++ b/frontend/src/components/notifications/templateVariables.ts
@@ -1,0 +1,105 @@
+import type { NotificationTrigger } from "@/types/notifications"
+
+// The variables a notification template can reference, mirroring
+// `build_context` in app/notifications/services/rendering.py.
+//
+// Kept as data rather than prose so the editor can show exactly what's
+// available for the trigger being written against — a list that's wrong is
+// worse than no list, because the operator finds out at send time when the
+// route silently falls back to the channel default.
+
+export interface TemplateVariable {
+	name: string
+	description: string
+	// Shown in the editor's reference so the operator can see the shape without
+	// running a preview.
+	example?: string
+}
+
+// Available on every event regardless of trigger. These are a fixed contract:
+// a typo in one is an error at render time, not an empty string.
+export const COMMON_VARIABLES: TemplateVariable[] = [
+	{ name: "severity", description: "Critical / High / Medium / Low / Informational", example: "High" },
+	{ name: "customer_code", description: "The customer this event belongs to. Empty on internal routes.", example: "ACME" },
+	{ name: "summary", description: "The event's body text — the AI summary, or the alert's description." },
+	{ name: "subject", description: "One-line title for the event." },
+	{ name: "link_url", description: "Deep link into CoPilot. May be empty.", example: "https://…/alerts/4821" },
+	{ name: "entity_type", description: "alert, case or case_task." },
+	{ name: "entity_id", description: "Numeric id of that entity.", example: "4821" },
+	{ name: "trigger", description: "Which trigger fired this.", example: "alert_created" },
+	{
+		name: "context.…",
+		description:
+			"Free-form per-event extras. A missing key renders empty rather than failing, because the same trigger " +
+			"carries different keys on different events.",
+		example: "context.asset_name"
+	},
+	{
+		name: "branding.…",
+		description:
+			"The customer's logo and brand colours, resolved the same way a PDF report's are. Keys: logo, title, " +
+			"accent, accent_strong, accent_text.",
+		example: "branding.accent_strong"
+	}
+]
+
+// Aliases kept from before templates were Jinja, so anything written against
+// the old string-substitution renderer keeps working.
+export const LEGACY_ALIASES: TemplateVariable[] = [
+	{ name: "alert_id", description: "Alias for entity_id." },
+	{ name: "alert_name", description: "The alert's name, falling back to subject." },
+	{ name: "report_url", description: "Alias for link_url." }
+]
+
+// Only populated on the assignment triggers. Offered elsewhere too — they
+// render empty rather than failing — but listing them under a trigger that
+// never sets them would invite templates that always have a hole in them.
+export const ASSIGNMENT_VARIABLES: TemplateVariable[] = [
+	{ name: "assignee", description: "Who it was assigned to.", example: "jdoe" },
+	{ name: "actor", description: "Who did the assigning.", example: "asmith" },
+	{ name: "context.title", description: "Title of the alert, case or task." }
+]
+
+const ALERT_VARIABLES: TemplateVariable[] = [
+	{ name: "context.asset_name", description: "Host the alert fired on.", example: "WKSTN-014" },
+	{ name: "context.rule_level", description: "Wazuh rule level, when the source provides one.", example: "12" },
+	{ name: "context.iocs", description: "Indicators extracted by the investigation. Loop over it — often absent." }
+]
+
+const ASSIGNMENT_TRIGGERS: NotificationTrigger[] = ["alert_assigned", "case_assigned", "case_task_assigned"]
+
+/** Variables worth showing for a given trigger, most relevant first. */
+export function variablesForTrigger(trigger: NotificationTrigger | null): TemplateVariable[] {
+	const specific = !trigger
+		? [...ASSIGNMENT_VARIABLES, ...ALERT_VARIABLES]
+		: ASSIGNMENT_TRIGGERS.includes(trigger)
+			? ASSIGNMENT_VARIABLES
+			: ALERT_VARIABLES
+
+	return [...specific, ...COMMON_VARIABLES, ...LEGACY_ALIASES]
+}
+
+// Small worked examples, so the first thing an operator sees isn't a blank box.
+// Each one is valid against every trigger.
+export const SNIPPETS: { label: string; source: string }[] = [
+	{
+		label: "Conditional",
+		source: "{% if context.asset_name %}Asset: {{ context.asset_name }}{% endif %}"
+	},
+	{
+		label: "Loop over IOCs",
+		source: "{% for ioc in context.iocs %}• {{ ioc.value }} ({{ ioc.type }})\n{% endfor %}"
+	},
+	{
+		label: "Fallback value",
+		source: "{{ assignee or 'unassigned' }}"
+	},
+	{
+		label: "Uppercase filter",
+		source: "{{ severity | upper }}"
+	},
+	{
+		label: "Link, when there is one",
+		source: "{% if link_url %}Open in CoPilot: {{ link_url }}{% endif %}"
+	}
+]

--- a/frontend/src/router/routes/admin.ts
+++ b/frontend/src/router/routes/admin.ts
@@ -25,6 +25,15 @@ export const adminRoutes: RouteRecordRaw[] = [
 		meta: { title: "Internal Notifications", auth: true, roles: AuthUserRole.Admin }
 	},
 	{
+		// Templates are shared across tenants — one edit changes what every
+		// route using it sends — so they live outside the per-customer tree and
+		// are admin-only, same reasoning as internal routes above.
+		path: "/notification-templates",
+		name: "NotificationTemplates",
+		component: () => import("@/views/NotificationTemplates.vue"),
+		meta: { title: "Message Templates", auth: true, roles: AuthUserRole.Admin }
+	},
+	{
 		path: "/logs",
 		name: "Logs",
 		component: () => import("@/views/Logs.vue"),

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -117,6 +117,10 @@ export interface NotificationChannelDescriptor {
 	// Shuffle's org is per-customer, so it can't serve an internal route.
 	supports_internal_scope: boolean
 	secret_fields: string[]
+	// Named-template formats this channel can render. Only email does HTML — a
+	// chat card would show the markup — so the route form filters its template
+	// picker on this rather than offering one the server would refuse.
+	template_formats: NotificationTemplateFormat[]
 }
 
 export interface NotificationRoute {
@@ -129,6 +133,10 @@ export interface NotificationRoute {
 	destination: string
 	min_severity: NotificationSeverity
 	format_template: string | null
+	// A shared template this route renders with. Precedence at send time is
+	// format_template -> template_id -> the channel default, so the inline field
+	// stays a per-route override of the shared one.
+	template_id: number | null
 	enabled: boolean
 	scope: NotificationScope
 	recipient_mode: RecipientMode
@@ -153,6 +161,8 @@ export interface NotificationRoutePayload {
 	destination?: string | null
 	min_severity: NotificationSeverity
 	format_template?: string | null
+	// Null detaches the route from its named template; omit to leave it alone.
+	template_id?: number | null
 	enabled: boolean
 	scope?: NotificationScope
 	recipient_mode?: RecipientMode
@@ -229,5 +239,68 @@ export interface ShuffleOrg {
 export interface ShuffleVerifyResult {
 	org_id: string
 	app_count: number | null
+	error: string | null
+}
+
+// ----- Named message templates (#1038) -----
+
+// Only email renders HTML — a chat card would show the markup — so the format a
+// template declares is checked against the channel's `template_formats` when it
+// is attached to a route.
+export type NotificationTemplateFormat = "text" | "markdown" | "html" | "json"
+
+export interface NotificationTemplate {
+	id: number
+	name: string
+	description: string | null
+	// Null means usable with any trigger. Set restricts it to one, so a template
+	// written around {{assignee}} can't be attached where that's always empty.
+	trigger: NotificationTrigger | null
+	format: NotificationTemplateFormat
+	// Email needs a subject and a Teams card needs a title; neither is derivable
+	// from body text, which is why it's a separate field.
+	subject_template: string | null
+	body_template: string
+	// Null means shared with every customer — same convention as custom
+	// dashboard templates.
+	customer_code: string | null
+	// Seeded built-ins. Read-only: the next startup would recreate them anyway,
+	// so the UI offers Duplicate instead of Edit.
+	is_default: boolean
+	created_by: string | null
+	created_at: string
+	updated_at: string | null
+}
+
+export interface NotificationTemplatePayload {
+	name: string
+	description?: string | null
+	trigger?: NotificationTrigger | null
+	format: NotificationTemplateFormat
+	subject_template?: string | null
+	body_template: string
+	customer_code?: string | null
+}
+
+export type NotificationTemplateUpdatePayload = Partial<NotificationTemplatePayload>
+
+// Takes the source inline rather than an id so the editor previews UNSAVED
+// edits — the same reason the custom-dashboard builder previews an unsaved
+// panel set, and what keeps preview and the real send from drifting.
+export interface TemplatePreviewPayload {
+	body_template: string
+	subject_template?: string | null
+	format: NotificationTemplateFormat
+	trigger?: NotificationTrigger
+	// Drives the sample event's branding, so a template using {{ branding.* }}
+	// previews with the colours that customer would really receive.
+	customer_code?: string | null
+}
+
+export interface TemplatePreviewResult {
+	body: string
+	subject: string | null
+	// Non-null when rendering failed. Returned rather than thrown so the editor
+	// can show it beside the template being written.
 	error: string | null
 }

--- a/frontend/src/views/NotificationTemplates.vue
+++ b/frontend/src/views/NotificationTemplates.vue
@@ -1,0 +1,179 @@
+<template>
+	<div class="page">
+		<div class="mb-4 flex flex-col gap-2">
+			<h1>Message templates</h1>
+			<p class="text-secondary max-w-3xl text-sm">
+				Reusable message bodies that notification routes render with. Write one, attach it to as many routes as
+				you like, and edit it in one place.
+				<br />
+				A route can still carry its own one-off template — that always wins over the shared one, so a single
+				route can deviate without forking it.
+			</p>
+		</div>
+
+		<n-card>
+			<transition name="transition-fade" mode="out-in">
+				<div v-if="showForm" class="flex flex-col gap-4">
+					<h4>{{ formTitle }}</h4>
+					<NotificationTemplateForm
+						:key="formKey"
+						:editing-template
+						@submitted="onFormSubmitted"
+						@close="closeForm()"
+					/>
+				</div>
+				<div v-else class="flex flex-col gap-4">
+					<div class="flex flex-wrap items-center justify-between gap-4">
+						<n-button size="small" type="primary" @click="openForm()">
+							<template #icon>
+								<Icon :name="AddIcon" :size="14" />
+							</template>
+							Add template
+						</n-button>
+
+						<div class="flex flex-wrap items-center gap-2">
+							<n-select
+								v-model:value="triggerFilter"
+								:options="triggerOptions"
+								size="small"
+								clearable
+								placeholder="Any trigger"
+								class="w-56"
+								@update:value="refreshList()"
+							/>
+							<n-button size="small" :disabled="loading" @click="refreshList()">
+								<template #icon>
+									<Icon :name="RefreshIcon" :size="14" />
+								</template>
+								Refresh
+							</n-button>
+						</div>
+					</div>
+
+					<n-spin :show="loading">
+						<div class="min-h-52">
+							<template v-if="list.length">
+								<NotificationTemplateItem
+									v-for="template of list"
+									:key="template.id"
+									:template
+									class="item-appear item-appear-bottom item-appear-005 mb-2"
+									@edit="openEdit(template)"
+									@duplicate="openDuplicate(template)"
+									@deleted="refreshList()"
+								/>
+							</template>
+							<n-empty
+								v-else-if="!loading"
+								description="No templates match. Built-in templates ship with the deployment — clear the filter to see them."
+								class="h-48 justify-center"
+							/>
+						</div>
+					</n-spin>
+				</div>
+			</transition>
+		</n-card>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { NotificationTemplate, NotificationTrigger } from "@/types/notifications"
+import { NButton, NCard, NEmpty, NSelect, NSpin, useMessage } from "naive-ui"
+import { computed, onBeforeMount, ref } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import NotificationTemplateForm from "@/components/notifications/NotificationTemplateForm.vue"
+import NotificationTemplateItem from "@/components/notifications/NotificationTemplateItem.vue"
+import { getApiErrorMessage } from "@/utils"
+
+// Deployment-level rather than nested under a customer: a template with no
+// customer_code is shared with every tenant, so there's no one customer it
+// belongs under. Admin-only for writes — these are shared across tenants, so a
+// bad edit reaches every route using them at once.
+
+const AddIcon = "carbon:add"
+const RefreshIcon = "carbon:renew"
+
+const message = useMessage()
+
+const list = ref<NotificationTemplate[]>([])
+const loading = ref(false)
+const showForm = ref(false)
+const editingTemplate = ref<NotificationTemplate | null>(null)
+const triggerFilter = ref<NotificationTrigger | null>(null)
+// Bumped on every open so the form remounts with fresh state — otherwise
+// editing one template then another would keep the first one's fields.
+const formKey = ref(0)
+
+const triggerOptions = [
+	{ label: "Alert created", value: "alert_created" },
+	{ label: "AI investigation complete", value: "investigation_complete" },
+	{ label: "Alert assigned", value: "alert_assigned" },
+	{ label: "Case assigned", value: "case_assigned" },
+	{ label: "Case task assigned", value: "case_task_assigned" }
+]
+
+const formTitle = computed(() => {
+	if (!editingTemplate.value) return "Create a template"
+	// A duplicate arrives as an unsaved template with no id.
+	return editingTemplate.value.id ? `Edit ${editingTemplate.value.name}` : `Duplicate of ${editingTemplate.value.name}`
+})
+
+function openForm() {
+	editingTemplate.value = null
+	formKey.value++
+	showForm.value = true
+}
+
+function openEdit(template: NotificationTemplate) {
+	editingTemplate.value = template
+	formKey.value++
+	showForm.value = true
+}
+
+function openDuplicate(template: NotificationTemplate) {
+	// A copy with no id, so the form creates rather than updates. This is how a
+	// built-in becomes editable: the original stays as a reference.
+	editingTemplate.value = {
+		...template,
+		id: 0,
+		name: `${template.name} (copy)`,
+		is_default: false,
+		created_by: null
+	}
+	formKey.value++
+	showForm.value = true
+}
+
+function closeForm() {
+	showForm.value = false
+	editingTemplate.value = null
+}
+
+function onFormSubmitted() {
+	closeForm()
+	refreshList()
+}
+
+function refreshList() {
+	loading.value = true
+	Api.notifications
+		.listTemplates({ trigger: triggerFilter.value })
+		.then(res => {
+			if (res.data.success) {
+				list.value = res.data.templates
+			} else {
+				message.warning(res.data.message || "Failed to load templates")
+			}
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "Failed to load templates")
+		})
+		.finally(() => {
+			loading.value = false
+		})
+}
+
+onBeforeMount(refreshList)
+</script>


### PR DESCRIPTION
Closes #1038

#1037 made a route's `format_template` real Jinja, but it stayed per-route: every route re-pasted its own copy, with no reuse and no way to edit them together. This adds the shared, named version.

**Precedence at render time is inline → named → channel default.** The inline field survives deliberately as a per-route override, so one route can deviate without forking the shared copy — and so every route that predates this renders byte-for-byte what it rendered before. A route with no `template_id` doesn't even hit the DB.

## Backend

- **`notification_template` table + `customer_notification_route.template_id`.** The FK has **no cascade**, deliberately: deleting a template detaches the routes using it and reports how many, so they fall back to their inline template or the channel default. Losing a template is an inconvenience; losing a route is an outage.
- **Compatibility is checked when a template is *attached*, not when it fires.** A template scoped to `alert_assigned` references `{{assignee}}`, which is empty on `alert_created`; an HTML template can't render as a Teams card. Caught at attach time it's a 400 the operator sees; caught at send time it's a route that silently degrades forever. It's re-checked when a template is *edited* too, or that guarantee would only hold until the first edit — the refusal names the routes it would break.
- **Five built-in templates seed at startup**, idempotent by name and never overwritten on restart, so changing these strings can't silently rewrite what a running deployment already sends. They're read-only; the UI offers Duplicate.
- **Branding** (`{{ branding.* }}`) resolves through the same service the PDF reports use, so a templated email inherits exactly the branding a report would, including per-customer overrides and their global fallbacks. Only looked up when a template actually references it.

### Two fixes this surfaced

**`context.*` under `StrictUndefined` was a live trap.** The preview renders against a fully-populated sample event, but a real alert often carries a sparse `context` — so `{% if context.asset_name %}` previewed perfectly and then fell back to the channel default in production. Preview passing while production silently degrades is the worst failure mode available here. `context` is now a `defaultdict` (a copy — it inserts on read, and the event's own dict must not accumulate keys): missing keys render empty. The top-level names stay strict, since those are a fixed contract and a typo in one is a real bug. Locked in by `test_a_missing_context_key_renders_empty`.

**Providers now receive a `RenderedMessage` rather than a bare body string.** A message needs a `format` (only email renders HTML — a chat card would show the markup) and a `subject` (email needs one, a Teams card needs a title), and neither is derivable from body text. It also carries `is_custom`, which Teams and webhook branch on; they used to derive it from `route.format_template`, which named templates made wrong — a route can now have a custom body with that column empty.

## Frontend

- **Message Templates** page (`/notification-templates`, admin-only): list, create, edit, duplicate, delete, filter by trigger.
- **Editor** with format/trigger/customer scope, subject + body, snippet buttons, a per-trigger variable reference, and a debounced live preview of the **unsaved** source — the same reason the custom-dashboard builder previews an unsaved panel set, and what keeps preview and the real send from drifting. HTML previews render in a **sandboxed iframe, not `v-html`**: the body is operator-authored and renders in an admin's browser, so `v-html` would let a template author run script in the previewer's session.
- **Route form** gains a shared-template picker, filtered client-side by the same rules the server enforces, plus a note when an inline template overrides it.
- Manual-send preview now shows a templated subject.
- Nav: "Internal Notifications" becomes a **Notifications** group with *Internal Routes* and *Message Templates*.

## Migration

`e5b8f31d0c47`, chaining from `d1a7c4e2f905`. Reviewed and already applied to the dev DB. No `server_default`/`alter_column` scaffolding — the table is new, so there's nothing to backfill.

## Verification

- 391 backend tests pass (45 new), pre-commit clean, `pnpm lint` / `type-check` / `build` green.
- Exercised end-to-end against the live MySQL rather than only in unit tests: create → attach to a route → an incompatible edit refused *and not persisted* → render via the named template → inline override wins → delete detaches instead of cascading, route survives. Test rows cleaned up.