### PR TITLE
feat(notifications): deliver the AI investigation report as rendered HTML

### DIFF
--- a/backend/app/ai_analyst/services/ai_analyst.py
+++ b/backend/app/ai_analyst/services/ai_analyst.py
@@ -46,6 +46,7 @@ from app.db.universal_models import AiAnalystPalaceLesson
 from app.db.universal_models import AiAnalystReport
 from app.db.universal_models import AiAnalystReview
 from app.incidents.models import Alert
+from app.incidents.models import Asset
 from app.notifications.services.emit import emit
 from app.notifications.services.event_builders import ai_report_reviewed_event
 from app.notifications.services.event_builders import investigation_complete_event
@@ -241,6 +242,29 @@ async def list_jobs_by_customer(customer_code: str, session: AsyncSession) -> Li
 # --- Report operations ---
 
 
+async def _alert_display_fields(alert_id: int, session: AsyncSession) -> tuple[Optional[str], Optional[str]]:
+    """(alert_name, asset_name) for a notification about `alert_id`.
+
+    The investigation emit used to send neither, so every delivered notification
+    read `Alert #14` instead of the alert's name, and the built-in template's
+    asset line could never render (#1048).
+
+    Never raises. This runs on the write-back path, where the report is already
+    durably stored — failing to decorate a notification must not turn a
+    successful submission into a 500. A missing name degrades to the old
+    behaviour rather than losing the notification.
+    """
+    try:
+        alert = await session.get(Alert, alert_id)
+        if alert is None:
+            return (None, None)
+        result = await session.execute(select(Asset.asset_name).where(Asset.alert_linked == alert_id).limit(1))
+        return (alert.alert_name, result.scalars().first())
+    except Exception as e:  # noqa: BLE001 — decoration must never fail the write-back
+        logger.warning(f"Could not resolve display fields for alert {alert_id}: {type(e).__name__}: {e}")
+        return (None, None)
+
+
 async def submit_report(request: SubmitReportRequest, session: AsyncSession) -> SubmitReportResponse:
     logger.info(f"Submitting AI analyst report for job {request.job_id}, alert {request.alert_id}")
 
@@ -270,12 +294,15 @@ async def submit_report(request: SubmitReportRequest, session: AsyncSession) -> 
     # blip or a CoPilot restart loses the notification even though the report is
     # already durably stored. Both paths build the same dedupe key, so whichever
     # arrives first wins and the other is a no-op.
+    alert_name, asset_name = await _alert_display_fields(report.alert_id, session)
     emit(
         investigation_complete_event(
             alert_id=report.alert_id,
             customer_code=report.customer_code,
             severity=report.severity_assessment,
             summary=report.summary or "An AI investigation completed for this alert.",
+            alert_name=alert_name,
+            asset_name=asset_name,
         ),
     )
 

--- a/backend/app/notifications/channels/resend.py
+++ b/backend/app/notifications/channels/resend.py
@@ -35,6 +35,7 @@ from app.notifications.channels.base import RenderedMessage
 from app.notifications.channels.base import SendResult
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.services.dispatchers import dispatch_resend
+from app.notifications.utils.markdown_html import markdown_to_html
 
 _CREDS_MEMO_KEY = "resend_creds"
 
@@ -122,9 +123,9 @@ class ResendChannel(ChannelProvider):
     supports_recipient_modes = {"static", "assignee"}
     # Empty: the API key is on the connector row, not in route config.
     secret_fields = set()
