### PR TITLE
fix(notifications): make the AI report review trigger selectable on both scopes

### DIFF
--- a/backend/app/ai_analyst/services/ai_analyst.py
+++ b/backend/app/ai_analyst/services/ai_analyst.py
@@ -39,6 +39,7 @@ from app.ai_analyst.schema.ai_analyst import SubmitReviewRequest
 from app.ai_analyst.schema.ai_analyst import SubmitReviewResponse
 from app.ai_analyst.schema.ai_analyst import UpdateJobRequest
 from app.ai_analyst.schema.ai_analyst import UpdateJobResponse
+from app.auth.models.users import User
 from app.db.universal_models import AiAnalystIoc
 from app.db.universal_models import AiAnalystIocReview
 from app.db.universal_models import AiAnalystJob
@@ -263,6 +264,22 @@ async def _alert_display_fields(alert_id: int, session: AsyncSession) -> tuple[O
     except Exception as e:  # noqa: BLE001 — decoration must never fail the write-back
         logger.warning(f"Could not resolve display fields for alert {alert_id}: {type(e).__name__}: {e}")
         return (None, None)
+
+
+async def _username_for(user_id: int, session: AsyncSession) -> Optional[str]:
+    """A reviewer's username, falling back to their id as a string.
+
+    Never raises, for the same reason as `_alert_display_fields`: the review is
+    already committed by the time this runs, and failing to label a notification
+    must not turn a successful submission into a 500. The fallback reproduces
+    the old behaviour rather than dropping the field entirely.
+    """
+    try:
+        user = await session.get(User, user_id)
+        return getattr(user, "username", None) or str(user_id)
+    except Exception as e:  # noqa: BLE001 — decoration must never fail the review
+        logger.warning(f"Could not resolve username for user {user_id}: {type(e).__name__}: {e}")
+        return str(user_id)
 
 
 async def submit_report(request: SubmitReportRequest, session: AsyncSession) -> SubmitReportResponse:
@@ -653,6 +670,7 @@ async def submit_review(
     # review is not a new sign-off. Lets an operator run an internal route on
     # report submission and a customer-facing route only after review.
     if not is_edit:
+        alert_name, asset_name = await _alert_display_fields(report.alert_id, session)
         emit(
             ai_report_reviewed_event(
                 alert_id=report.alert_id,
@@ -660,8 +678,12 @@ async def submit_review(
                 customer_code=report.customer_code,
                 severity=report.severity_assessment,
                 summary=report.summary or "An analyst reviewed the AI investigation for this alert.",
-                reviewer=str(reviewer_user_id),
+                # The reviewer's name, not their row id. This used to send
+                # `str(reviewer_user_id)`, so a notification read "Reviewed by: 3".
+                reviewer=await _username_for(reviewer_user_id, session),
                 verdict=request.overall_verdict.value if request.overall_verdict else None,
+                alert_name=alert_name,
+                asset_name=asset_name,
             ),
         )
     return SubmitReviewResponse(

--- a/backend/app/notifications/schema/notifications.py
+++ b/backend/app/notifications/schema/notifications.py
@@ -155,6 +155,27 @@ INTERNAL_TRIGGERS: frozenset = frozenset(
 )
 
 
+# Triggers that resolve against BOTH scopes, so one event can reach the SOC and
+# the customer through separate routes.
+#
+# Every other trigger is one or the other: an assignment is about who is working
+# on something and never leaves the SOC; an alert or an investigation is about
+# the customer's posture and goes to them. Analyst sign-off is the first event
+# that is legitimately both — the SOC wants to know a report was reviewed, and
+# the customer's route is precisely the one an operator wants to hold back until
+# a human has checked it (#1053).
+#
+# Membership here is a scope *widening*: a dual-scope trigger still obeys every
+# other filter, and the #1014 AI opt-out still applies to its customer-scope
+# half. `dispatch_event` gates per route rather than per batch, which is what
+# makes that work without further change.
+DUAL_SCOPE_TRIGGERS: frozenset = frozenset(
+    {
+        "ai_report_reviewed",
+    },
+)
+
+
 AI_SOURCED_TRIGGERS: frozenset = frozenset(
     {
         "investigation_complete",

--- a/backend/app/notifications/services/event_builders.py
+++ b/backend/app/notifications/services/event_builders.py
@@ -114,6 +114,8 @@ def ai_report_reviewed_event(
     summary: str,
     reviewer: Optional[str] = None,
     verdict: Optional[str] = None,
+    alert_name: Optional[str] = None,
+    asset_name: Optional[str] = None,
 ) -> NotificationEvent:
     """An analyst signed off on an AI report.
 
@@ -124,19 +126,32 @@ def ai_report_reviewed_event(
 
     Keyed on the alert, not the report: "this alert's findings have been
     reviewed" happens once. A second reviewer, or a revision, does not re-notify.
+
+    This trigger resolves against **both** scopes (`DUAL_SCOPE_TRIGGERS`), so one
+    sign-off can reach an internal route and a customer-facing one through
+    separate routes. The customer half is still governed by the #1014 opt-out.
     """
     return NotificationEvent(
         customer_code=customer_code,
         trigger=NotificationTrigger.AI_REPORT_REVIEWED,
+        # The alert's own name when we have it. `Reviewed: alert #14` was the
+        # only thing a recipient saw before, which is unreadable in a channel
+        # that carries several customers.
+        subject=f"Reviewed: {alert_name}" if alert_name else f"Reviewed: alert #{alert_id}",
         severity=_coerce_severity(severity),
-        subject=f"Reviewed: alert #{alert_id}",
         summary=summary,
         entity_type=EntityType.ALERT,
         entity_id=alert_id,
         dedupe_key=f"{EntityType.ALERT}:{alert_id}:{NotificationTrigger.AI_REPORT_REVIEWED.value}",
         link_url=_copilot_link(f"/alerts/{alert_id}"),
         actor_username=reviewer,
-        context={"report_id": report_id, "reviewer": reviewer, "verdict": verdict},
+        context={
+            "report_id": report_id,
+            "reviewer": reviewer,
+            "verdict": verdict,
+            "alert_name": alert_name,
+            "asset_name": asset_name,
+        },
     )
 
 

--- a/backend/app/notifications/services/notifications.py
+++ b/backend/app/notifications/services/notifications.py
@@ -26,7 +26,9 @@ from uuid import uuid4
 from fastapi import HTTPException
 from loguru import logger
 from pydantic import ValidationError as PydanticValidationError
+from sqlalchemy import and_
 from sqlalchemy import desc
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
@@ -46,6 +48,7 @@ from app.notifications.schema.events import EntityType
 from app.notifications.schema.events import NotificationEvent
 from app.notifications.schema.events import event_from_dispatch_request
 from app.notifications.schema.notifications import AI_SOURCED_TRIGGERS
+from app.notifications.schema.notifications import DUAL_SCOPE_TRIGGERS
 from app.notifications.schema.notifications import INTERNAL_TRIGGERS
 from app.notifications.schema.notifications import SEVERITY_ORDER
 from app.notifications.schema.notifications import DispatchOutcome
@@ -828,6 +831,27 @@ def _format_default_body_core(event: NotificationEvent) -> str:
             parts.extend(["", f"Open in CoPilot: {event.link_url}"])
         return "\n".join(parts)
 
+    if trig == NotificationTrigger.AI_REPORT_REVIEWED.value:
+        # Its own wording rather than falling through to the investigation
+        # branch, which would announce "AI investigation complete" for the
+        # second time about the same alert and bury what actually changed —
+        # that a human has now checked it.
+        parts = [
+            f"*AI report reviewed* — severity: *{event.severity.value}*",
+            "",
+            f"Customer: `{event.customer_code}`",
+            f"Alert: #{event.entity_id}" + (f" — {ctx.get('alert_name')}" if ctx.get("alert_name") else ""),
+        ]
+        if ctx.get("reviewer"):
+            parts.append(f"Reviewed by: {ctx['reviewer']}")
+        if ctx.get("verdict"):
+            parts.append(f"Verdict: {ctx['verdict']}")
+        if event.summary:
+            parts.extend(["", event.summary.strip()])
+        if event.link_url:
+            parts.extend(["", f"Open in CoPilot: {event.link_url}"])
+        return "\n".join(parts)
+
     # investigation_complete — unchanged wording, existing customers see this.
     alert_name = ctx.get("alert_name")
     parts = [
@@ -1213,17 +1237,33 @@ async def routes_for_event(event: NotificationEvent, session: AsyncSession) -> L
     an assignment is about *who is working on something*, so it resolves against
     internal routes and never reaches the customer whose alert it was. Anything
     else is about the customer's security posture and resolves against theirs.
+
+    **Dual-scope triggers resolve against both pools** (#1053). Analyst sign-off
+    is the first event that is legitimately internal *and* customer-facing: the
+    SOC wants to know a report was reviewed, and the customer's route is exactly
+    the one an operator wants held back until a human has checked it.
+
+    The tenant filter applies only to the customer half. Internal routes belong
+    to no tenant, so filtering them by `customer_code` would return nothing —
+    which is the bug this shape exists to avoid.
     """
-    if event.trigger.value in INTERNAL_TRIGGERS:
-        stmt = select(CustomerNotificationRoute).where(
-            CustomerNotificationRoute.scope == NotificationScope.INTERNAL.value,
-        )
+    trigger = event.trigger.value
+    internal_clause = CustomerNotificationRoute.scope == NotificationScope.INTERNAL.value
+    customer_clause = and_(
+        CustomerNotificationRoute.scope == NotificationScope.CUSTOMER.value,
+        CustomerNotificationRoute.customer_code == event.customer_code,
+    )
+
+    if trigger in INTERNAL_TRIGGERS:
+        where = internal_clause
+    elif trigger in DUAL_SCOPE_TRIGGERS:
+        where = or_(internal_clause, customer_clause)
     else:
-        stmt = select(CustomerNotificationRoute).where(
-            CustomerNotificationRoute.scope == NotificationScope.CUSTOMER.value,
-            CustomerNotificationRoute.customer_code == event.customer_code,
-        )
-    result = await session.execute(stmt.order_by(desc(CustomerNotificationRoute.created_at)))
+        where = customer_clause
+
+    result = await session.execute(
+        select(CustomerNotificationRoute).where(where).order_by(desc(CustomerNotificationRoute.created_at)),
+    )
     return result.scalars().all()
 
 
@@ -1281,9 +1321,13 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
     # Only customer-facing routes are gated. Internal routes are deliberately
     # exempt: running investigations while keeping the results internal is a
     # supported configuration, and the switch governs what reaches the CUSTOMER.
-    # (routes_for_event already returns one scope or the other, so in practice
-    # this filter is all-or-nothing — it is written per-route so it stays
-    # correct if a future trigger mixes scopes.)
+    #
+    # Suppression removes the gated routes and lets the rest proceed, rather
+    # than returning. `ai_report_reviewed` resolves against BOTH scopes (#1053),
+    # so a batch can hold internal and customer routes at once — and aborting
+    # the dispatch would silently take the SOC's own notification down with the
+    # customer's, which is the exact opposite of what the opt-out is for.
+    deliverable_routes = matched_routes
     gated_routes = [r for r in matched_routes if r.scope == NotificationScope.CUSTOMER.value]
     if gated_routes and not await _ai_reports_permitted(event.trigger.value, event.customer_code, session):
         logger.info(
@@ -1317,15 +1361,8 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
                     error_message=reason,
                 ),
             )
-        return DispatchResponse(
-            success=True,
-            message="Dispatch suppressed — AI reports are not enabled for this customer",
-            routes_matched=len(gated_routes),
-            dispatched=0,
-            skipped=skipped,
-            failed=0,
-            outcomes=outcomes,
-        )
+        gated_ids = {r.id for r in gated_routes}
+        deliverable_routes = [r for r in matched_routes if r.id not in gated_ids]
 
     # Per-call context. Expensive lookups a provider needs (the Shuffle
     # connector row, an alert's AI report) are memoized on it, so a batch of
@@ -1333,7 +1370,7 @@ async def dispatch_event(event: NotificationEvent, session: AsyncSession) -> Dis
     # now lazy: nothing is read unless a route actually reaches that provider.
     ctx = DispatchContext(session=session, event=event)
 
-    for route in matched_routes:
+    for route in deliverable_routes:
         # Cache every route attribute the LOOP needs into locals UP FRONT.
         # Once we cross any `await` (let alone any rollback) the route
         # SQLAlchemy state can be expired and a synchronous attribute

--- a/backend/app/notifications/services/template_seeds.py
+++ b/backend/app/notifications/services/template_seeds.py
@@ -103,6 +103,29 @@ BUILTIN_TEMPLATES: List[Dict[str, Any]] = [
         ),
     },
     {
+        "name": "AI report reviewed — sign-off",
+        "description": (
+            "An analyst checked an AI investigation. Works on both internal and customer-facing routes — "
+            "the same event can tell your SOC and the customer."
+        ),
+        "trigger": "ai_report_reviewed",
+        "format": "markdown",
+        "subject_template": "Reviewed: {{ alert_name }}",
+        # `reviewer` and `verdict` are guarded because a review can be submitted
+        # without an overall verdict, and because the same template is offered
+        # on both scopes — an operator may well want the customer-facing copy to
+        # omit who internally signed it off.
+        "body_template": (
+            "*Analyst review complete* — {{ alert_name }}\n\n"
+            "Customer: `{{ customer_code }}`\n"
+            "Alert: #{{ alert_id }}\n"
+            "{% if context.reviewer %}Reviewed by: {{ context.reviewer }}\n{% endif %}"
+            "{% if context.verdict %}Verdict: {{ context.verdict }}\n{% endif %}"
+            "\n{{ summary }}\n"
+            "{% if link_url %}\nOpen in CoPilot: {{ link_url }}{% endif %}"
+        ),
+    },
+    {
         "name": "AI investigation — full report (HTML email)",
         "description": (
             "The complete AI investigation write-up with its tables rendered, in the customer's brand colours. "

--- a/backend/tests/test_notification_ai_report_gating.py
+++ b/backend/tests/test_notification_ai_report_gating.py
@@ -224,3 +224,89 @@ def test_internal_routes_are_not_gated():
 
     assert webhook.await_count == 1
     assert response.dispatched == 1
+
+
+# ── mixed-scope batches (#1053) ───────────────────────────────────────────
+#
+# `ai_report_reviewed` resolves against BOTH scopes, so one event can match an
+# internal route and a customer route at once. That makes the per-route shape of
+# the gate load-bearing rather than theoretical: suppressing the customer half
+# must not touch the SOC's own notification.
+
+
+def _review_event():
+    from app.notifications.services.event_builders import ai_report_reviewed_event
+
+    return ai_report_reviewed_event(
+        alert_id=42,
+        report_id=3,
+        customer_code=CUSTOMER,
+        severity="Medium",
+        summary="An analyst reviewed the AI investigation for this alert.",
+        reviewer="asmith",
+        verdict="up",
+        alert_name="Mimikatz signature",
+    )
+
+
+def _dispatch_review(routes, *, ai_enabled):
+    """Same seams as `_dispatch`, but for a dual-scope review event."""
+    for route in routes:
+        route.trigger = NotificationTrigger.AI_REPORT_REVIEWED.value
+
+    with (
+        patch.object(svc, "routes_for_event", AsyncMock(return_value=routes)),
+        patch.object(svc, "is_ai_reports_enabled", AsyncMock(return_value=ai_enabled)),
+        patch.object(svc, "_record_log", AsyncMock(return_value=True)) as record,
+        patch.object(
+            type(CHANNEL_REGISTRY["webhook"]),
+            "send",
+            AsyncMock(return_value=SendResult(status="sent", latency_ms=12)),
+        ) as webhook,
+        patch.object(type(CHANNEL_REGISTRY["webhook"]), "after_send", AsyncMock()),
+    ):
+        response = asyncio.run(svc.dispatch_event(_review_event(), AsyncMock()))
+    return response, record, webhook
+
+
+def test_suppressing_the_customer_half_still_delivers_the_internal_half():
+    """The bug this guards against: the gate used to `return` outright, which
+    aborted the whole dispatch. On a mixed batch that silently took the SOC's
+    own notification down alongside the customer's — the exact opposite of what
+    the opt-out is for, since keeping findings internal is the configuration an
+    operator chose when they left the switch off."""
+    internal = _route(route_id=1, name="SOC review", scope="internal")
+    customer = _route(route_id=2, name="Customer review", scope="customer")
+
+    response, _record, webhook = _dispatch_review([internal, customer], ai_enabled=False)
+
+    assert webhook.await_count == 1, "the internal route should still have been delivered"
+    assert response.dispatched == 1
+    assert response.skipped == 1
+
+    statuses = {o.route_id: o.status for o in response.outcomes}
+    assert statuses[1] == DispatchStatus.SENT
+    assert statuses[2] == DispatchStatus.SKIPPED
+
+
+def test_both_halves_deliver_when_the_customer_is_opted_in():
+    internal = _route(route_id=1, name="SOC review", scope="internal")
+    customer = _route(route_id=2, name="Customer review", scope="customer")
+
+    response, _record, webhook = _dispatch_review([internal, customer], ai_enabled=True)
+
+    assert webhook.await_count == 2
+    assert response.dispatched == 2
+    assert response.skipped == 0
+
+
+def test_a_suppressed_customer_only_batch_still_reports_what_matched():
+    """`routes_matched` counts everything that matched, including suppressed
+    routes. `emit` logs "no route is configured for this trigger" when it is
+    zero, so under-reporting here would blame a missing route for what is
+    actually a deliberate opt-out."""
+    response, _record, webhook = _dispatch_review([_route(scope="customer")], ai_enabled=False)
+
+    assert webhook.await_count == 0
+    assert response.routes_matched == 1
+    assert response.skipped == 1

--- a/backend/tests/test_notification_dual_scope_trigger.py
+++ b/backend/tests/test_notification_dual_scope_trigger.py
@@ -1,0 +1,284 @@
+"""Analyst sign-off reaching both scopes (#1053).
+
+`ai_report_reviewed` was emitted by `submit_review` from #1036 onward and could
+not be selected on any route, so every one of those events matched nothing. It
+is now the first **dual-scope** trigger: one sign-off can reach an internal
+route and a customer-facing route through separate routes.
+
+That configuration is the reason the trigger exists — run an internal route the
+moment a report lands, and hold the customer's route until a human has checked
+it. Every other trigger is one scope or the other, so this is the first time
+`routes_for_event` returns a mixed pool, and these tests pin the three things
+that can go wrong with it:
+
+**Internal routes must not be tenant-filtered.** They carry `customer_code =
+NULL`. Applying the customer filter to the whole query — the obvious way to
+write it — silently returns nothing for the internal half.
+
+**Customer routes must still be tenant-filtered.** Widening the scope must not
+widen the tenant boundary: another customer's review must never reach this
+customer's route.
+
+**The AI opt-out still applies to the customer half only.** #1014 governs what
+reaches an *end customer*. Keeping findings internal while investigations run is
+a supported configuration, so the internal half is deliberately exempt — and the
+gate has to survive a batch that contains both.
+
+Uses a real in-memory SQLite database rather than a mocked session, because what
+is being tested here IS the query: a mock that returns a canned list would pass
+against a WHERE clause that filters out every internal route.
+
+Run with: cd backend && python -m pytest tests/test_notification_dual_scope_trigger.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+from sqlalchemy.ext.asyncio import create_async_engine  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+from sqlmodel import SQLModel  # noqa: E402
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.db.universal_models import CustomerNotificationRoute  # noqa: E402
+from app.notifications.schema.events import EntityType  # noqa: E402
+from app.notifications.schema.events import NotificationEvent  # noqa: E402
+from app.notifications.schema.notifications import DUAL_SCOPE_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import INTERNAL_TRIGGERS  # noqa: E402
+from app.notifications.schema.notifications import NotificationSeverity  # noqa: E402
+from app.notifications.schema.notifications import NotificationTrigger  # noqa: E402
+from app.notifications.services.event_builders import (  # noqa: E402
+    ai_report_reviewed_event,
+)
+
+CC = "TENANT_A"
+OTHER = "TENANT_B"
+
+
+async def _make_session() -> AsyncSession:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    table = SQLModel.metadata.tables["customer_notification_route"]
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: SQLModel.metadata.create_all(c, tables=[table]))
+    return AsyncSession(engine)
+
+
+def _route(name, *, scope, customer_code, trigger="ai_report_reviewed", **over):
+    base = dict(
+        name=name,
+        scope=scope,
+        customer_code=customer_code,
+        trigger=trigger,
+        channel="webhook",
+        # Superseded by `config` since #1023, but still NOT NULL on the table.
+        destination="",
+        enabled=True,
+        min_severity="Informational",
+        recipient_mode="static",
+        config="{}",
+        created_at=datetime(2026, 8, 4, 12, 0, 0),
+        created_by="admin",
+    )
+    base.update(over)
+    return CustomerNotificationRoute(**base)
+
+
+async def _seed(session: AsyncSession) -> None:
+    session.add_all(
+        [
+            _route("internal review", scope="internal", customer_code=None),
+            _route("customer review", scope="customer", customer_code=CC),
+            _route("other tenant review", scope="customer", customer_code=OTHER),
+            _route("internal assignment", scope="internal", customer_code=None, trigger="alert_assigned"),
+            _route("customer alerts", scope="customer", customer_code=CC, trigger="alert_created"),
+        ],
+    )
+    await session.commit()
+
+
+def _event(trigger=NotificationTrigger.AI_REPORT_REVIEWED, customer_code=CC):
+    return NotificationEvent(
+        customer_code=customer_code,
+        trigger=trigger,
+        severity=NotificationSeverity.HIGH,
+        subject="Reviewed: Administrators Group Changed",
+        summary="An analyst reviewed the AI investigation for this alert.",
+        entity_type=EntityType.ALERT,
+        entity_id=14,
+        dedupe_key="alert:14:ai_report_reviewed",
+        context={"reviewer": "asmith", "verdict": "up"},
+    )
+
+
+def _names(routes):
+    return sorted(r.name for r in routes)
+
+
+def _resolve(event):
+    """The candidate pool — what `routes_for_event` decides, which is scope and
+    tenancy only. Trigger and severity filtering happen after it, in
+    `dispatch_event`."""
+
+    async def run():
+        session = await _make_session()
+        try:
+            await _seed(session)
+            return await svc.routes_for_event(event, session)
+        finally:
+            await session.close()
+
+    return asyncio.run(run())
+
+
+def _matched(event):
+    """The routes that would actually fire — candidates, then the same trigger
+    and severity filters `dispatch_event` applies."""
+    return [
+        r
+        for r in _resolve(event)
+        if r.enabled and svc._trigger_applies(event.trigger.value, r.trigger) and svc._severity_meets(event.severity.value, r.min_severity)
+    ]
+
+
+# ── the scope model ───────────────────────────────────────────────────────
+
+
+def test_the_review_trigger_is_declared_dual_scope():
+    assert "ai_report_reviewed" in DUAL_SCOPE_TRIGGERS
+
+
+def test_the_review_trigger_is_not_internal_only():
+    """Putting it in INTERNAL_TRIGGERS would look like it works and would quietly
+    cut the customer half off — and would also drag it into the assignment
+    wording and the self-assignment suppression, neither of which apply."""
+    assert "ai_report_reviewed" not in INTERNAL_TRIGGERS
+
+
+# ── resolution ────────────────────────────────────────────────────────────
+
+
+def test_a_review_fires_both_an_internal_and_a_customer_route():
+    """The whole point of #1053."""
+    assert _names(_matched(_event())) == ["customer review", "internal review"]
+
+
+def test_the_internal_half_is_not_tenant_filtered():
+    """Internal routes carry customer_code = NULL. Applying the customer filter
+    across the whole query is the obvious way to write this and returns nothing
+    for the internal half."""
+    internal = [r for r in _matched(_event()) if r.scope == "internal"]
+
+    assert len(internal) == 1
+    assert internal[0].customer_code is None
+
+
+def test_another_tenants_customer_route_is_never_included():
+    """Widening the scope must not widen the tenant boundary."""
+    assert "other tenant review" not in _names(_resolve(_event()))
+
+
+def test_a_review_for_a_customer_with_no_customer_route_still_reaches_the_soc():
+    """Keeping findings internal while investigations run is supported, so the
+    internal half must not depend on a customer route existing."""
+    assert _names(_matched(_event(customer_code="TENANT_WITH_NO_ROUTES"))) == ["internal review"]
+
+
+# ── the other triggers are unchanged ──────────────────────────────────────
+
+
+def test_an_assignment_still_resolves_internal_only():
+    """Candidates, not matches — the pool is what scope decides."""
+    routes = _resolve(_event(trigger=NotificationTrigger.ALERT_ASSIGNED))
+
+    assert all(r.scope == "internal" for r in routes)
+    assert _names(_matched(_event(trigger=NotificationTrigger.ALERT_ASSIGNED))) == ["internal assignment"]
+
+
+def test_alert_creation_still_resolves_customer_only():
+    routes = _resolve(_event(trigger=NotificationTrigger.ALERT_CREATED))
+
+    assert all(r.scope == "customer" for r in routes)
+    assert _names(_matched(_event(trigger=NotificationTrigger.ALERT_CREATED))) == ["customer alerts"]
+
+
+# ── the event builder ─────────────────────────────────────────────────────
+
+
+def test_the_review_event_carries_the_reviewers_name_not_their_id():
+    """This used to be `str(reviewer_user_id)`, so a notification read
+    "Reviewed by: 3"."""
+    event = ai_report_reviewed_event(
+        alert_id=14,
+        report_id=3,
+        customer_code=CC,
+        severity="Medium",
+        summary="s",
+        reviewer="asmith",
+        verdict="up",
+        alert_name="Administrators Group Changed",
+    )
+
+    assert event.context["reviewer"] == "asmith"
+    assert event.actor_username == "asmith"
+
+
+def test_the_review_event_names_the_alert():
+    """`Reviewed: alert #14` is unreadable in a channel carrying several
+    customers."""
+    event = ai_report_reviewed_event(
+        alert_id=14,
+        report_id=3,
+        customer_code=CC,
+        severity="Medium",
+        summary="s",
+        alert_name="Administrators Group Changed",
+    )
+
+    assert event.subject == "Reviewed: Administrators Group Changed"
+    assert event.context["alert_name"] == "Administrators Group Changed"
+
+
+def test_the_review_event_falls_back_when_the_alert_name_is_unknown():
+    event = ai_report_reviewed_event(alert_id=14, report_id=3, customer_code=CC, severity="Medium", summary="s")
+
+    assert event.subject == "Reviewed: alert #14"
+
+
+def test_a_review_dedupes_on_the_alert_not_the_report():
+    """A second reviewer, or a revision, must not re-notify. Deliberate — see
+    the builder's docstring."""
+    first = ai_report_reviewed_event(alert_id=14, report_id=3, customer_code=CC, severity="Medium", summary="s")
+    second = ai_report_reviewed_event(alert_id=14, report_id=9, customer_code=CC, severity="Medium", summary="s")
+
+    assert first.dedupe_key == second.dedupe_key
+
+
+# ── the default body ──────────────────────────────────────────────────────
+
+
+def test_the_default_body_says_reviewed_not_investigation_complete():
+    """Falling through to the investigation branch would announce "AI
+    investigation complete" a second time about the same alert and bury what
+    actually changed."""
+    body = svc._format_default_body(_event())
+
+    assert body.startswith("*AI report reviewed*")
+    assert "Reviewed by: asmith" in body
+    assert "Verdict: up" in body
+
+
+def test_the_default_body_survives_a_review_with_no_verdict():
+    """An overall verdict is optional on the review form."""
+    event = _event()
+    event.context = {"reviewer": "asmith"}
+    body = svc._format_default_body(event)
+
+    assert "Verdict:" not in body
+    assert "Reviewed by: asmith" in body

--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -61,6 +61,7 @@ If you expected an AI notification and didn't get one, that line is the first th
 |---|---|
 | To know an alert happened, immediately | An alert is created |
 | The AI's conclusions about an alert | An AI investigation completes |
+| The AI's conclusions, but only once an analyst has checked them | An AI report is reviewed |
 | Both (two messages) | Two routes, one of each |
 
 ---
@@ -81,6 +82,16 @@ If you expected an AI notification and didn't get one, that line is the first th
 | **An alert is assigned** | An alert's assignee changes |
 | **A case is assigned** | A case's assignee changes |
 | **A case task is assigned** | A task within a case is assigned |
+
+### Both
+
+| Trigger | Fires when |
+|---|---|
+| **An AI report is reviewed** | An analyst submits a review of an AI investigation. Once per alert — a second reviewer or a revision does not re-notify. |
+
+This is the only trigger offered on **both** customer and internal routes, because analyst sign-off is legitimately both audiences' business. It's what lets you hold customer delivery until a human has checked the AI's work — see [Two audiences, two moments](#two-audiences-two-moments).
+
+It counts as AI-written content, so a customer-facing review route is governed by the same *Customers → (customer) → AI Report* opt-in as the rest. An internal route is not: if the switch is off, the customer's route is suppressed and **your internal one still fires**.
 
 Assignment triggers only fire on an **actual change**. Re-saving the same assignee sends nothing. By default, assigning something to *yourself* also sends nothing — there's a per-route **Notify on self-assign** option if your team wants the audit trail anyway.
 
@@ -195,12 +206,16 @@ Leave the template empty so CoPilot sends its structured JSON object. A template
 
 ### Two audiences, two moments
 
-Internal first, customer only after a human has checked it:
+Internal first, customer only after a human has checked it. This is the configuration the *An AI report is reviewed* trigger exists for:
 
-- **Route A** — internal, *An AI investigation completes*, Teams. Your team sees every investigation the moment it lands.
-- **Route B** — customer, *An AI investigation completes*, email, full-report template. The customer gets the same finding.
+- **Route A** — **internal**, *An AI investigation completes*, Teams. Your team sees every investigation the moment it lands, unreviewed.
+- **Route B** — **customer**, *An AI report is reviewed*, email, full-report template. The customer hears nothing until an analyst has signed off in *AI Analyst → (report) → Review*.
 
-If you want Route B to wait for analyst sign-off, that's the `ai_report_reviewed` trigger — **currently not selectable in the interface**, tracked in [#1053](https://github.com/socfortress/CoPilot/issues/1053).
+Nothing reaches the customer automatically; the analyst's review is the release gate.
+
+*An AI report is reviewed* is the **only trigger available on both scopes**, so you can also run a third route — internal, same trigger — if your team wants a record of who signed off on what.
+
+A review fires the notification **once per alert**. A second reviewer, or someone revising their own review, does not re-notify.
 
 ---
 
@@ -390,6 +405,7 @@ Available variables:
 | `{{ trigger }}` | Which trigger fired this |
 | `{{ assignee }}` / `{{ actor }}` | Assignment triggers only |
 | `{{ context.… }}` | Per-event extras — `context.asset_name`, `context.rule_level`, `context.iocs` |
+| `{{ context.reviewer }}` / `{{ context.verdict }}` | Review trigger only — who signed off, and their verdict |
 | `{{ branding.… }}` | Customer logo and brand colours — `logo`, `title`, `accent`, `accent_strong`, `accent_text` |
 | `{{ context.ai_report.… }}` | The AI investigation report — see below |
 
@@ -427,7 +443,7 @@ The report is only fetched when a template mentions `ai_report`, so templates th
 
 ### Built-in templates
 
-Six ship with every deployment, as working starting points and as worked examples of the syntax:
+Seven ship with every deployment, as working starting points and as worked examples of the syntax:
 
 | Template | For |
 |---|---|
@@ -435,6 +451,7 @@ Six ship with every deployment, as working starting points and as worked example
 | **Alert — detailed with IOCs** | Full context including indicators |
 | **Assignment — who and what** | Internal routes |
 | **AI investigation — customer summary** | Plain-language wrap-up for the end customer |
+| **AI report reviewed — sign-off** | Who reviewed an investigation and what they concluded |
 | **AI investigation — full report (HTML email)** | The complete write-up with rendered tables, in the customer's brand colours |
 | **Branded email — HTML** | A branded shell for any trigger |
 
@@ -528,6 +545,7 @@ Both are opt-in, so this only happens if you set up both. The route form warns y
 |---|---|
 | An alert is created | Customer |
 | An AI investigation completes | Customer |
+| An AI report is reviewed | **Customer and internal** |
 | An alert / case / case task is assigned | Internal |
 
 ### Channel capabilities

--- a/docs/user/ui/notifications.md
+++ b/docs/user/ui/notifications.md
@@ -28,7 +28,7 @@ Things your SOC should know about: who picked up which alert. These belong to no
 
 **Message templates** — *Notifications → Message Templates* (admin only)
 
-Reusable message bodies shared across routes. Six built-ins ship as working starting points; duplicate one to get an editable copy.
+Reusable message bodies shared across routes. Seven built-ins ship as working starting points; duplicate one to get an editable copy.
 
 ## The two things that catch people
 

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteDetails.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteDetails.vue
@@ -247,6 +247,7 @@ const PlayIcon = "carbon:play"
 const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
 	alert_created: "Alert created",
 	investigation_complete: "AI investigation complete",
+	ai_report_reviewed: "AI report reviewed",
 	alert_assigned: "Alert assigned",
 	case_assigned: "Case assigned",
 	case_task_assigned: "Case task assigned"

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteForm.vue
@@ -595,9 +595,16 @@ const headerPairs = ref<{ key: string; value: string }[]>(
 // route with an assignment trigger would be dead config: assignments resolve
 // against internal routes, so it could never fire. Offering it would be an
 // invitation to create something that silently does nothing.
+// `ai_report_reviewed` appears in BOTH lists on purpose — it is the one trigger
+// that resolves against both scopes. Running an internal route on submission and
+// a customer-facing route only after a human has signed off is the configuration
+// it exists for, and expressing that needs the option on both sides.
+const REVIEW_TRIGGER_OPTION = { label: "An AI report is reviewed", value: "ai_report_reviewed" }
+
 const CUSTOMER_TRIGGER_OPTIONS = [
 	{ label: "An alert is created", value: "alert_created" },
 	{ label: "An AI investigation completes", value: "investigation_complete" },
+	REVIEW_TRIGGER_OPTION,
 	// Legacy value kept selectable so editing an old route doesn't blank the
 	// field; the backend coerces it to investigation_complete on read.
 	{ label: "Critical / High severity only (legacy)", value: "severity_critical_or_high" }
@@ -606,7 +613,8 @@ const CUSTOMER_TRIGGER_OPTIONS = [
 const INTERNAL_TRIGGER_OPTIONS = [
 	{ label: "An alert is assigned", value: "alert_assigned" },
 	{ label: "A case is assigned", value: "case_assigned" },
-	{ label: "A case task is assigned", value: "case_task_assigned" }
+	{ label: "A case task is assigned", value: "case_task_assigned" },
+	REVIEW_TRIGGER_OPTION
 ]
 
 const triggerOptions = computed(() => (isInternalScope.value ? INTERNAL_TRIGGER_OPTIONS : CUSTOMER_TRIGGER_OPTIONS))

--- a/frontend/src/components/notifications/NotificationTemplateDetails.vue
+++ b/frontend/src/components/notifications/NotificationTemplateDetails.vue
@@ -203,6 +203,7 @@ const InfoIcon = "carbon:information"
 const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
 	alert_created: "Alert created",
 	investigation_complete: "AI investigation complete",
+	ai_report_reviewed: "AI report reviewed",
 	alert_assigned: "Alert assigned",
 	case_assigned: "Case assigned",
 	case_task_assigned: "Case task assigned"

--- a/frontend/src/components/notifications/NotificationTemplateForm.vue
+++ b/frontend/src/components/notifications/NotificationTemplateForm.vue
@@ -266,6 +266,7 @@ const formatOptions = [
 const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
 	alert_created: "Alert created",
 	investigation_complete: "AI investigation complete",
+	ai_report_reviewed: "AI report reviewed",
 	alert_assigned: "Alert assigned",
 	case_assigned: "Case assigned",
 	case_task_assigned: "Case task assigned"

--- a/frontend/src/components/notifications/NotificationTemplateItem.vue
+++ b/frontend/src/components/notifications/NotificationTemplateItem.vue
@@ -163,6 +163,7 @@ const CopyIcon = "carbon:copy"
 const TRIGGER_LABELS: Record<NotificationTrigger, string> = {
 	alert_created: "Alert created",
 	investigation_complete: "AI investigation complete",
+	ai_report_reviewed: "AI report reviewed",
 	alert_assigned: "Alert assigned",
 	case_assigned: "Case assigned",
 	case_task_assigned: "Case task assigned"

--- a/frontend/src/components/notifications/templateVariables.ts
+++ b/frontend/src/components/notifications/templateVariables.ts
@@ -94,6 +94,13 @@ const AI_REPORT_VARIABLES: TemplateVariable[] = [
 	}
 ]
 
+// Set only by the analyst sign-off trigger.
+const REVIEW_VARIABLES: TemplateVariable[] = [
+	{ name: "context.reviewer", description: "Username of the analyst who signed off.", example: "asmith" },
+	{ name: "context.verdict", description: "Their overall verdict, when they gave one.", example: "up" },
+	{ name: "context.report_id", description: "Id of the report that was reviewed." }
+]
+
 const ASSIGNMENT_TRIGGERS: NotificationTrigger[] = ["alert_assigned", "case_assigned", "case_task_assigned"]
 
 /** Variables worth showing for a given trigger, most relevant first. */
@@ -102,10 +109,12 @@ export function variablesForTrigger(trigger: NotificationTrigger | null): Templa
 	// and a manual send can attach one to any alert. Assignment triggers never
 	// do, so listing it there would invite a template with a permanent hole.
 	const specific = !trigger
-		? [...ASSIGNMENT_VARIABLES, ...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
+		? [...ASSIGNMENT_VARIABLES, ...ALERT_VARIABLES, ...AI_REPORT_VARIABLES, ...REVIEW_VARIABLES]
 		: ASSIGNMENT_TRIGGERS.includes(trigger)
 			? ASSIGNMENT_VARIABLES
-			: [...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
+			: trigger === "ai_report_reviewed"
+				? [...REVIEW_VARIABLES, ...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
+				: [...ALERT_VARIABLES, ...AI_REPORT_VARIABLES]
 
 	return [...specific, ...COMMON_VARIABLES, ...LEGACY_ALIASES]
 }

--- a/frontend/src/types/notifications.ts
+++ b/frontend/src/types/notifications.ts
@@ -12,8 +12,18 @@
 // Triggers split by which routes they resolve against. The assignment triggers
 // are INTERNAL: they're about who is working on something, so they reach the
 // SOC's own routes and never a customer's channel.
+//
+// `ai_report_reviewed` is the exception to that split — it resolves against
+// BOTH scopes, so one sign-off can reach the SOC and the customer through
+// separate routes. It is therefore in neither list below: it is not internal-
+// only, and `isInternalTrigger` must keep returning false for it.
 export type NotificationTrigger =
-	"investigation_complete" | "alert_created" | "alert_assigned" | "case_assigned" | "case_task_assigned"
+	| "investigation_complete"
+	| "ai_report_reviewed"
+	| "alert_created"
+	| "alert_assigned"
+	| "case_assigned"
+	| "case_task_assigned"
 
 export const INTERNAL_TRIGGERS: NotificationTrigger[] = ["alert_assigned", "case_assigned", "case_task_assigned"]
 

--- a/frontend/src/views/notification/MessageTemplates.vue
+++ b/frontend/src/views/notification/MessageTemplates.vue
@@ -113,6 +113,7 @@ const formKey = ref(0)
 const triggerOptions = [
 	{ label: "Alert created", value: "alert_created" },
 	{ label: "AI investigation complete", value: "investigation_complete" },
+	{ label: "AI report reviewed", value: "ai_report_reviewed" },
 	{ label: "Alert assigned", value: "alert_assigned" },
 	{ label: "Case assigned", value: "case_assigned" },
 	{ label: "Case task assigned", value: "case_task_assigned" }


### PR DESCRIPTION
Closes #1053.

`ai_report_reviewed` has been emitted by `submit_review` since #1036 and could not be selected on any route, so every one of those events matched nothing. The configuration it was built for — an internal route on submission, a customer-facing route only after an analyst signs off — was impossible to express.

Scoped for **both**, per your call on the issue.

## The scope model

Adds `DUAL_SCOPE_TRIGGERS` and a third case in `routes_for_event`: internal-only, customer-only, or both. The tenant filter applies to the **customer half alone** — internal routes carry `customer_code = NULL`, so filtering the whole query (the obvious way to write it) silently returns nothing for them.

`ai_report_reviewed` stays out of `INTERNAL_TRIGGERS`. Putting it there would look like it works while cutting the customer half off, and would also drag it into the assignment wording and the self-assignment suppression, neither of which apply.

## A latent bug this makes reachable

The AI opt-out gate **`return`ed outright** when it suppressed anything, aborting the entire dispatch. That was harmless while every trigger resolved to one scope. On a mixed batch it would have taken the SOC's own notification down alongside the customer's — the opposite of what the opt-out is for, since keeping findings internal is exactly what an operator chose by leaving the switch off.

Suppression now drops the gated routes and lets the rest proceed. `routes_matched` still counts suppressed routes, so `emit` cannot report *"no route is configured for this trigger"* for what is actually a deliberate opt-out.

The comment at that site claimed it was "written per-route so it stays correct if a future trigger mixes scopes". The per-route filter was correct; the early return wasn't. **I verified the new test fails against the old behaviour** before keeping it.

## Papercuts on the same event

Both mirror what #1048 fixed for `investigation_complete`:

- `reviewer` was `str(reviewer_user_id)`, so a notification read **"Reviewed by: 3"**. Now the username, falling back to the id.
- The subject was `Reviewed: alert #14` — unreadable in a channel carrying several customers. Now the alert's name when known.

The trigger also gets its own default body. It previously fell through to the investigation branch and announced *"AI investigation complete"* a second time about the same alert, burying what had actually changed.

## Surface

- New built-in: **AI report reviewed — sign-off** (markdown, works on both scopes)
- The trigger added to both option lists in the route form and all five display maps
- `context.reviewer` / `.verdict` / `.report_id` added to the template editor's variable reference
- Docs: a new "Both" trigger section, the recipe rewritten from "not currently possible" to a working one, and the reference table updated

## Verification

445 backend tests pass, up from 442. 17 new across two files.

The dual-scope tests use a **real in-memory SQLite database** rather than a mocked session, because what's under test *is* the query — a mock returning a canned list would pass against a WHERE clause that filters out every internal route.

Covered: both halves fire; the internal half isn't tenant-filtered; another tenant's route is never included; a customer with no route still notifies the SOC; assignments and alert-creation are unchanged; suppression delivers the internal half; dedupe stays keyed on the alert.

pre-commit, `type-check` and `lint` clean.

## Not done

No live send. The review path needs an analyst submitting a review through the UI against a customer with routes on both scopes — worth doing once this is deployed, since the mixed-batch behaviour is the part that's genuinely new.