### PR TITLE
Fix Velociraptor flow duration formatting

### DIFF
--- a/frontend/src/components/agents/agentFlow/AgentFlowItem.vue
+++ b/frontend/src/components/agents/agentFlow/AgentFlowItem.vue
@@ -169,6 +169,7 @@
 </template>
 
 <script setup lang="ts">
+import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 import type { FlowResult } from "@/types/flow"
 import _pick from "lodash/pick"
 import { NEmpty, NInput, NModal, NPopover, NScrollbar, NTabPane, NTabs } from "naive-ui"
@@ -195,7 +196,7 @@ const EnabledIcon = "ri:check-line"
 const showDetails = ref(false)
 const dFormats = useSettingsStore().dateFormat
 
-const executionDuration = computed(() => dayjs.duration(flow.execution_duration).humanize())
+const executionDuration = computed(() => formatNanosecondsDuration(flow.execution_duration))
 
 const properties = computed(() => {
 	return _pick(flow, [

--- a/frontend/src/components/agents/agentFlow/AgentFlowQueryStat.vue
+++ b/frontend/src/components/agents/agentFlow/AgentFlowQueryStat.vue
@@ -85,6 +85,7 @@
 </template>
 
 <script setup lang="ts">
+import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 import type { FlowQueryStat } from "@/types/flow"
 import _pick from "lodash/pick"
 import { NInput, NModal, NTabPane, NTabs } from "naive-ui"
@@ -101,7 +102,7 @@ const { stat, embedded } = defineProps<{ stat: FlowQueryStat; embedded?: boolean
 const showDetails = ref(false)
 const dFormats = useSettingsStore().dateFormat
 
-const duration = computed(() => dayjs.duration(stat.duration).humanize())
+const duration = computed(() => formatNanosecondsDuration(stat.duration))
 
 const properties = computed(() => {
 	return _pick(stat, [

--- a/frontend/src/utils/formatNanosecondsDuration.ts
+++ b/frontend/src/utils/formatNanosecondsDuration.ts
@@ -1,0 +1,29 @@
+export function formatNanosecondsDuration(nanoseconds?: number | null): string {
+	if (nanoseconds == null || !Number.isFinite(nanoseconds) || nanoseconds < 0) {
+		return "N/A"
+	}
+
+	const milliseconds = nanoseconds / 1_000_000
+
+	if (milliseconds < 1000) {
+		return `${Math.round(milliseconds)} ms`
+	}
+
+	const totalSeconds = milliseconds / 1000
+
+	if (totalSeconds < 60) {
+		return `${Number(totalSeconds.toFixed(2))} s`
+	}
+
+	const minutes = Math.floor(totalSeconds / 60)
+	const seconds = Math.round(totalSeconds % 60)
+
+	if (minutes < 60) {
+		return seconds > 0 ? `${minutes} min ${seconds} s` : `${minutes} min`
+	}
+
+	const hours = Math.floor(minutes / 60)
+	const remainingMinutes = minutes % 60
+
+	return remainingMinutes > 0 ? `${hours} h ${remainingMinutes} min` : `${hours} h`
+}


### PR DESCRIPTION
## Problem

Velociraptor flow and query-stat duration values are expressed in nanoseconds, while Day.js interprets numeric duration values as milliseconds.

This caused short flows to be displayed with extremely large durations. For example, a flow lasting 0.711 seconds was displayed as approximately 8 days.

## Changes

- Add explicit formatting for nanosecond duration values.
- Display sub-second durations in milliseconds.
- Display short durations with precise seconds.
- Apply the formatter to both flow execution time and query statistics.

## Verification

Tested against a real Velociraptor flow:

- Velociraptor value: 0.71 seconds
- Before: 8 days
- After: 711 ms