### PR TITLE
fix(agents): skip Velociraptor during sync when connector unverified

### DIFF
--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -671,7 +671,18 @@ async def sync_all_agents() -> SyncedAgentsResponse:
     logger.info("Syncing agents as part of scheduled job")
     loop = asyncio.get_event_loop()
     await loop.create_task(sync_agents_wazuh())
-    await loop.create_task(sync_agents_velociraptor())
+
+    # Velociraptor is optional — a deployment with only the Wazuh Manager verified must still
+    # complete the Wazuh side of the sync rather than failing the whole request.
+    try:
+        await loop.create_task(sync_agents_velociraptor())
+    except Exception as e:
+        logger.error(f"Failed to sync agents with Velociraptor, continuing without it: {e}")
+        return SyncedAgentsResponse(
+            success=True,
+            message=f"Agents synced from Wazuh Manager. Velociraptor sync skipped: {e}",
+        )
+
     return SyncedAgentsResponse(
         success=True,
         message="Agents synced started successfully",

--- a/backend/app/agents/services/sync.py
+++ b/backend/app/agents/services/sync.py
@@ -17,6 +17,7 @@ from app.agents.velociraptor.schema.agents import VelociraptorOrganizations
 from app.agents.wazuh.schema.agents import WazuhAgent
 from app.agents.wazuh.schema.agents import WazuhAgentsList
 from app.connectors.models import Connectors
+from app.connectors.utils import is_connector_verified
 from app.db.db_session import get_db_session
 from app.db.universal_models import Agents
 
@@ -302,6 +303,17 @@ async def update_agent_with_velociraptor_in_db(
     logger.info("Agent updated with Velociraptor details in the database")
 
 
+async def is_velociraptor_verified() -> bool:
+    """
+    Checks whether the Velociraptor connector exists and is verified.
+
+    Returns:
+        bool: True when the connector is present and verified, False otherwise.
+    """
+    async with get_db_session() as session:
+        return await is_connector_verified("Velociraptor", session)
+
+
 async def sync_agents_velociraptor() -> SyncedAgentsResponse:
     """
     Syncronizes the agents with Velociraptor. This function retrieves all the
@@ -310,16 +322,43 @@ async def sync_agents_velociraptor() -> SyncedAgentsResponse:
     `velociraptor_id` is not None, invoke the Velociraptor API and pass it the
     `velociraptor_id`.
 
+    Deployments that only run the Wazuh Manager have no Velociraptor connector to talk
+    to — that is a supported configuration, so this returns a successful no-op response
+    instead of raising when the connector is missing, unverified, or unreachable.
+
     :param session: The database session to use for querying and updating agents.
     :type session: AsyncSession
     :return: The response indicating the success of the synchronization operation and the list of agents added.
     :rtype: SyncedAgentsResponse
     """
     agents_added_list: List[VelociraptorAgent] = []
-    velo_orgs = await fetch_velociraptor_organizations()
+
+    if not await is_velociraptor_verified():
+        logger.info(
+            "Velociraptor connector is not verified. Skipping Velociraptor agent sync.",
+        )
+        return SyncedAgentsResponse(
+            success=True,
+            message="Velociraptor connector is not verified. Skipped Velociraptor agent sync.",
+            agents_added=agents_added_list,
+        )
+
+    try:
+        velo_orgs = await fetch_velociraptor_organizations()
+    except Exception as e:
+        logger.error(f"Failed to collect Velociraptor organizations: {e}")
+        return SyncedAgentsResponse(
+            success=True,
+            message=f"Skipped Velociraptor agent sync: failed to collect Velociraptor organizations: {e}",
+            agents_added=agents_added_list,
+        )
     logger.info(f"Collected Velociraptor Orgs: {velo_orgs}")
     for org in velo_orgs.organizations:
-        velociraptor_clients = await fetch_velociraptor_clients(org_id=org.OrgId)
+        try:
+            velociraptor_clients = await fetch_velociraptor_clients(org_id=org.OrgId)
+        except Exception as e:
+            logger.error(f"Failed to collect Velociraptor clients for org {org.OrgId}: {e}")
+            continue
         logger.info(f"Collected Velociraptor Clients: {velociraptor_clients}")
         velociraptor_clients = velociraptor_clients.clients if hasattr(velociraptor_clients, "clients") else []
 

--- a/backend/tests/test_agent_sync_without_velociraptor.py
+++ b/backend/tests/test_agent_sync_without_velociraptor.py
@@ -1,0 +1,54 @@
+"""Regression tests for issue #1045 — agent sync must not 500 without Velociraptor.
+
+A deployment where only the Wazuh Manager connector is verified is supported:
+the Wazuh agents are still collected and written to the database, and the
+Velociraptor half of the sync is skipped instead of raising.
+
+These are pure unit tests against the sync service — no DB or app wiring; the
+connector check and the Velociraptor fetches are monkeypatched.
+
+Run with: cd backend && python -m pytest tests/test_agent_sync_without_velociraptor.py
+"""
+
+import asyncio
+import os
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.agents.services.sync as sync  # noqa: E402
+
+
+def test_sync_velociraptor_skipped_when_connector_unverified(monkeypatch):
+    called = {"orgs": False}
+
+    async def fake_verified():
+        return False
+
+    async def fake_orgs():
+        called["orgs"] = True
+        raise AssertionError("Velociraptor must not be queried when unverified")
+
+    monkeypatch.setattr(sync, "is_velociraptor_verified", fake_verified)
+    monkeypatch.setattr(sync, "fetch_velociraptor_organizations", fake_orgs)
+
+    response = asyncio.run(sync.sync_agents_velociraptor())
+
+    assert response.success is True
+    assert "not verified" in response.message
+    assert called["orgs"] is False
+
+
+def test_sync_velociraptor_skipped_when_org_collection_fails(monkeypatch):
+    async def fake_verified():
+        return True
+
+    async def fake_orgs():
+        raise RuntimeError("gRPC channel unavailable")
+
+    monkeypatch.setattr(sync, "is_velociraptor_verified", fake_verified)
+    monkeypatch.setattr(sync, "fetch_velociraptor_organizations", fake_orgs)
+
+    response = asyncio.run(sync.sync_agents_velociraptor())
+
+    assert response.success is True
+    assert "gRPC channel unavailable" in response.message


### PR DESCRIPTION
Closes #1045

## Problem

`POST /agents/sync` returned a 500 on deployments where only the Wazuh Manager connector is verified. The route awaited `sync_agents_velociraptor()` unconditionally, and `UniversalService.create("Velociraptor")` raises when the connector row is missing, unverified, or the gRPC endpoint is unreachable. The Wazuh half of the sync had already collected and written agents, but the request still failed — and the scheduled `agent_sync` job never stamped `last_success`.

## Changes

**`backend/app/agents/services/sync.py`**
- New `is_velociraptor_verified()` helper wrapping `is_connector_verified("Velociraptor", session)` — a missing connector row reads as unverified.
- `sync_agents_velociraptor()` short-circuits when unverified: logs and returns `success=True` with a "skipped" message, making zero Velociraptor calls.
- `fetch_velociraptor_organizations()` is wrapped, so a verified-but-unreachable server (gRPC down, stale config file) degrades the same way instead of raising.
- Per-org `fetch_velociraptor_clients()` is wrapped — one broken org no longer aborts the loop over the rest.

**`backend/app/agents/routes/agents.py`**
- Wazuh sync runs first, Velociraptor sync is guarded, so any residual Velociraptor failure returns a successful response noting the skip rather than a 500.

**`backend/tests/test_agent_sync_without_velociraptor.py`**
- Unit tests for both skip paths (unverified connector, org collection failure). Written in the repo's `asyncio.run` style since there is no pytest-asyncio dependency.

## Testing

`pre-commit` passes on all three files. The new tests were **not executed** — no local Python env with pytest and Docker was not running on this machine, so they need a run in CI or a working backend env.