### PR TITLE
docs(notifications): correct stale claims, add worked examples and templates

### DIFF
--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -1,6 +1,6 @@
 # Notifications (Admin/Operator)
 
-CoPilot can send a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose **what** triggers it, **who** receives it, and **which channel** carries it.
+CoPilot can send a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose **what** triggers it, **who** receives it, **which channel** carries it, and **how the message is worded**.
 
 This guide covers the notification routing engine as a whole, plus setup for each channel: **Email (Resend)**, **Microsoft Teams**, **Shuffle**, and **direct webhooks**.
 
@@ -10,13 +10,14 @@ This guide covers the notification routing engine as a whole, plus setup for eac
 
 ## The idea
 
-A **route** is one rule. It answers three questions:
+A **route** is one rule. It answers four questions:
 
 | Question | Field |
 |---|---|
 | When should this fire? | **Trigger** |
 | How severe must it be? | **Minimum severity** |
 | Where does it go? | **Channel** + its configuration |
+| What does it say? | **Message template** (optional — there's a sensible default) |
 
 You can have as many routes as you like. Every route matching an event fires independently, so one alert can notify a customer's Teams channel *and* a webhook into your automation platform *and* nothing else, depending on what you've configured.
 
@@ -26,9 +27,41 @@ This distinction matters more than any other setting.
 
 **Customer routes** deliver to the end customer. They live under *Customers → (customer) → Notifications* and carry that customer's code. Use them for things the customer should know about: an alert was raised, an investigation concluded.
 
-**Internal routes** deliver to your SOC. They live under *Internal Notifications* in the main navigation, belong to no customer, and are **admin-only**. Use them for things your team should know about: who picked up which alert.
+**Internal routes** deliver to your SOC. They live under *Notifications → Internal Routes* in the main navigation, belong to no customer, and are **admin-only**. Use them for things your team should know about: who picked up which alert.
 
 Assignment notifications are internal by design. If you assign an ACME alert to an analyst, that notification reaches your team — never ACME's channel. This isn't configurable, and it isn't meant to be: telling a customer which of your analysts is handling their incident is rarely intended.
+
+---
+
+## Which trigger do I want?
+
+**This is the single most common source of confusion, so it's worth a section of its own.**
+
+When an alert arrives and AI analysis is enabled for that customer, **two separate events happen minutes apart**:
+
+```
+21:35:03   Alert #14 created                    →  fires "An alert is created" routes
+21:35:03   Talon investigation starts
+21:37:15   Investigation finishes, report saved →  fires "An AI investigation completes" routes
+```
+
+They are **different triggers**. A route configured for *an alert is created* will **never** fire when the investigation finishes, no matter how the rest of it is set up.
+
+That matters because **AI content only rides the second event**. If you want the investigation's findings — the summary, or the full report — you need a route with the *An AI investigation completes* trigger. A customer with only an alert-creation route gets the alert notification and nothing else, forever, and **nothing anywhere reports an error**, because a trigger with no subscriber isn't a failure — it's just an event nobody asked about.
+
+Since v0.1.85 the backend log records it explicitly:
+
+```
+Notification emit [investigation_complete] alert#14: no route is configured for this trigger; nothing sent.
+```
+
+If you expected an AI notification and didn't get one, that line is the first thing to look for.
+
+| You want… | Trigger to use |
+|---|---|
+| To know an alert happened, immediately | An alert is created |
+| The AI's conclusions about an alert | An AI investigation completes |
+| Both (two messages) | Two routes, one of each |
 
 ---
 
@@ -55,7 +88,22 @@ Assignment triggers only fire on an **actual change**. Re-saving the same assign
 
 **Minimum severity** is inclusive: a route set to *High* fires on High and Critical, not Medium.
 
-For alert creation, severity comes from the Wazuh rule level (12–15 Critical, 8–11 High, 4–7 Medium, 1–3 Low). Alerts from sources with no rule level are treated as **Medium** so they aren't silently filtered out.
+For alert creation, severity comes from the Wazuh rule level:
+
+| Rule level | Severity |
+|---|---|
+| 12–15 | Critical |
+| 8–11 | High |
+| 4–7 | Medium |
+| 1–3 | Low |
+
+**Alerts from sources with no rule level default to `High`.** Office 365, CrowdStrike, Carbon Black, Huntress and similar integrations carry no Wazuh rule level, and they are deliberately loud by default rather than silently filtered out. Change it deployment-wide with `DEFAULT_ALERT_SEVERITY` in your `.env`:
+
+```bash
+DEFAULT_ALERT_SEVERITY=Medium   # Critical | High | Medium | Low | Informational
+```
+
+> **The AI's severity is a different number.** An investigation assesses the *finding*, which often disagrees with the alert. Alert #14 in our own testing was `Critical` by rule level while its investigation concluded `Medium`. **An *AI investigation completes* route filters on the AI's assessment**, not the alert's — so a route gated at *High* will drop investigations the AI graded Medium, even for a Critical alert. If that surprises you, set AI routes lower than you'd set alert-creation routes.
 
 Assignment notifications are **Informational** — being assigned something isn't a security severity. Set assignment routes to *Informational and above*, or they'll never fire.
 
@@ -63,16 +111,96 @@ Assignment notifications are **Informational** — being assigned something isn'
 
 ## Channels
 
-| Channel | Delivers to | Can email the assignee? |
-|---|---|---|
-| **Email (Resend)** | Fixed addresses, or whoever an item is assigned to | **Yes** |
-| **Microsoft Teams** | A Teams channel, via an incoming webhook | No |
-| **Shuffle** | A Shuffle app in the customer's org | No |
-| **Webhook** | Any HTTPS endpoint | No |
+| Channel | Delivers to | Can email the assignee? | Template formats |
+|---|---|---|---|
+| **Email (Resend)** | Fixed addresses, or whoever an item is assigned to | **Yes** | text, markdown, **html** |
+| **Microsoft Teams** | A Teams channel, via an incoming webhook | No | text, markdown |
+| **Shuffle** | A Shuffle app in the customer's org | No | text, markdown |
+| **Webhook** | Any HTTPS endpoint | No | text, markdown |
 
 Only email can address a *person*. A webhook targets a fixed URL and Teams targets a fixed channel, so "notify whoever this was assigned to" requires the Resend channel.
 
+Only email renders HTML. Markdown and HTML templates are both converted to a formatted email body, with a plain-text part alongside for clients that refuse HTML. On chat channels markdown is already the native format.
+
 **Shuffle is unavailable on internal routes.** A Shuffle integration belongs to a specific customer, and an internal route has no customer — so the option isn't offered there.
+
+---
+
+## Worked examples
+
+Complete recipes. The confusion usually comes from the *combination* of settings rather than any single field, so each of these shows every choice together.
+
+### Email the customer a full AI report after every investigation
+
+The setup most people are actually after when they ask "why isn't the report being emailed?"
+
+| Field | Value |
+|---|---|
+| Where | *Customers → (customer) → Notifications* |
+| Trigger | **An AI investigation completes** |
+| Minimum severity | *Informational and above* (the AI's assessment is often Medium — see above) |
+| Channel | Email (Resend) |
+| Deliver to | A fixed list of addresses |
+| To | The customer's security contact |
+| Message template | **AI investigation — full report (HTML email)** |
+
+**Also required:** *Customers → (customer) → AI Report* must be **enabled**. It's opt-in, and while it's off every AI notification to that customer is suppressed and logged as `skipped`.
+
+The customer receives the complete write-up — timeline, IOC verdicts, recommended actions — with its tables rendered, in their brand colours.
+
+To send just a short summary instead, use the **AI investigation — customer summary** template. Same route, different template.
+
+### Teams card for Critical alerts only
+
+| Field | Value |
+|---|---|
+| Where | *Customers → (customer) → Notifications* |
+| Trigger | **An alert is created** |
+| Minimum severity | *Critical* |
+| Channel | Microsoft Teams |
+| Webhook URL | From the Teams Workflows app |
+| Message template | *(none — the default card is designed for this)* |
+
+Leave the template empty. Teams renders its own card with a severity-coloured header, a facts table and an **Open in CoPilot** link; a custom template replaces the body but not the card structure.
+
+### Email an analyst when they're handed an alert
+
+| Field | Value |
+|---|---|
+| Where | *Notifications → Internal Routes* (admin only) |
+| Trigger | **An alert is assigned** |
+| Minimum severity | *Informational and above* ← **required** |
+| Channel | Email (Resend) |
+| Deliver to | **Whoever it's assigned to** |
+| Message template | **Assignment — who and what** |
+
+Two things bite here. Assignment events are always **Informational**, so any higher floor means the route never fires. And this must be an **internal** route — assignment triggers aren't offered on customer routes because they could never match.
+
+Analysts need an email address on their CoPilot account. A missing one is recorded as `failed` with the reason rather than silently falling back to anyone else.
+
+### Push everything into your own automation
+
+| Field | Value |
+|---|---|
+| Where | *Customers → (customer) → Notifications* |
+| Trigger | **An AI investigation completes** |
+| Minimum severity | *Informational and above* |
+| Channel | Webhook |
+| Webhook URL | Your HTTPS endpoint |
+| Custom headers | `Authorization: Bearer …` |
+| Include full AI report | **On** |
+| Message template | *(none — you want the structured JSON, not prose)* |
+
+Leave the template empty so CoPilot sends its structured JSON object. A template replaces the entire body with its rendered output, which is what you want for a provider-specific shape like Discord's `{"content": …}` — and not what you want when you're parsing the payload.
+
+### Two audiences, two moments
+
+Internal first, customer only after a human has checked it:
+
+- **Route A** — internal, *An AI investigation completes*, Teams. Your team sees every investigation the moment it lands.
+- **Route B** — customer, *An AI investigation completes*, email, full-report template. The customer gets the same finding.
+
+If you want Route B to wait for analyst sign-off, that's the `ai_report_reviewed` trigger — **currently not selectable in the interface**, tracked in [#1053](https://github.com/socfortress/CoPilot/issues/1053).
 
 ---
 
@@ -103,7 +231,7 @@ Then go to **Connectors**, find **Resend**, and click **Verify**.
 
 ### 3. Create a route
 
-Under *Customers → (customer) → Notifications* (or *Internal Notifications* for assignments):
+Under *Customers → (customer) → Notifications* (or *Notifications → Internal Routes* for assignments):
 
 | Field | Notes |
 |---|---|
@@ -203,27 +331,133 @@ By default CoPilot sends a structured JSON object:
 }
 ```
 
-If you set a **custom message template**, its rendered output is sent as the raw body instead — which is how you match a provider-specific shape like Discord's `{"content": …}` or Slack's `{"text": …}`.
+**Include full AI report** is a checkbox on the route, not something you reference in a template. When it's on, the report's extra fields are merged into that same JSON object.
+
+If you set a **message template**, its rendered output is sent as the raw body *instead* of the structured object — which is how you match a provider-specific shape like Discord's `{"content": …}` or Slack's `{"text": …}`. If you're parsing the payload programmatically, leave the template empty.
 
 ---
 
-## Custom message templates
+## Message templates
 
-Any route can override the default wording. Templates use `{{token}}` substitution:
+Every route sends a sensible default message. Templates let you change the wording, the structure, and — on email — the formatting.
 
-| Token | Contains |
+There are **two ways** to set one, and they don't behave the same.
+
+### Named templates (recommended)
+
+*Notifications → Message Templates* in the main navigation. Write a template once, attach it to as many routes as you like, edit it in one place.
+
+A named template carries:
+
+| Property | Meaning |
 |---|---|
-| `{{customer_code}}` | Customer code |
-| `{{alert_id}}` / `{{entity_id}}` | The alert, case or task id |
-| `{{alert_name}}` | Alert title |
-| `{{severity}}` | Critical / High / Medium / Low / Informational |
-| `{{summary}}` | The default one-paragraph summary |
-| `{{report_url}}` | Deep link back into CoPilot |
-| `{{assignee}}` | Who it was assigned to (assignment triggers) |
-| `{{actor}}` | Who did the assigning |
-| `{{entity_type}}` | `alert`, `case` or `case_task` |
+| **Name** | How you'll recognise it in the route form |
+| **Format** | `text`, `markdown` or `html` — decides how channels render it |
+| **Subject** | Optional. Email only; other channels ignore it. |
+| **Body** | The message itself |
+| **Trigger** | Optional. Restricts the template to one trigger so it can't be attached where its variables don't exist. |
+| **Customer** | Optional. Leave empty to share it with every customer. |
 
-On webhook routes only, `{{report}}` injects the full AI report as a JSON object.
+### Inline templates (per-route override)
+
+The **Custom message body** field on an individual route. Use it when one route needs to deviate without forking a shared template.
+
+### Precedence
+
+**Inline → named → channel default.** An inline body always wins; if there's none, the route's named template is used; if there's neither, you get the channel's built-in wording.
+
+### Writing a template
+
+Templates are [Jinja](https://jinja.palletsprojects.com/en/stable/templates/) — conditionals, loops and filters all work:
+
+```jinja
+*{{ severity }}* — {{ alert_name }}
+Customer: `{{ customer_code }}`
+{% if context.asset_name %}Asset: {{ context.asset_name }}{% endif %}
+{% if link_url %}Open in CoPilot: {{ link_url }}{% endif %}
+```
+
+Available variables:
+
+| Variable | Contains |
+|---|---|
+| `{{ severity }}` | Critical / High / Medium / Low / Informational |
+| `{{ customer_code }}` | Customer code. Empty on internal routes. |
+| `{{ summary }}` | The event's body text |
+| `{{ subject }}` | One-line title |
+| `{{ link_url }}` | Deep link into CoPilot. May be empty. |
+| `{{ entity_type }}` / `{{ entity_id }}` | `alert`, `case` or `case_task`, and its id |
+| `{{ trigger }}` | Which trigger fired this |
+| `{{ assignee }}` / `{{ actor }}` | Assignment triggers only |
+| `{{ context.… }}` | Per-event extras — `context.asset_name`, `context.rule_level`, `context.iocs` |
+| `{{ branding.… }}` | Customer logo and brand colours — `logo`, `title`, `accent`, `accent_strong`, `accent_text` |
+| `{{ context.ai_report.… }}` | The AI investigation report — see below |
+
+`{{ alert_id }}`, `{{ alert_name }}` and `{{ report_url }}` are kept as aliases so anything written before templates became Jinja still works.
+
+> **A misspelled variable is an error, not an empty string.** `{{ summry }}` doesn't render blank — the whole template fails and the route falls back to the channel default, with the reason recorded on the dispatch-log row. The editor validates when you save, and the live preview shows exactly what will be sent.
+>
+> The one exception is `context.…`, where a missing key *does* render empty. The same trigger legitimately carries different keys on different events — one alert has an asset name, the next doesn't — so guard with `{% if context.asset_name %}` rather than assuming it's there.
+
+### Including the AI investigation report
+
+`{{ context.ai_report }}` gives a template the full investigation:
+
+| Field | Contains |
+|---|---|
+| `.html` | The report rendered as HTML, tables and all. **Use this in an `html` template.** |
+| `.markdown` | The raw markdown source |
+| `.summary` | The short summary |
+| `.recommended_actions` | The AI's suggested next steps |
+| `.severity` | The AI's assessment — **not** the alert's severity |
+| `.iocs` | Indicators, each with `.value`, `.type`, `.vt_verdict`, `.vt_score` |
+| `.ioc_count` | How many there were in total |
+
+Always guard it — most alerts have no investigation:
+
+```jinja
+{% if context.ai_report %}
+  {{ context.ai_report.html }}
+{% else %}
+  {{ summary }}
+{% endif %}
+```
+
+The report is only fetched when a template mentions `ai_report`, so templates that don't reference it cost nothing.
+
+### Built-in templates
+
+Six ship with every deployment, as working starting points and as worked examples of the syntax:
+
+| Template | For |
+|---|---|
+| **Alert — concise** | One-liner for high-volume chat channels |
+| **Alert — detailed with IOCs** | Full context including indicators |
+| **Assignment — who and what** | Internal routes |
+| **AI investigation — customer summary** | Plain-language wrap-up for the end customer |
+| **AI investigation — full report (HTML email)** | The complete write-up with rendered tables, in the customer's brand colours |
+| **Branded email — HTML** | A branded shell for any trigger |
+
+Built-ins are **read-only** — the next startup would recreate them anyway. Use **Duplicate** to get an editable copy.
+
+---
+
+## Sending something manually
+
+Sometimes you want to push one specific alert or case to a channel — outside the triggers and severity filters entirely.
+
+Open an alert or case and choose **Send to channel…**.
+
+| | |
+|---|---|
+| **Where it can go** | Only a **configured route** — the item's own customer's routes, plus internal ones. There's no free-text address field, by design. |
+| **Who can do it** | Internal routes: analysts and admins. Customer-facing routes: **admins only**. |
+| **Include the AI investigation report** | Attaches the full write-up. Alerts only; refused if the alert has no investigation. |
+| **Preview** | Renders exactly what will be sent, without sending it |
+
+This sends a **real** notification: it consumes provider quota and is recorded in the dispatch log with `trigger_source = manual`. Sending twice sends twice — deliberately, since clicking send twice on purpose should work.
+
+The customer AI opt-out still applies. If *Customers → (customer) → AI Report* is off, including the report is refused rather than quietly dropped.
 
 ---
 
@@ -245,15 +479,17 @@ Every saved route has a **Send test** button. It sends a **real** notification t
 
 `skipped` is not an error. It's CoPilot recording a decision it made, which is usually what you want to see when asking "why didn't I get an email".
 
+A row also carries a **template error** when a custom template failed and the channel default went out in its place — so a broken template is visible without having to reproduce it.
+
 ### Nothing arrived
 
 Work down this list:
 
-1. **Is the route enabled?**
-2. **Does the trigger match?** An assignment won't fire an *alert is created* route.
-3. **Is the severity high enough?** Assignment routes must be set to *Informational and above*.
+1. **Is there a route for that trigger at all?** The most common cause by far. An *alert is created* route does not fire when an AI investigation completes — see [Which trigger do I want?](#which-trigger-do-i-want). Check the backend log for `no route is configured for this trigger`.
+2. **Is the route enabled?**
+3. **Is the severity high enough?** Assignment routes must be set to *Informational and above*. AI routes filter on the **AI's** assessment, which is often lower than the alert's.
 4. **Right scope?** Assignment notifications only reach **internal** routes. A customer route with an assignment trigger can never fire — which is why the UI doesn't offer that combination.
-5. **Check the dispatch log.** A `failed` row carries the provider's own message. A `skipped` row says which rule applied.
+5. **Check the dispatch log.** A `failed` row carries the provider's own message. A `skipped` row says which rule applied. **No row at all** means no route matched — go back to step 1.
 6. **Is the connector verified?** Connectors → Resend → Verify.
 
 ### AI report notifications aren't arriving for one customer
@@ -261,6 +497,16 @@ Work down this list:
 There's a separate switch: *Customers → (customer) → AI Report*. It controls whether AI-written findings may reach that customer at all, and it's **opt-in** — a customer who has never been enabled is disabled.
 
 When it's off, AI notifications to that customer's routes are suppressed and logged as `skipped`. Internal routes are unaffected, so you can keep running investigations while keeping results in-house.
+
+### The email arrived but the formatting is wrong
+
+- **Asterisks showing as literal `*text*`** — the template's format is `text`. Change it to `markdown` and email will render it. Chat channels treat markdown natively either way.
+- **Tables showing as rows of `|` characters** — same cause. Markdown or HTML format renders them properly on email; chat channels can't render tables at all.
+- **HTML tags visible in the message** — an `html` template sent to a chat channel. Only email renders HTML.
+
+### The template previewed fine but the real message is the default
+
+Almost always a `context.…` variable that exists on the sample event and not on the real one. The preview uses a fully-populated sample; real events are sparser. Guard every `context.…` reference with `{% if %}`.
 
 ---
 
@@ -286,12 +532,12 @@ Both are opt-in, so this only happens if you set up both. The route form warns y
 
 ### Channel capabilities
 
-| Channel | Assignee delivery | Internal routes | Secret |
-|---|---|---|---|
-| Email (Resend) | Yes | Yes | API key on the connector |
-| Microsoft Teams | No | Yes | The webhook URL itself |
-| Webhook | No | Yes | Custom headers |
-| Shuffle | No | **No** | Deployment API key |
+| Channel | Assignee delivery | Internal routes | HTML | Secret |
+|---|---|---|---|---|
+| Email (Resend) | Yes | Yes | Yes | API key on the connector |
+| Microsoft Teams | No | Yes | No | The webhook URL itself |
+| Webhook | No | Yes | No | Custom headers |
+| Shuffle | No | **No** | No | Deployment API key |
 
 ### Environment variables
 
@@ -300,6 +546,13 @@ Both are opt-in, so this only happens if you set up both. The route form warns y
 RESEND_URL=https://api.resend.com
 RESEND_API_KEY=re_your_key_here
 RESEND_FROM_ADDRESS=alerts@yourdomain.com
+
+# Severity assumed for alerts whose source carries no rule level.
+# Default: High
+DEFAULT_ALERT_SEVERITY=High
+
+# Base URL used to build "Open in CoPilot" links. Without it, links are omitted.
+COPILOT_URL=https://copilot.yourdomain.com
 ```
 
 Teams and webhook routes need no environment configuration — their URLs live on the route. Shuffle uses the existing deployment-wide `SHUFFLER_API_KEY`.

--- a/docs/user/ui/notifications.md
+++ b/docs/user/ui/notifications.md
@@ -5,7 +5,7 @@ description: Send alerts, AI investigation results and assignment events to emai
 
 # Notifications (routes & channels)
 
-CoPilot sends a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose the **trigger**, the **severity floor**, and the **channel**.
+CoPilot sends a message when something happens — a new alert lands, an AI investigation finishes, an analyst is assigned a case. You choose the **trigger**, the **severity floor**, the **channel**, and optionally the **message template**.
 
 Four channels ship today:
 
@@ -22,15 +22,25 @@ Four channels ship today:
 
 Things the customer should know about: an alert was raised, an investigation concluded.
 
-**Internal routes** — *Internal Notifications* in the main navigation (admin only)
+**Internal routes** — *Notifications → Internal Routes* (admin only)
 
 Things your SOC should know about: who picked up which alert. These belong to no customer, which is the point — assigning an ACME alert to an analyst notifies your team, never ACME.
 
-## The one thing to know
+**Message templates** — *Notifications → Message Templates* (admin only)
+
+Reusable message bodies shared across routes. Six built-ins ship as working starting points; duplicate one to get an editable copy.
+
+## The two things that catch people
+
+**An alert being created and its AI investigation finishing are different triggers**, minutes apart. A route set to *An alert is created* will never fire when the investigation completes — and AI content only rides the second event. If you want the report, you need a route with the *An AI investigation completes* trigger. Nothing reports an error when no route matches; it just stays quiet.
 
 **Assignment notifications are internal by design.** They only reach internal routes. A customer route with an assignment trigger could never fire, so the interface doesn't offer that combination.
 
 If you want the assignee emailed directly, use the **Email (Resend)** channel with *Deliver to → Whoever it's assigned to*. It's the only channel that can address a person; a webhook targets a URL and Teams targets a channel.
+
+## Sending one item on demand
+
+Open any alert or case and choose **Send to channel…** to push it to a configured route immediately, bypassing the trigger and severity filters. Alerts can carry their AI investigation report. Customer-facing targets are admin-only.
 
 ## Testing
 
@@ -40,7 +50,7 @@ For Teams, look at the channel afterwards rather than trusting the result. A mal
 
 ## Read the full guide
 
-- **Notifications (Admin/Operator)**: ../notifications.md — setup for each channel, quota management, message templates, and troubleshooting
+- **Notifications (Admin/Operator)**: ../notifications.md — worked route examples, setup for each channel, quota management, message templates, and troubleshooting
 
 ## Related pages
 

--- a/frontend/src/components/notifications/templateVariables.ts
+++ b/frontend/src/components/notifications/templateVariables.ts
@@ -70,15 +70,42 @@ const ALERT_VARIABLES: TemplateVariable[] = [
 	{ name: "context.iocs", description: "Indicators extracted by the investigation. Loop over it — often absent." }
 ]
 
+// The AI investigation report. Resolved only when a template mentions
+// `ai_report`, so listing it here is also what tells an operator the cost is
+// opt-in. Absent on most alerts — every example guards accordingly.
+const AI_REPORT_VARIABLES: TemplateVariable[] = [
+	{
+		name: "context.ai_report.html",
+		description: "The full report rendered as HTML, tables included. Use in an html-format template; email only.",
+		example: "{% if context.ai_report %}{{ context.ai_report.html }}{% endif %}"
+	},
+	{ name: "context.ai_report.markdown", description: "The raw markdown source of the report." },
+	{ name: "context.ai_report.summary", description: "The report's short summary." },
+	{ name: "context.ai_report.recommended_actions", description: "The AI's suggested next steps." },
+	{
+		name: "context.ai_report.severity",
+		description: "The AI's assessment of the finding — often lower than the alert's own severity.",
+		example: "Medium"
+	},
+	{
+		name: "context.ai_report.iocs",
+		description: "Indicators with verdicts. Each has .value, .type, .vt_verdict and .vt_score.",
+		example: "{% for i in context.ai_report.iocs %}{{ i.value }} ({{ i.vt_verdict }}){% endfor %}"
+	}
+]
+
 const ASSIGNMENT_TRIGGERS: NotificationTrigger[] = ["alert_assigned", "case_assigned", "case_task_assigned"]
 
 /** Variables worth showing for a given trigger, most relevant first. */
 export function variablesForTrigger(trigger: NotificationTrigger | null): TemplateVariable[] {
+	// The report rides alert-shaped events: investigation_complete carries one,
+	// and a manual send can attach one to any alert. Assignment triggers never
+	// do, so listing it there would invite a template with a permanent hole.
 	const specific = !trigger
-		? [...ASSIGNMENT_VARIABLES, ...ALERT_VARIABLES]
+		? [...ASSIGNMENT_VARIABLES, ...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
 		: ASSIGNMENT_TRIGGERS.includes(trigger)
 			? ASSIGNMENT_VARIABLES
-			: ALERT_VARIABLES
+			: [...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
 
 	return [...specific, ...COMMON_VARIABLES, ...LEGACY_ALIASES]
 }
@@ -105,5 +132,9 @@ export const SNIPPETS: { label: string; source: string }[] = [
 	{
 		label: "Link, when there is one",
 		source: "{% if link_url %}Open in CoPilot: {{ link_url }}{% endif %}"
+	},
+	{
+		label: "AI report, or the summary",
+		source: "{% if context.ai_report %}{{ context.ai_report.html }}{% else %}{{ summary }}{% endif %}"
 	}
 ]


### PR DESCRIPTION
Follows the confusion that produced #1048 — which turned out to be operator error, but undiagnosable operator error, and tracing it revealed the guide was actively wrong in three places.

## Wrong, not merely incomplete

**Severity fallback.** The guide said alerts from sources with no rule level "are treated as **Medium**". Since #1040 the fallback is `High`, configurable via `DEFAULT_ALERT_SEVERITY`. An operator gating a route at High reads that line and concludes their Office 365 / CrowdStrike / Defender alerts are filtered out — the opposite of what happens.

**`{{report}}` does not exist.** Documented as a webhook-only template token. There is no such token in `build_context`; it's `include_full_report`, a checkbox on the route config.

**Templates aren't token substitution.** The whole section described `{{token}}` replacement. They've been sandboxed Jinja since #1037.

## Missing entirely

- Named message templates (#1038) — the *Notifications → Message Templates* page had no documentation at all
- Manual send (#1042)
- AI report inclusion and markdown-renders-on-email (#1048)

## The main addition

A **"Which trigger do I want?"** section, plus **five worked route recipes**.

Alert-created and investigation-complete are two events minutes apart, AI content only rides the second, and a trigger nobody subscribed to is silent by design. That combination is what cost a debugging session. The recipes show trigger + scope + severity + channel + template together, because the confusion comes from the combination rather than any single field:

- Email the customer a full AI report after every investigation
- Teams card for Critical alerts only
- Email an analyst when they're handed an alert
- Push everything into your own automation
- Two audiences, two moments

Also newly documented: **an AI route filters on the AI's assessment of the finding, not the alert's severity.** They routinely disagree — alert #14 in testing was `Critical` by rule level while its investigation concluded `Medium` — so a route gated at High silently drops it.

## In-product

`templateVariables.ts` (the reference shown in the template editor) gained `context.ai_report.*`, left incomplete by #1048, plus a guarded snippet.

## Verification

Every claim checked against the source rather than carried over: the rule-level bands against `severity_from_rule_level`, `FALLBACK_SEVERITY = "High"`, per-channel `template_formats`, the six built-in names, the route form's actual trigger options, and all four env vars against `.env.example`. Internal links and the new anchor resolve; pre-commit, `type-check` and `lint` clean.

## Related

The doc references [#1053](https://github.com/socfortress/CoPilot/issues/1053) where a recipe would otherwise describe a configuration that can't currently be built — `ai_report_reviewed` is emitted but not selectable on any route.