-    # The only channel that renders HTML: an `html` template is posted as both
-    # the `html` and `text` parts, so it arrives formatted and still degrades to
-    # readable text. A chat card would show the markup instead.
+    # The only channel that renders HTML. Both `html` and `markdown` templates
+    # get an HTML part alongside a text one, so they arrive formatted and still
+    # degrade to something readable. A chat card would show the markup instead.
     template_formats = {"text", "markdown", "html"}
 
     async def send(
@@ -180,10 +181,22 @@ class ResendChannel(ChannelProvider):
         # so deployment-wide inbox filtering on "[CoPilot]" keeps working.
         subject = self._subject(cfg, event, override=message.subject)
 
-        # Email is the only channel that can render HTML, so an `html` template
-        # is sent as the HTML part with the same source as the text fallback.
-        # Clients that refuse HTML still get something readable.
-        is_html = message.format == "html"
+        # Email is the only channel that can render HTML, so both HTML-capable
+        # formats get an HTML part with the rendered source as the text
+        # fallback. Clients that refuse HTML still get something readable.
+        #
+        # `markdown` is converted rather than passed through. A markdown body
+        # reaching an inbox as-is shows literal `*Severity:*` — correct in Slack
+        # and Teams where those asterisks are bold, wrong in a mail client, and
+        # unreadable once an AI report's tables are involved (#1048). `text` is
+        # deliberately left alone: the channel default body is markdown-ish but
+        # typed `text`, and converting it would change what every existing route
+        # already delivers.
+        html_body = None
+        if message.format == "html":
+            html_body = message.body
+        elif message.format == "markdown":
+            html_body = str(markdown_to_html(message.body)) or None
 
         status, error_message, latency_ms, message_id = await dispatch_resend(
             base_url=base_url,
@@ -194,7 +207,7 @@ class ResendChannel(ChannelProvider):
             reply_to=cfg.reply_to,
             subject=subject,
             text_body=message.body,
-            html_body=message.body if is_html else None,
+            html_body=html_body,
         )
         return SendResult(
             status=status,

--- a/backend/app/notifications/services/ai_report_context.py
+++ b/backend/app/notifications/services/ai_report_context.py
@@ -1,0 +1,125 @@
+"""Loading an AI investigation report into notification template context.
+
+Until #1048 the notification engine could see an investigation's 400-character
+`summary` and nothing else. The report itself — `ai_analyst_report.
+report_markdown`, typically 6–8 KB of structured findings — was written by Talon,
+displayed in CoPilot, exposed to the customer portal, and invisible to every
+delivery channel.
+
+This module closes that gap by projecting a report into a dict that templates
+reach as `{{ context.ai_report.* }}`.
+
+**A projection, never storage.** No column, no table, no migration; the same
+discipline the Detections Catalog follows. Markdown stays the source of truth
+and HTML is computed per send, because a cached copy would drift from the
+markdown the moment the renderer changes — and the conversion is sub-millisecond
+on a report this size, so there is nothing to save.
+
+**Loading is authorization-sensitive.** A report is customer data. The loader
+takes an alert id and reads unconditionally, so every caller must run its own
+access checks *first* — `manual_send` does, after `_require_object_access` and
+`_require_ai_report_permitted`. On the automatic path `dispatch_event` has
+already applied the #1014 opt-out before any rendering happens. Calling this
+earlier than either would turn it into a read primitive.
+
+**Absence is normal, not an error.** Most alerts have no investigation, cases
+never do, and a route can be configured for a customer whose AI trigger is off.
+Every path returns `None` rather than raising, and the templates guard on it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.universal_models import AiAnalystIoc
+from app.db.universal_models import AiAnalystReport
+from app.notifications.utils.markdown_html import markdown_to_html
+
+#: Cap on how many indicators reach a template. A pathological investigation
+#: could extract hundreds, and a template looping over all of them would blow
+#: through MAX_RENDERED_BYTES and drop the whole message to the channel default.
+#: Truncating is the better failure: the report body still names every indicator,
+#: and `ioc_count` tells the template the true total so it can say so.
+MAX_IOCS = 50
+
+
+def _ioc_to_dict(ioc: AiAnalystIoc) -> Dict[str, Any]:
+    return {
+        "value": ioc.ioc_value,
+        "type": ioc.ioc_type,
+        "vt_verdict": ioc.vt_verdict,
+        "vt_score": ioc.vt_score or "",
+        "details": ioc.details or "",
+    }
+
+
+async def load_ai_report_context(alert_id: int, session: AsyncSession) -> Optional[Dict[str, Any]]:
+    """The newest AI report for `alert_id`, shaped for template rendering.
+
+    Returns `None` when the alert has no report — which the callers treat as
+    "nothing to include" rather than a failure.
+
+    **Newest wins.** An alert can accumulate several reports: the 15-minute
+    scheduled sweep and the real-time trigger both run the same workflow, and a
+    re-investigation adds a row rather than replacing one. Ordering by
+    `created_at` then `id` breaks the tie deterministically when two land in the
+    same second, which the bare timestamp would not.
+    """
+    result = await session.execute(
+        select(AiAnalystReport)
+        .where(AiAnalystReport.alert_id == alert_id)
+        .order_by(AiAnalystReport.created_at.desc(), AiAnalystReport.id.desc())
+        .limit(1),
+    )
+    report = result.scalars().first()
+    if report is None:
+        return None
+
+    ioc_result = await session.execute(
+        select(AiAnalystIoc).where(AiAnalystIoc.report_id == report.id).order_by(AiAnalystIoc.id),
+    )
+    iocs: List[AiAnalystIoc] = list(ioc_result.scalars().all())
+
+    markdown = report.report_markdown or ""
+
+    return {
+        "markdown": markdown,
+        # Pre-rendered so an html-format template is one substitution rather than
+        # a filter chain, and so the conversion happens once even if a template
+        # references it twice.
+        "html": markdown_to_html(markdown),
+        "summary": report.summary or "",
+        "recommended_actions": report.recommended_actions or "",
+        # The AI's assessment of the *finding*, which is a different judgement
+        # from the alert's own severity — an alert can be Critical while its
+        # investigation concludes Medium. Exposed under its own name so a
+        # template can show both without them being confused for each other.
+        "severity": report.severity_assessment or "",
+        "created_at": report.created_at,
+        "report_id": report.id,
+        "iocs": [_ioc_to_dict(i) for i in iocs[:MAX_IOCS]],
+        "ioc_count": len(iocs),
+        "iocs_truncated": len(iocs) > MAX_IOCS,
+    }
+
+
+async def safe_load_ai_report_context(alert_id: int, session: AsyncSession) -> Optional[Dict[str, Any]]:
+    """`load_ai_report_context`, but a failure degrades instead of propagating.
+
+    Rendering sits between an event and a delivery. A malformed report or a
+    transient DB error must cost the recipient the report section, not the whole
+    notification — the same reasoning that makes `render_body` fall back rather
+    than raise.
+    """
+    try:
+        return await load_ai_report_context(alert_id, session)
+    except Exception as e:  # noqa: BLE001 — a report must never break a dispatch
+        logger.warning(f"Could not load AI report for alert {alert_id}: {type(e).__name__}: {e}")
+        return None

--- a/backend/app/notifications/services/emit.py
+++ b/backend/app/notifications/services/emit.py
@@ -60,6 +60,17 @@ async def _run(event: NotificationEvent) -> None:
                 f"{response.dispatched} sent, {response.skipped} skipped, {response.failed} failed "
                 f"across {response.routes_matched} route(s).",
             )
+        else:
+            # Logged rather than passed over in silence. A trigger nobody has
+            # subscribed to used to be indistinguishable from one that never
+            # fired: an operator whose routes were all `alert_created` saw
+            # nothing at all when an investigation completed, with no way to
+            # tell a missing route from a broken engine. Naming the trigger
+            # makes the fix obvious.
+            logger.info(
+                f"Notification emit [{event.trigger.value}] {event.entity_type}#{event.entity_id}: "
+                f"no route is configured for this trigger; nothing sent.",
+            )
     except asyncio.TimeoutError:
         logger.error(
             f"Notification emit [{event.trigger.value}] {event.entity_type}#{event.entity_id} "

--- a/backend/app/notifications/services/event_builders.py
+++ b/backend/app/notifications/services/event_builders.py
@@ -77,12 +77,19 @@ def investigation_complete_event(
     severity: Optional[str],
     summary: str,
     alert_name: Optional[str] = None,
+    asset_name: Optional[str] = None,
 ) -> NotificationEvent:
     """An AI investigation finished and its report was written back.
 
     The dedupe key is identical to the one `event_from_dispatch_request` builds,
     which is what makes CoPilot's own emit and Talon's push converge on a single
     notification rather than two.
+
+    `alert_name` and `asset_name` are optional because Talon's push has never
+    carried an asset and may omit the name — but the CoPilot-side emit passes
+    both (#1048). Without them the subject degrades to `Alert #14` and the
+    seeded template's `{% if context.asset_name %}` can never fire, which is
+    what customers were actually receiving.
     """
     return NotificationEvent(
         customer_code=customer_code,
@@ -94,7 +101,7 @@ def investigation_complete_event(
         entity_id=alert_id,
         dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.INVESTIGATION_COMPLETE.value}",
         link_url=_copilot_link(f"/alerts/{alert_id}"),
-        context={"alert_name": alert_name},
+        context={"alert_name": alert_name, "asset_name": asset_name},
     )
 
 

--- a/backend/app/notifications/services/manual_send.py
+++ b/backend/app/notifications/services/manual_send.py
@@ -54,6 +54,7 @@ from app.notifications.schema.notifications import DispatchStatus
 from app.notifications.schema.notifications import NotificationScope
 from app.notifications.schema.notifications import NotificationSeverity
 from app.notifications.schema.notifications import NotificationTrigger
+from app.notifications.services.ai_report_context import safe_load_ai_report_context
 
 SUPPORTED_ENTITY_TYPES = (EntityType.ALERT, EntityType.CASE)
 
@@ -196,6 +197,50 @@ async def _require_ai_report_permitted(
         )
 
 
+async def _attach_ai_report(
+    event: NotificationEvent,
+    entity_type: str,
+    include_ai_report: bool,
+    session: AsyncSession,
+) -> None:
+    """Load the AI report onto the event when the operator asked for it.
+
+    **Runs last, after every authorization check.** The loader reads without
+    asking who is calling, so pulling a report before `_require_object_access`
+    and `_require_ai_report_permitted` have passed would make this function the
+    read primitive those checks exist to prevent.
+
+    Refuses when there is nothing to include rather than sending silently
+    without it. The operator ticked a box that says the report will be attached;
+    delivering a notification that quietly lacks one is the wrong answer, and on
+    a customer-facing send they would have no way to tell.
+
+    Pre-populating `context["ai_report"]` also bypasses the template-source
+    guard in `_ensure_ai_report_context`, which is deliberate: a manual send
+    routinely targets a route with no template at all, where there is no source
+    to inspect and the channel default renders the report instead.
+    """
+    if not include_ai_report:
+        return
+
+    if entity_type != EntityType.ALERT:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Only an alert can carry an AI investigation report; this is a {entity_type}.",
+        )
+
+    report = await safe_load_ai_report_context(event.entity_id, session)
+    if report is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Alert {event.entity_id} has no AI investigation report to include. "
+                "Send without it, or run an investigation for this alert first."
+            ),
+        )
+    event.context["ai_report"] = report
+
+
 async def _deliver(route: CustomerNotificationRoute, event: NotificationEvent, session: AsyncSession):
     """Hand off to the channel provider and record the outcome.
 
@@ -242,6 +287,7 @@ async def preview_manual(
     await _require_ai_report_permitted(route, entity, include_ai_report, session)
 
     event = build_manual_event(entity_type=entity_type, entity_id=entity_id, entity=entity, user=user)
+    await _attach_ai_report(event, entity_type, include_ai_report, session)
     message, _template_error = await _render_body(route, event, session)
     # The whole message, not just the body: a named template can carry a
     # subject, and a preview that hid it would misrepresent what an email
@@ -278,6 +324,7 @@ async def send_manual(
     await _require_ai_report_permitted(route, entity, include_ai_report, session)
 
     event = build_manual_event(entity_type=entity_type, entity_id=entity_id, entity=entity, user=user)
+    await _attach_ai_report(event, entity_type, include_ai_report, session)
     logger.info(
         f"Manual send: {entity_type}#{entity_id} -> route {route.id} ({route.channel}, {route.scope}) "
         f"by {getattr(user, 'username', 'unknown')}",

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -62,6 +62,7 @@ from app.notifications.schema.notifications import ShuffleApp
 from app.notifications.schema.notifications import ShuffleIntegrationCreate
 from app.notifications.schema.notifications import ShuffleIntegrationUpdate
 from app.notifications.schema.notifications import ShuffleOrg
+from app.notifications.services.ai_report_context import safe_load_ai_report_context
 from app.notifications.services.dispatchers import (
     list_shuffle_apps as shuffle_apps_client,
 )
@@ -739,7 +740,43 @@ async def _ai_reports_permitted(trigger: str, customer_code: str, session: Async
     return await is_ai_reports_enabled(customer_code, session)
 
 
+def _ai_report_section(event: NotificationEvent) -> str:
+    """The AI report appended to a default body, or "" when there is none.
+
+    Exists so that ticking "Include the AI investigation report" on a route with
+    **no template at all** still delivers the report. Without this, the checkbox
+    would only work for routes an operator had already customised — which is
+    exactly the case where they least need help.
+
+    Emits the report markdown verbatim. On email that is turned into real HTML
+    downstream (the message is flagged `markdown` when this section is present);
+    on chat channels markdown is already the native format.
+    """
+    report = (event.context or {}).get("ai_report")
+    if not report:
+        return ""
+
+    body = report.get("markdown") or report.get("summary") or ""
+    if not body.strip():
+        return ""
+
+    heading = "*AI investigation*"
+    severity = report.get("severity")
+    if severity:
+        heading = f"*AI investigation* — assessed severity: *{severity}*"
+    return "\n".join(["", "---", "", heading, "", body.strip()])
+
+
 def _format_default_body(event: NotificationEvent) -> str:
+    """The channel default body, plus the AI report when one was requested.
+
+    Split from `_format_default_body_core` so every per-trigger branch gains the
+    report section without repeating the append at three return sites.
+    """
+    return _format_default_body_core(event) + _ai_report_section(event)
+
+
+def _format_default_body_core(event: NotificationEvent) -> str:
     """Default message body when a route sets no `format_template`.
 
     Markdown-ish: readable as-is in Slack, Teams and a plaintext email. Per-
@@ -835,16 +872,27 @@ async def _render_body(
     louder, and deliberately so — a message with a stray `{{foo}}` in it was
     already broken, just silently.
     """
-    fallback = _format_default_body(event)
-
     inline = route.format_template
     if inline:
+        await _ensure_ai_report_context(inline, event, session, ctx=ctx)
+        fallback = _format_default_body(event)
         body, error = render_body(inline, event, fallback)
         return (RenderedMessage(body=body, is_custom=error is None), error)
 
     template = await resolve_template_for_route(route, session)
     if template is None:
-        return (RenderedMessage(body=fallback), None)
+        fallback = _format_default_body(event)
+        # A default body that carries a report is markdown, not plain text: the
+        # report is markdown by nature, and flagging it lets the email channel
+        # render its tables instead of shipping pipes. Without a report the
+        # format stays `text`, so ordinary notifications are byte-for-byte
+        # unchanged.
+        fmt = "markdown" if (event.context or {}).get("ai_report") else "text"
+        return (RenderedMessage(body=fallback, format=fmt), None)
+
+    source = f"{template.body_template}{template.subject_template or ''}"
+    await _ensure_ai_report_context(source, event, session, ctx=ctx)
+    fallback = _format_default_body(event)
 
     autoescape = template.format == "html"
     extra = await _branding_context(template, event, session, ctx=ctx)
@@ -907,6 +955,46 @@ async def _branding_context(
         lambda: build_branding_context(customer_code, session),
     )
     return {"branding": branding}
+
+
+async def _ensure_ai_report_context(
+    source: str,
+    event: NotificationEvent,
+    session: AsyncSession,
+    *,
+    ctx: Optional[DispatchContext] = None,
+) -> None:
+    """Put the alert's AI report on the event when a template asks for it.
+
+    Follows `_branding_context`'s guard exactly, for the same reason: Jinja
+    resolves names by their literal spelling, so a template that never writes
+    `ai_report` cannot reach one, and skipping the lookup keeps a plain chat
+    template at zero extra queries on the ingest hot path. Investigations are the
+    minority of alerts and the report is the largest thing the engine can load —
+    fetching it speculatively would be the wrong default.
+
+    Injects onto `event.context` rather than passing `extra_context`, so the
+    report is reachable identically from an inline template, a named template
+    and `_format_default_body`. Manual send pre-populates the same key, which is
+    why the presence check comes before the load.
+
+    `None` is stored on a miss rather than left absent, so a second route in the
+    same batch does not re-query. Templates guard with `{% if context.ai_report %}`
+    and both a `None` and an absent key read as falsy.
+    """
+    if "ai_report" not in source:
+        return
+    if "ai_report" in (event.context or {}):
+        return
+    # Cases and tasks have no investigation; only alerts do.
+    if event.entity_type != EntityType.ALERT:
+        return
+
+    async def _load():
+        return await safe_load_ai_report_context(event.entity_id, session)
+
+    report = await ctx.memoize(f"ai_report:{event.entity_id}", _load) if ctx is not None else await _load()
+    event.context["ai_report"] = report
 
 
 async def _record_log(

--- a/backend/app/notifications/services/template_seeds.py
+++ b/backend/app/notifications/services/template_seeds.py
@@ -103,6 +103,51 @@ BUILTIN_TEMPLATES: List[Dict[str, Any]] = [
         ),
     },
     {
+        "name": "AI investigation — full report (HTML email)",
+        "description": (
+            "The complete AI investigation write-up with its tables rendered, in the customer's brand colours. "
+            "Email channels only. Falls back to the summary when an alert has no report."
+        ),
+        "trigger": "investigation_complete",
+        "format": "html",
+        # `context.ai_report` is resolved lazily — mentioning it here is what
+        # causes the report to be loaded at all (`_ensure_ai_report_context`).
+        # Every access stays guarded: an alert with no investigation renders the
+        # summary instead of failing to the channel default, which on a
+        # customer-facing route would be the worse outcome.
+        #
+        # `.html` is already `Markup`, so autoescape leaves it alone; everything
+        # else in this template is escaped normally.
+        "body_template": (
+            '<div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;'
+            'max-width:760px;margin:0 auto;padding:24px">'
+            "{% if branding.logo %}"
+            '<img src="{{ branding.logo }}" alt="{{ branding.title | default("") }}" '
+            'style="max-height:48px;margin-bottom:24px">'
+            "{% endif %}"
+            '<h2 style="color:{{ branding.accent | default("#1f2937") }};margin:0 0 8px">{{ alert_name }}</h2>'
+            '<p style="color:#6b7280;margin:0 0 24px">'
+            "Alert severity: <strong>{{ severity }}</strong>"
+            "{% if context.ai_report and context.ai_report.severity %}"
+            " · Assessed: <strong>{{ context.ai_report.severity }}</strong>"
+            "{% endif %}"
+            "{% if customer_code %} · {{ customer_code }}{% endif %}</p>"
+            "{% if context.ai_report and context.ai_report.html %}"
+            "{{ context.ai_report.html }}"
+            "{% else %}"
+            '<div style="line-height:1.6;color:#374151">{{ summary }}</div>'
+            "{% endif %}"
+            "{% if link_url %}"
+            '<p style="margin-top:32px">'
+            '<a href="{{ link_url }}" style="background:{{ branding.accent_strong | default("#2563eb") }};'
+            'color:{{ branding.accent_text | default("#ffffff") }};padding:10px 20px;border-radius:6px;'
+            'text-decoration:none;display:inline-block">View in CoPilot</a></p>'
+            "{% endif %}"
+            "</div>"
+        ),
+        "subject_template": "Investigation complete — {{ alert_name }}",
+    },
+    {
         "name": "Branded email — HTML",
         "description": (
             "HTML email in the customer's brand colours. Email channels only. "

--- a/backend/app/notifications/utils/markdown_html.py
+++ b/backend/app/notifications/utils/markdown_html.py
@@ -1,0 +1,142 @@
+"""Markdown → HTML for notification bodies.
+
+Two callers, one renderer:
+
+**AI investigation reports.** `ai_analyst_report.report_markdown` is a 6–8 KB
+document whose substance lives in GFM tables — a reconstructed event timeline,
+an IOC verdict table, a recurrence comparison. Delivered as plain text those are
+pipe-delimited noise, which is the whole reason #1048 exists.
+
+**Markdown-format templates on the email channel.** A template declaring
+`format="markdown"` used to reach an inbox as literal `*Severity:*`, because
+`ResendChannel` only ever set an HTML part for `format="html"`. Correct in Slack
+and Teams, where those asterisks are bold; wrong in a mail client.
+
+Three things here are load-bearing rather than stylistic:
+
+**`html=False` is not the default.** Both the `commonmark` and `gfm-like`
+presets ship `html: True`, so raw HTML in the source passes through unescaped.
+Report markdown is LLM-written and templates are operator-authored — neither is
+trusted enough for that — so the option is set explicitly. Verified by
+`test_raw_html_in_markdown_is_escaped`.
+
+**Tables need enabling.** They are not part of CommonMark. Under the default
+preset a GFM table renders as one run-on paragraph with visible pipes, which
+looks like working output and is the single easiest thing to get silently wrong
+here. `gfm-like` turns them on.
+
+**Styling has to be inline.** Mail clients strip or ignore `<style>` blocks with
+enough regularity that a stylesheet is not worth relying on, and an unstyled
+`<table>` renders borderless with collapsed spacing. The render rules below
+attach `style=` attributes directly to the elements that need them.
+"""
+
+from __future__ import annotations
+
+from markdown_it import MarkdownIt
+from markupsafe import Markup
+
+#: Inline styles for the elements whose default rendering is unacceptable in an
+#: email. Kept deliberately small — headings, paragraphs and lists look fine
+#: unstyled, and every rule here is one more thing to maintain.
+_TABLE_STYLE = "border-collapse:collapse;width:100%;margin:16px 0;font-size:14px"
+_TH_STYLE = "border:1px solid #d1d5db;padding:6px 10px;background:#f3f4f6;text-align:left;font-weight:600"
+_TD_STYLE = "border:1px solid #d1d5db;padding:6px 10px;vertical-align:top"
+_PRE_STYLE = "background:#f3f4f6;padding:12px;border-radius:6px;overflow-x:auto;font-size:13px"
+_CODE_STYLE = "background:#f3f4f6;padding:2px 4px;border-radius:3px;font-size:13px"
+_BLOCKQUOTE_STYLE = "border-left:3px solid #d1d5db;margin:16px 0;padding:0 0 0 16px;color:#4b5563"
+
+#: The wrapper keeps the report visually distinct from whatever surrounds it in
+#: the template, and gives one place to set a readable base font.
+_WRAPPER_STYLE = "font-family:system-ui,-apple-system,Segoe UI,sans-serif;font-size:14px;line-height:1.6;color:#374151"
+
+
+def _styled(tag: str, style: str):
+    """A render rule that emits `<tag style="...">`, preserving nothing else.
+
+    Sound for the tags used here because none of them carry markdown-authored
+    attributes — a GFM table cell has alignment at most, which is handled
+    separately below.
+    """
+
+    def rule(self, tokens, idx, options, env):  # noqa: ANN001 — markdown-it's rule signature
+        return f'<{tag} style="{style}">'
+
+    return rule
+
+
+def _td_rule(tag: str, base: str):
+    """Cell rule that honours GFM column alignment.
+
+    markdown-it puts alignment in the token's `style` attr (`text-align:right`).
+    Dropping it would silently left-align every numeric column in a report.
+    """
+
+    def rule(self, tokens, idx, options, env):  # noqa: ANN001
+        token = tokens[idx]
+        align = token.attrGet("style") or ""
+        style = f"{base};{align}" if align else base
+        return f'<{tag} style="{style}">'
+
+    return rule
+
+
+def _build_renderer() -> MarkdownIt:
+    md = MarkdownIt(
+        "gfm-like",
+        {
+            # Not the default. See the module docstring.
+            "html": False,
+            # Off because it needs the optional `linkify-it-py` package, which
+            # is not a dependency. Explicit URLs in a report still render as
+            # links via normal markdown link syntax.
+            "linkify": False,
+            "typographer": False,
+        },
+    )
+    md.add_render_rule("table_open", _styled("table", _TABLE_STYLE))
+    md.add_render_rule("th_open", _td_rule("th", _TH_STYLE))
+    md.add_render_rule("td_open", _td_rule("td", _TD_STYLE))
+    md.add_render_rule("blockquote_open", _styled("blockquote", _BLOCKQUOTE_STYLE))
+    md.add_render_rule("code_inline", _code_inline_rule)
+    md.add_render_rule("fence", _fence_rule)
+    md.add_render_rule("code_block", _fence_rule)
+    return md
+
+
+def _code_inline_rule(self, tokens, idx, options, env):  # noqa: ANN001
+    from markdown_it.common.utils import escapeHtml
+
+    return f'<code style="{_CODE_STYLE}">{escapeHtml(tokens[idx].content)}</code>'
+
+
+def _fence_rule(self, tokens, idx, options, env):  # noqa: ANN001
+    """Code blocks without syntax highlighting.
+
+    The default fence renderer would add a language class for a highlighter that
+    is not present in an email anyway; escaping the content and styling the
+    `<pre>` is the whole job.
+    """
+    from markdown_it.common.utils import escapeHtml
+
+    return f'<pre style="{_PRE_STYLE}"><code>{escapeHtml(tokens[idx].content)}</code></pre>\n'
+
+
+_RENDERER = _build_renderer()
+
+
+def markdown_to_html(source: str) -> Markup:
+    """Render `source` as HTML, wrapped and safe to inject into a template.
+
+    Returns `Markup` rather than `str` because `_render_body` turns Jinja
+    autoescaping ON for `format="html"` templates. A plain string would arrive
+    at the recipient as visible `&lt;table&gt;` tags. Marking it safe is
+    justified by the escaping done during conversion, not in spite of it — every
+    byte of the source has been through markdown-it with `html=False`.
+
+    An empty source produces empty output rather than an empty wrapper, so
+    `{% if context.ai_report.html %}` behaves the way a template author expects.
+    """
+    if not source or not source.strip():
+        return Markup("")
+    return Markup(f'<div style="{_WRAPPER_STYLE}">{_RENDERER.render(source)}</div>')

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -34,6 +34,7 @@ httpx[http2]<0.29
 influxdb-client[async]
 Jinja2
 loguru
+markdown-it-py  # direct dep since #1048 — notification bodies and AI reports render markdown to HTML for email
 miniopy-async
 packaging
 pdfkit

--- a/backend/tests/test_notification_ai_report_delivery.py
+++ b/backend/tests/test_notification_ai_report_delivery.py
@@ -1,0 +1,493 @@
+"""Delivering the AI investigation report through a notification (#1048).
+
+Before this, an investigation's 6–8 KB report was written by Talon, stored,
+displayed in CoPilot and exposed to the customer portal — and no delivery
+channel could see any of it. Routes sent the 400-character `summary`. Separately,
+the manual-send dialog offered an "Include the AI investigation report" checkbox
+that was wired only as a permission gate: ticking it could refuse a send, never
+add content.
+
+What these tests protect, in rough order of how expensive the regression would
+be:
+
+**The lazy guard.** Loading a report is the largest single read the dispatch
+loop can perform, and investigations are a minority of alerts. A template that
+never mentions `ai_report` must cost zero extra queries — `alert_created` is on
+the ingest hot path. `test_a_template_that_never_mentions_the_report_does_not_load_one`
+is the one that stops a well-meaning refactor from making every alert pay for a
+report nobody asked for.
+
+**Escaping.** Report markdown is LLM-written and reaches an HTML email. The
+`html=False` option is not the markdown-it default — both the commonmark and
+gfm-like presets ship `html: True` — so an upgrade or a preset change could
+silently start passing raw HTML through.
+
+**Tables.** They are not part of CommonMark. Under the wrong preset a GFM table
+renders as a run-on paragraph with visible pipes, which looks like working
+output. This is the single easiest thing here to get silently wrong, and it is
+also the entire reason the feature exists.
+
+**Degradation.** An alert with no report, a report over the render cap, a case
+rather than an alert — each must produce a sensible notification or a clear
+refusal, never a dropped Critical alert.
+
+Unit tests with fake sessions — no DB.
+
+Run with: cd backend && python -m pytest tests/test_notification_ai_report_delivery.py
+"""
+
+import asyncio
+import json
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from fastapi import HTTPException  # noqa: E402
+from markupsafe import Markup  # noqa: E402
+
+import app.notifications.services.manual_send as ms  # noqa: E402
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.notifications.channels.base import DispatchContext  # noqa: E402
+from app.notifications.schema.events import EntityType  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.rendering import MAX_RENDERED_BYTES  # noqa: E402
+from app.notifications.services.rendering import render_body  # noqa: E402
+from app.notifications.services.template_seeds import BUILTIN_TEMPLATES  # noqa: E402
+from app.notifications.utils.markdown_html import markdown_to_html  # noqa: E402
+
+CUSTOMER = "ACME"
+
+#: A miniature of a real report: a heading, a GFM table, and inline emphasis.
+#: Real ones run 6–8 KB with five or more tables.
+REPORT_MD = """# Investigation Report — Alert #14
+
+## Alert Summary
+- **Severity:** Medium
+
+| Field | Value | Level |
+|---|---|---:|
+| Event ID | 4732 | 12 |
+| Group | Administrators | 5 |
+
+Confirmed automated red team simulation activity.
+"""
+
+
+def _report(**over):
+    base = dict(
+        markdown=REPORT_MD,
+        html=markdown_to_html(REPORT_MD),
+        summary="A local admin was added on agent 025.",
+        recommended_actions="Create a suppression rule.",
+        severity="Medium",
+        created_at=datetime(2026, 8, 3, 21, 37, 15),
+        report_id=3,
+        iocs=[{"value": "simadmin", "type": "user", "vt_verdict": "suspicious", "vt_score": "", "details": ""}],
+        ioc_count=1,
+        iocs_truncated=False,
+    )
+    base.update(over)
+    return base
+
+
+def _event(with_report=False, **over):
+    context = {"alert_name": "Administrators Group Changed", "asset_name": "test"}
+    if with_report:
+        context["ai_report"] = _report()
+    base = dict(
+        customer_code=CUSTOMER,
+        trigger=NotificationTrigger.INVESTIGATION_COMPLETE,
+        severity=NotificationSeverity.CRITICAL,
+        subject="Administrators Group Changed",
+        summary="An AI investigation completed for this alert.",
+        entity_type=EntityType.ALERT,
+        entity_id=14,
+        dedupe_key="alert:14:investigation_complete",
+        link_url="https://copilot.invalid/alerts/14",
+        context=context,
+    )
+    base.update(over)
+    return NotificationEvent(**base)
+
+
+def _route(**over):
+    base = dict(
+        id=1,
+        name="Customer email",
+        channel="resend",
+        scope="customer",
+        customer_code=CUSTOMER,
+        enabled=True,
+        trigger="investigation_complete",
+        min_severity="Informational",
+        destination="",
+        format_template=None,
+        template_id=None,
+        config=json.dumps({"to": ["soc@acme.example"]}),
+        shuffle_integration_id=None,
+        notify_on_self_assign=False,
+        recipient_mode="static",
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _template(**over):
+    base = dict(
+        id=7,
+        name="AI report",
+        description=None,
+        trigger="investigation_complete",
+        format="html",
+        subject_template=None,
+        body_template="{{ context.ai_report.html }}",
+        customer_code=None,
+        is_default=False,
+        created_by="admin",
+        updated_at=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _session(template=None):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = template
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+def _render(route, event, session, ctx=None, loader=None):
+    """Render, with the report loader stubbed so no DB is involved.
+
+    Returns (message, template_error, loader_mock).
+    """
+    loader = loader or AsyncMock(return_value=_report())
+    with patch.object(svc, "safe_load_ai_report_context", loader):
+        message, err = asyncio.run(svc._render_body(route, event, session, ctx=ctx))
+    return message, err, loader
+
+
+# ── the markdown renderer ─────────────────────────────────────────────────
+
+
+def test_a_gfm_table_becomes_a_real_html_table():
+    """Tables are not in CommonMark. Under the default preset this renders as a
+    paragraph full of visible pipes — output that looks like it worked."""
+    html = markdown_to_html(REPORT_MD)
+
+    assert "<table" in html
+    assert "<th" in html and "<td" in html
+    assert "| Field |" not in html, "pipes left in the output mean the table extension is off"
+
+
+def test_column_alignment_survives():
+    """A right-aligned numeric column silently left-aligning is the kind of
+    regression a custom render rule introduces."""
+    html = markdown_to_html("| n |\n|---:|\n| 12 |")
+    assert "text-align:right" in html
+
+
+def test_raw_html_in_markdown_is_escaped():
+    """`html=False` is NOT the markdown-it default — both the commonmark and
+    gfm-like presets ship `html: True`. Report markdown is LLM-written and lands
+    in an email, so this option is load-bearing rather than defensive."""
+    html = markdown_to_html("Normal text <script>alert(1)</script> more")
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_styling_is_inline_because_mail_clients_drop_stylesheets():
+    html = markdown_to_html(REPORT_MD)
+
+    assert "<style" not in html, "a stylesheet would be stripped by many clients"
+    assert 'style="' in html
+
+
+def test_the_result_is_markup_so_autoescape_leaves_it_alone():
+    """`_render_body` turns autoescape ON for html templates. A plain str would
+    reach the recipient as visible &lt;table&gt; tags."""
+    assert isinstance(markdown_to_html("# x"), Markup)
+
+
+def test_empty_markdown_gives_empty_output_not_an_empty_wrapper():
+    """So `{% if context.ai_report.html %}` behaves as an author expects."""
+    assert markdown_to_html("") == ""
+    assert markdown_to_html("   \n  ") == ""
+
+
+# ── the lazy guard ────────────────────────────────────────────────────────
+
+
+def test_a_template_that_never_mentions_the_report_does_not_load_one():
+    """The hot-path guarantee. `alert_created` fires on every ingested alert and
+    almost none of them have an investigation; loading a report speculatively
+    would put the largest read in the engine on the busiest path."""
+    session = _session(template=_template(body_template="Alert: {{ alert_name }}", format="text"))
+    _message, _err, loader = _render(_route(template_id=7), _event(), session)
+
+    assert loader.await_count == 0
+
+
+def test_a_template_that_mentions_the_report_gets_one():
+    session = _session(template=_template())
+    message, err, loader = _render(_route(template_id=7), _event(), session)
+
+    assert err is None
+    assert loader.await_count == 1
+    assert "<table" in message.body
+
+
+def test_the_subject_template_also_triggers_the_load():
+    """The guard reads body and subject together — a report referenced only in
+    the subject must still resolve."""
+    session = _session(
+        template=_template(
+            body_template="Static body",
+            subject_template="{{ context.ai_report.severity }} finding",
+        ),
+    )
+    message, _err, loader = _render(_route(template_id=7), _event(), session)
+
+    assert loader.await_count == 1
+    assert message.subject == "Medium finding"
+
+
+def test_an_inline_template_can_reach_the_report_too():
+    """`include_ai_report` must not depend on which template style a route uses."""
+    session = _session()
+    message, err, loader = _render(
+        _route(format_template="Report: {{ context.ai_report.summary }}"),
+        _event(),
+        session,
+    )
+
+    assert err is None
+    assert loader.await_count == 1
+    assert "A local admin was added" in message.body
+
+
+def test_a_case_never_loads_a_report():
+    """Investigations belong to alerts. A case-assigned event reaching a
+    report-shaped template must not query for one."""
+    session = _session(template=_template(body_template="{{ context.ai_report }}", format="text"))
+    _message, _err, loader = _render(
+        _route(template_id=7),
+        _event(entity_type=EntityType.CASE, trigger=NotificationTrigger.CASE_ASSIGNED),
+        session,
+    )
+
+    assert loader.await_count == 0
+
+
+def test_an_already_attached_report_is_not_reloaded():
+    """Manual send pre-populates the key. Re-querying would be wasted work and
+    could disagree with what the preview showed."""
+    session = _session(template=_template())
+    _message, _err, loader = _render(_route(template_id=7), _event(with_report=True), session)
+
+    assert loader.await_count == 0
+
+
+def test_two_routes_in_one_dispatch_share_a_single_load():
+    """The memo lives on DispatchContext so a customer with an email route and a
+    chat route pays for the report once."""
+    event = _event()
+    ctx = DispatchContext(session=AsyncMock(), event=event)
+    loader = AsyncMock(return_value=_report())
+
+    for route_id in (1, 2):
+        _render(_route(id=route_id, template_id=7), event, _session(template=_template()), ctx=ctx, loader=loader)
+
+    assert loader.await_count == 1
+
+
+def test_a_missing_report_renders_without_raising():
+    """Most alerts have no investigation. Under StrictUndefined an unguarded
+    reference would drop the message to the channel default, so the guard has to
+    survive a None."""
+    session = _session(template=_template(body_template="{% if context.ai_report %}R{% else %}none{% endif %}", format="text"))
+    message, err, _loader = _render(
+        _route(template_id=7),
+        _event(),
+        session,
+        loader=AsyncMock(return_value=None),
+    )
+
+    assert err is None
+    assert message.body == "none"
+
+
+# ── the channel default body ──────────────────────────────────────────────
+
+
+def test_the_default_body_is_untouched_without_a_report():
+    """Every existing route must render byte-for-byte what it rendered before."""
+    session = _session()
+    message, err, _loader = _render(_route(), _event(), session)
+
+    assert err is None
+    # The strongest available statement: identical to the pre-#1048 formatter,
+    # which is still in the tree as `_format_default_body_core`.
+    assert message.body == svc._format_default_body_core(_event())
+    assert message.format == "text"
+
+
+def test_the_default_body_carries_the_report_when_one_is_attached():
+    """So ticking the checkbox works on a route with no template at all — which
+    is exactly the case where an operator most needs it to."""
+    session = _session()
+    message, _err, _loader = _render(_route(), _event(with_report=True), session)
+
+    assert "Investigation Report" in message.body
+    assert "assessed severity: *Medium*" in message.body
+
+
+def test_a_default_body_with_a_report_is_flagged_markdown():
+    """Otherwise the email channel ships the report's tables as pipes. `text`
+    stays `text` when there is no report, so nothing else changes."""
+    session = _session()
+    with_report, _e1, _l1 = _render(_route(), _event(with_report=True), session)
+    without, _e2, _l2 = _render(_route(), _event(), _session())
+
+    assert with_report.format == "markdown"
+    assert without.format == "text"
+
+
+# ── the seeded built-in ───────────────────────────────────────────────────
+
+
+def _full_report_seed():
+    return next(t for t in BUILTIN_TEMPLATES if t["name"] == "AI investigation — full report (HTML email)")
+
+
+def test_the_full_report_builtin_exists_and_is_html():
+    seed = _full_report_seed()
+
+    assert seed["format"] == "html"
+    assert seed["trigger"] == "investigation_complete"
+
+
+def test_the_full_report_builtin_renders_the_report():
+    seed = _full_report_seed()
+    body, err = render_body(
+        seed["body_template"],
+        _event(with_report=True),
+        "FALLBACK",
+        autoescape=True,
+        extra_context={"branding": {"logo": None, "accent": "#111", "accent_strong": "#222", "accent_text": "#fff", "title": "T"}},
+    )
+
+    assert err is None
+    assert "<table" in body, "the report's tables must survive Jinja autoescaping"
+    assert "&lt;table" not in body, "Markup was lost somewhere and the HTML got escaped"
+
+
+def test_the_full_report_builtin_falls_back_to_the_summary():
+    """An investigation_complete route can fire for an alert whose report row is
+    missing. Dropping to the channel default on a customer-facing route would be
+    the worse outcome, so the template degrades instead."""
+    seed = _full_report_seed()
+    body, err = render_body(
+        seed["body_template"],
+        _event(),
+        "FALLBACK",
+        autoescape=True,
+        extra_context={"branding": {"logo": None, "accent": "#111", "accent_strong": "#222", "accent_text": "#fff", "title": "T"}},
+    )
+
+    assert err is None
+    assert body != "FALLBACK"
+    assert "An AI investigation completed" in body
+
+
+def test_every_builtin_still_renders_against_an_event_with_a_report():
+    """Attaching a report adds a key to `context`; no existing built-in may
+    change behaviour or start failing because of it."""
+    branding = {"logo": None, "accent": "#111", "accent_strong": "#222", "accent_text": "#fff", "title": "T"}
+    for seed in BUILTIN_TEMPLATES:
+        body, err = render_body(
+            seed["body_template"],
+            _event(with_report=True, trigger=NotificationTrigger.ALERT_CREATED),
+            "FALLBACK",
+            autoescape=seed["format"] == "html",
+            extra_context={"branding": branding},
+        )
+        assert err is None, f"{seed['name']} failed: {err}"
+        assert body != "FALLBACK", f"{seed['name']} fell back to the channel default"
+
+
+# ── size, the one hard limit ──────────────────────────────────────────────
+
+
+def test_an_oversized_report_degrades_instead_of_disappearing():
+    """A pathological report must cost the recipient the report section, not the
+    notification. The cap is checked after rendering, so this is the path that
+    proves the fallback still engages."""
+    huge = "x" * (MAX_RENDERED_BYTES + 1)
+    session = _session(template=_template(body_template="{{ context.ai_report.markdown }}", format="text"))
+    message, err, _loader = _render(
+        _route(template_id=7),
+        _event(),
+        session,
+        loader=AsyncMock(return_value=_report(markdown=huge, html=Markup(""))),
+    )
+
+    assert err is not None and "limit" in err
+    assert message.body.startswith("*AI investigation complete*"), "the channel default should have gone out"
+
+
+# ── manual send ───────────────────────────────────────────────────────────
+
+
+def _attach(entity_type="alert", include=True, report=None):
+    event = _event()
+    with patch.object(ms, "safe_load_ai_report_context", AsyncMock(return_value=report)):
+        asyncio.run(ms._attach_ai_report(event, entity_type, include, AsyncMock()))
+    return event
+
+
+def test_ticking_the_box_attaches_the_report():
+    """The whole point: before #1048 this flag reached one permission check and
+    was then discarded, so the checkbox could only ever refuse a send."""
+    event = _attach(report=_report())
+
+    assert event.context["ai_report"]["markdown"] == REPORT_MD
+
+
+def test_leaving_the_box_unticked_loads_nothing():
+    event = _attach(include=False, report=_report())
+
+    assert "ai_report" not in event.context
+
+
+def test_asking_for_a_report_that_does_not_exist_is_refused():
+    """Silently sending without it would leave the operator believing the
+    customer received findings they never got."""
+    with pytest.raises(HTTPException) as exc:
+        _attach(report=None)
+
+    assert exc.value.status_code == 400
+    assert "no AI investigation report" in exc.value.detail
+
+
+def test_asking_for_a_report_on_a_case_is_refused():
+    """Cases have no investigations; the UI should not offer this, and the
+    server does not trust that it didn't."""
+    with pytest.raises(HTTPException) as exc:
+        _attach(entity_type="case", report=None)
+
+    assert exc.value.status_code == 400
+    assert "Only an alert" in exc.value.detail

--- a/backend/tests/test_notification_manual_send_authz.py
+++ b/backend/tests/test_notification_manual_send_authz.py
@@ -79,7 +79,24 @@ def _session(alert=None, route=None):
     return session
 
 
-def _send(user, alert, route, *, tag_ok=True, customer_ok=True, ai_enabled=True, include_ai_report=False):
+#: Stands in for a loaded AI report. These tests are about authorization, not
+#: content, so the shape only has to be truthy — but it must be *present*, or a
+#: send asking for the report is refused for having nothing to attach, which
+#: would fail these tests for a reason none of them are testing.
+_A_REPORT = {"markdown": "# Report", "html": "<h1>Report</h1>", "summary": "s", "severity": "Medium", "iocs": []}
+
+
+def _send(
+    user,
+    alert,
+    route,
+    *,
+    tag_ok=True,
+    customer_ok=True,
+    ai_enabled=True,
+    include_ai_report=False,
+    report=_A_REPORT,
+):
     sent = AsyncMock(return_value=SimpleNamespace(status="sent", error_message=None, latency_ms=5, provider_reference="r"))
     with (
         patch.object(ms, "_load_entity", AsyncMock(return_value=alert)),
@@ -87,6 +104,7 @@ def _send(user, alert, route, *, tag_ok=True, customer_ok=True, ai_enabled=True,
         patch("app.incidents.middleware.tag_access.tag_access_handler.can_user_access_alert", AsyncMock(return_value=tag_ok)),
         patch("app.middleware.customer_access.customer_access_handler.check_customer_access", AsyncMock(return_value=customer_ok)),
         patch.object(ms, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)),
+        patch.object(ms, "safe_load_ai_report_context", AsyncMock(return_value=report)),
         patch.object(ms, "_deliver", sent),
     ):
         outcome = asyncio.run(

--- a/backend/tests/test_notification_resend_channel.py
+++ b/backend/tests/test_notification_resend_channel.py
@@ -68,12 +68,13 @@ def _route(config=None, recipient_mode="static", **over):
     return SimpleNamespace(**base)
 
 
-def _send(route, event=None, creds=CREDS, recent_sends=0, user=...):
+def _send(route, event=None, creds=CREDS, recent_sends=0, user=..., message=None):
     """Invoke the provider with HTTP, connector and DB lookups stubbed.
 
     Returns (result, kwargs-the-dispatcher-was-called-with-or-None).
     """
     ev = event or _event()
+    message = message if message is not None else RenderedMessage(body="RENDERED BODY")
     sent = AsyncMock(return_value=("sent", None, 12, "msg-1"))
     creds_mock = AsyncMock(side_effect=creds) if isinstance(creds, Exception) else AsyncMock(return_value=creds)
 
@@ -92,7 +93,7 @@ def _send(route, event=None, creds=CREDS, recent_sends=0, user=...):
             CHANNEL_REGISTRY["resend"].send(
                 route=route,
                 event=ev,
-                message=RenderedMessage(body="RENDERED BODY"),
+                message=message,
                 ctx=DispatchContext(session=AsyncMock(), event=ev),
             ),
         )
@@ -290,3 +291,58 @@ def test_malformed_config_fails_only_this_route():
     assert result.status == "failed"
     assert "Invalid resend config" in result.error_message
     assert kwargs is None
+
+
+# ── body formats and the HTML part (#1048) ────────────────────────────────
+#
+# Email is the only channel that can render HTML, so the mapping from a
+# template's declared `format` onto Resend's `html`/`text` parts is where a
+# customer-visible regression is cheapest to introduce and hardest to notice —
+# nobody reads their own notification emails until one looks wrong.
+
+
+def test_a_text_body_gets_no_html_part():
+    """The channel default is markdown-ish but typed `text`. Converting it would
+    change what every pre-existing route already delivers."""
+    _result, kwargs = _send(_route(), message=RenderedMessage(body="*New alert* — severity: *Critical*", format="text"))
+
+    assert kwargs["text_body"] == "*New alert* — severity: *Critical*"
+    assert kwargs["html_body"] is None
+
+
+def test_an_html_body_is_passed_through_verbatim():
+    """An operator who wrote HTML meant that HTML — it is not re-processed."""
+    html = '<div style="color:red">Hand written</div>'
+    _result, kwargs = _send(_route(), message=RenderedMessage(body=html, format="html"))
+
+    assert kwargs["html_body"] == html
+    assert kwargs["text_body"] == html
+
+
+def test_a_markdown_body_is_converted_to_an_html_part():
+    """Previously delivered as literal `*Severity:*` — correct in Slack, wrong
+    in an inbox. The markdown source stays as the text part so a client that
+    refuses HTML still gets something readable."""
+    _result, kwargs = _send(_route(), message=RenderedMessage(body="**Severity:** Low", format="markdown"))
+
+    assert kwargs["text_body"] == "**Severity:** Low", "the plain-text part keeps the markdown source"
+    assert "<strong>Severity:</strong>" in kwargs["html_body"]
+    assert "**" not in kwargs["html_body"]
+
+
+def test_a_markdown_table_survives_into_the_html_part():
+    """The reason this conversion exists at all: an AI report's substance is in
+    its tables, and a pipe-delimited table is unreadable in a mail client."""
+    body = "| Field | Value |\n|---|---|\n| Event ID | 4732 |"
+    _result, kwargs = _send(_route(), message=RenderedMessage(body=body, format="markdown"))
+
+    assert "<table" in kwargs["html_body"]
+    assert "<td" in kwargs["html_body"]
+    assert "4732" in kwargs["html_body"]
+
+
+def test_an_empty_markdown_body_produces_no_html_part():
+    """`html: ""` would be a malformed multipart; None omits the part entirely."""
+    _result, kwargs = _send(_route(), message=RenderedMessage(body="   ", format="markdown"))
+
+    assert kwargs["html_body"] is None

--- a/frontend/src/components/notifications/ManualSendDialog.vue
+++ b/frontend/src/components/notifications/ManualSendDialog.vue
@@ -40,8 +40,21 @@
 					<strong>Internal Notifications</strong>.
 				</div>
 
-				<n-form-item v-if="selectedRoute" :show-feedback="false">
-					<n-checkbox v-model:checked="includeAiReport">Include the AI investigation report</n-checkbox>
+				<!--
+					Alerts only: an investigation belongs to an alert, and the server
+					refuses the combination for anything else. Offering it on a case
+					would be an option that can only produce an error.
+				-->
+				<n-form-item v-if="selectedRoute && entityType === 'alert'" :show-feedback="false">
+					<div class="flex flex-col gap-1">
+						<n-checkbox v-model:checked="includeAiReport" @update:checked="onOptionChange">
+							Include the AI investigation report
+						</n-checkbox>
+						<div class="text-secondary text-xs">
+							Attaches the full write-up. Email renders it formatted; chat channels receive markdown.
+							Refused if this alert has no investigation.
+						</div>
+					</div>
 				</n-form-item>
 
 				<div v-if="preview !== null" class="flex flex-col gap-1">
@@ -180,6 +193,10 @@ function onRouteChange() {
 	previewSubject.value = null
 	previewError.value = null
 }
+
+// Same reasoning as onRouteChange: including the AI report changes the rendered
+// body, so a preview taken before the toggle no longer describes the send.
+const onOptionChange = onRouteChange
 
 function payload() {
 	return {


### PR DESCRIPTION
Closes #1048.

An investigation's report — 6–8 KB of markdown whose substance lives in GFM tables — was written by Talon, stored, displayed in CoPilot and exposed to the customer portal, and **no delivery channel could see any of it**. Routes sent the 400-character `summary`. Separately, the manual-send dialog's *“Include the AI investigation report”* checkbox was wired end-to-end as a **permission gate** and never as a content switch: ticking it could refuse a send, never add content.

## What changed

**`context.ai_report`** — a report is projected into the template context (markdown, rendered HTML, summary, recommended actions, severity, IOCs) so templates and the channel default body can carry it. Markdown stays the source of truth; HTML is computed per send. **No column, no table, no migration.**

**Resolution is lazy**, guarded by the same substring check `_branding_context` uses. A template that never spells `ai_report` costs zero extra queries — `alert_created` is on the ingest hot path and investigations are a minority of alerts, so speculative loading would put the engine's largest read on its busiest path.

**Markdown templates now render to HTML on email.** A markdown body previously reached an inbox as literal `*Severity:*` — correct in Slack and Teams where those are bold, wrong in a mail client, and unreadable once a report's tables are involved. `text` is deliberately unchanged: the channel default body is markdown-ish but typed `text`, and converting it would alter what every existing route already delivers.

**New built-in** — *“AI investigation — full report (HTML email)”*, degrading to the summary when an alert has no report rather than dropping to the channel default.

### Papercuts found while tracing the flow

- `submit_report` passed neither `alert_name` nor `asset_name`, so every delivered investigation notification read `Alert #14` and the built-in template's asset line could never fire.
- A zero-match emit logged nothing, making a trigger nobody had subscribed to indistinguishable from one that never fired. This is what made the original report hard to diagnose.
- Asking for a report that doesn't exist now 400s instead of silently sending without it.

## A design decision worth flagging

“Should the full report go out automatically?” dissolved once injection became template-driven. The report is loaded only if a template asks for it, so it is **route configuration**: point an `investigation_complete` route at the summary template or the full-report template. No policy is hardcoded either way.

## Verification

**Unit** — 426 tests pass, up from 395. 31 new, covering the lazy guard (the hot-path guarantee), HTML escaping, table survival, size-cap degradation, and manual-send refusals. One pre-existing test was failing for a reason it wasn't testing (`_send` now stubs the report loader) and was fixed rather than deleted.

**End-to-end, real data** — the actual 6807-char report for alert 14 renders to 18800 chars of HTML with all five tables intact, raw HTML escaped, at 19 KB against the 64 KB render cap.

**Live delivery** — two real emails sent through `deliver_one` against the dev deployment's Resend connector and route:

| log row | path | status | provider ref |
|---|---|---|---|
| 13 | no template → default body + report, markdown→HTML | sent | `73e4bffa…` |
| 14 | new HTML built-in | sent | `0cdcaca0…` |

Row 14's heading rendered `color:#ca6b25` — patmos's real brand accent rather than the template fallback — confirming per-customer branding resolves through the live path too.

**Static** — pre-commit clean; frontend `type-check` and `lint` clean.

## Known ceiling

The 64 KB render cap is the one real limit. A report ~3.4× larger than this one would trip it and fall back to the channel default — tested, and it degrades cleanly with the reason recorded on the dispatch row. If reports grow, the answer is a real email attachment rather than a bigger cap.

## Dependency

`markdown-it-py` was already pinned at 4.2.0 in `requirements.txt` as a transitive of `rich`; promoted to a direct declaration in `requirements.in`. No lock change, no new package. `html=False` is set explicitly — **both markdown-it presets default it to `True`**, and report markdown is LLM-written.
