### PR TITLE
fix(notifications): allow deleting a route that has dispatch history

### DIFF
--- a/backend/alembic/versions/b4c7e2a91f38_drop_dispatch_log_route_fk.py
+++ b/backend/alembic/versions/b4c7e2a91f38_drop_dispatch_log_route_fk.py
@@ -1,0 +1,94 @@
+"""drop the notification_dispatch_log -> customer_notification_route FK
+
+Revision ID: b4c7e2a91f38
+Revises: e5b8f31d0c47
+Create Date: 2026-08-04 15:20:00.000000
+
+Deleting a notification route failed for any route that had ever dispatched.
+Two stacked causes: the ORM's default nullify-on-delete tried to set
+`notification_dispatch_log.route_id = NULL`, which the column forbids, and the
+foreign key itself was ON DELETE NO ACTION, so MySQL would have refused the
+delete regardless.
+
+The delete dialog promises "Dispatch log entries will be retained", and that is
+the behaviour we want: the log is an append-only record of what was sent to
+whom, so it has to outlive the route that wrote it.
+
+`route_id` therefore becomes a plain indexed column, following the convention
+already used by `incident_management_*.customer_code`, `monitoring_alerts` and
+`customer_integrations` — orphans tolerated by design. It stays NOT NULL so an
+orphaned row still records which route sent it, which is what an egress audit
+trail needs.
+
+See issue #1057.
+
+"""
+from typing import Sequence
+from typing import Union
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4c7e2a91f38"
+down_revision: Union[str, None] = "e5b8f31d0c47"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "notification_dispatch_log"
+REFERRED = "customer_notification_route"
+INDEX_NAME = "ix_notification_dispatch_log_route_id"
+
+
+def _route_fk_names(conn) -> list:
+    """Every FK on the log table that points at the routes table.
+
+    Looked up rather than hardcoded because MySQL auto-names these
+    (`notification_dispatch_log_ibfk_1` on our deployments) and the number
+    depends on the order constraints were created — a name that is correct here
+    is not guaranteed to be correct on another install. Returning a list also
+    makes this a no-op on SQLite, which never created the constraint.
+    """
+    return [fk["name"] for fk in inspect(conn).get_foreign_keys(TABLE) if fk.get("referred_table") == REFERRED and fk.get("name")]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for name in _route_fk_names(conn):
+        op.drop_constraint(name, TABLE, type_="foreignkey")
+
+    # MySQL keeps the FK's backing index when the constraint is dropped, and
+    # `route_id` is indexed by design (the dispatch-log view filters on it), so
+    # the index is recreated only if this deployment somehow lost it.
+    existing = {ix["name"] for ix in inspect(conn).get_indexes(TABLE)}
+    if INDEX_NAME not in existing and not any(ix.get("column_names") == ["route_id"] for ix in inspect(conn).get_indexes(TABLE)):
+        op.create_index(INDEX_NAME, TABLE, ["route_id"])
+
+
+def downgrade() -> None:
+    """Restore the foreign key.
+
+    **This will fail if any log row references a route that has since been
+    deleted** — which is precisely the state the upgrade makes reachable. That
+    is deliberate: the alternative is silently deleting audit rows recording
+    what was sent to a customer, which is worse than a loud failure.
+
+    To downgrade, first decide what to do with the orphans:
+
+        SELECT id, route_id, customer_code, dispatched_at
+        FROM notification_dispatch_log l
+        WHERE NOT EXISTS (
+            SELECT 1 FROM customer_notification_route r WHERE r.id = l.route_id
+        );
+    """
+    conn = op.get_bind()
+    if not _route_fk_names(conn):
+        op.create_foreign_key(
+            "notification_dispatch_log_ibfk_1",
+            TABLE,
+            REFERRED,
+            ["route_id"],
+            ["id"],
+        )

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -996,14 +996,19 @@ class CustomerNotificationRoute(SQLModel, table=True):
     updated_at: Optional[datetime] = Field(default=None)
 
     customer: Optional["Customers"] = Relationship()
-    # NB: no `back_populates` on the reverse relationships below. The
-    # dispatch service never traverses these — but with back_populates
-    # configured, SQLAlchemy fires implicit synchronous loads on the
-    # parent collections during flush() to keep the in-session graph in
-    # sync, which throws MissingGreenlet under AsyncSession. One-way
-    # foreign keys are fine here; we walk them via explicit queries
-    # (`session.get(...)`) when we need them.
-    dispatches: list["NotificationDispatchLog"] = Relationship(sa_relationship_kwargs={"overlaps": "route"})
+    # NB: no `back_populates` on the reverse relationship below. The dispatch
+    # service never traverses it — but with back_populates configured,
+    # SQLAlchemy fires implicit synchronous loads on the parent collections
+    # during flush() to keep the in-session graph in sync, which throws
+    # MissingGreenlet under AsyncSession. One-way foreign keys are fine here; we
+    # walk them via explicit queries (`session.get(...)`) when we need them.
+    #
+    # There is deliberately no `dispatches` collection. It was never traversed,
+    # and its mere existence broke route deletion: on `session.delete(route)`
+    # SQLAlchemy loaded the collection and tried to de-associate each row by
+    # setting `notification_dispatch_log.route_id = NULL`, which that column
+    # forbids. The log intentionally outlives the route that wrote it (#1057),
+    # so there is no parent/child lifecycle to model.
     shuffle_integration: Optional["CustomerShuffleIntegration"] = Relationship(sa_relationship_kwargs={"overlaps": "routes"})
 
 
@@ -1098,11 +1103,22 @@ class NotificationDispatchLog(SQLModel, table=True):
     # for pre-existing rows, which reproduces the old tuple's meaning exactly.
     dedupe_key: str = Field(max_length=255, nullable=False, index=True)
 
-    route_id: int = Field(
-        foreign_key="customer_notification_route.id",
-        nullable=False,
-        index=True,
-    )
+    # Deliberately NOT a foreign key, following the same convention as
+    # `incident_management_*.customer_code`, `monitoring_alerts` and
+    # `customer_integrations`: a plain indexed column whose orphans are
+    # tolerated by design.
+    #
+    # The log is an append-only record of what was sent to whom, not a live
+    # relational entity — deleting a route must not erase the history of what
+    # that route already delivered, and "Dispatch log entries will be retained"
+    # is what the delete dialog promises. With a real FK that promise was
+    # impossible: the constraint was ON DELETE NO ACTION, so MySQL refused the
+    # delete outright, and the ORM's default nullify-on-delete hit this column's
+    # NOT NULL first. See #1057.
+    #
+    # NOT NULL is kept so attribution survives: an orphaned row still records
+    # which route sent it, which is exactly what an egress audit trail needs.
+    route_id: int = Field(nullable=False, index=True)
     trigger: str = Field(max_length=64, nullable=False)
 
     dispatched_at: datetime = Field(default_factory=datetime.utcnow, index=True)
@@ -1138,10 +1154,10 @@ class NotificationDispatchLog(SQLModel, table=True):
     # Was `shuffle_execution_id`; renamed once a second channel needed the slot.
     provider_reference: Optional[str] = Field(default=None, max_length=128)
 
-    # See note on CustomerNotificationRoute.dispatches — back_populates
-    # removed deliberately to keep AsyncSession flush() synchronous-IO-free.
-    # `overlaps` makes the deliberate one-way nature explicit to SQLAlchemy 2.
-    route: Optional["CustomerNotificationRoute"] = Relationship(sa_relationship_kwargs={"overlaps": "dispatches"})
+    # No `route` relationship either. `route_id` is no longer a foreign key, so
+    # SQLAlchemy has no join condition to infer — and a log row deliberately
+    # survives its route, which makes "the route this belongs to" a question
+    # that can have no answer. Callers that need the route look it up by id.
 
 
 class CustomerShuffleIntegration(SQLModel, table=True):

--- a/backend/tests/test_notification_route_deletion.py
+++ b/backend/tests/test_notification_route_deletion.py
@@ -1,0 +1,258 @@
+"""Deleting a notification route keeps its dispatch history (#1057).
+
+Deleting any route that had ever dispatched failed with
+
+    (1048, "Column 'route_id' cannot be null")
+    UPDATE notification_dispatch_log SET route_id=%s WHERE ... id = %s
+
+Two stacked causes, and fixing either alone leaves the bug:
+
+1. **The ORM nullified the children.** `CustomerNotificationRoute.dispatches`
+   was a plain one-to-many with no cascade configured, so `session.delete(route)`
+   loaded the collection and tried to de-associate each row by setting
+   `route_id = NULL` — a column declared NOT NULL.
+
+2. **The foreign key would have refused anyway.** It was ON DELETE NO ACTION,
+   so even with the ORM silenced MySQL would have rejected the delete.
+
+The fix removes both: `route_id` is now a plain indexed column with no FK, and
+neither side of the relationship exists. The log is append-only evidence of what
+was sent to whom, so it deliberately outlives the route that wrote it — which is
+what the delete dialog has always promised.
+
+Only a route that had **never dispatched** could be deleted before, which is why
+this survived: every test route was freshly created.
+
+Uses a real in-memory SQLite database, because the bug was in what the ORM
+emitted on flush. A mocked session cannot express it — `session.delete` would
+just be an AsyncMock that records the call and never issues the UPDATE.
+
+Run with: cd backend && python -m pytest tests/test_notification_route_deletion.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from sqlalchemy import inspect as sa_inspect  # noqa: E402
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+from sqlalchemy.ext.asyncio import create_async_engine  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+from sqlmodel import SQLModel  # noqa: E402
+
+import app.notifications.services.notifications as svc  # noqa: E402
+from app.db.universal_models import CustomerNotificationRoute  # noqa: E402
+from app.db.universal_models import NotificationDispatchLog  # noqa: E402
+
+CC = "TENANT_A"
+
+# `customers` and `customer_shuffle_integration` are here only because the route
+# still has many-to-one relationships to them, which SQLAlchemy resolves while
+# processing the delete. They hold no rows in these tests.
+_TABLES = [
+    "customer_notification_route",
+    "notification_dispatch_log",
+    "customers",
+    "customer_shuffle_integration",
+]
+
+
+async def _make_session() -> AsyncSession:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    tables = [SQLModel.metadata.tables[t] for t in _TABLES]
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: SQLModel.metadata.create_all(c, tables=tables))
+    # expire_on_commit=False matches the app's AsyncSessionLocal; the default
+    # would expire attributes on commit and refresh them synchronously on next
+    # access, which is MissingGreenlet under asyncio.
+    return AsyncSession(engine, expire_on_commit=False)
+
+
+def _route(scope="customer", customer_code=CC):
+    return CustomerNotificationRoute(
+        name="Test Email",
+        scope=scope,
+        customer_code=customer_code,
+        trigger="alert_created",
+        channel="resend",
+        destination="",
+        enabled=True,
+        min_severity="Informational",
+        recipient_mode="static",
+        config="{}",
+        created_at=datetime(2026, 8, 4, 12, 0, 0),
+        created_by="admin",
+    )
+
+
+def _log(route_id, dedupe_key):
+    return NotificationDispatchLog(
+        customer_code=CC,
+        alert_id=14,
+        entity_type="alert",
+        entity_id=14,
+        dedupe_key=dedupe_key,
+        route_id=route_id,
+        trigger="alert_created",
+        status="sent",
+        dispatched_at=datetime(2026, 8, 4, 12, 5, 0),
+    )
+
+
+async def _seed_route_with_history(session, *, scope="customer", customer_code=CC, entries=3):
+    route = _route(scope=scope, customer_code=customer_code)
+    session.add(route)
+    await session.commit()
+    session.add_all([_log(route.id, f"alert:14:{i}") for i in range(entries)])
+    await session.commit()
+    return route.id
+
+
+def _run(coro_factory):
+    async def run():
+        session = await _make_session()
+        try:
+            return await coro_factory(session)
+        finally:
+            await session.close()
+
+    return asyncio.run(run())
+
+
+async def _remaining_logs(session):
+    return list((await session.execute(select(NotificationDispatchLog))).scalars().all())
+
+
+# ── the model shape the fix depends on ────────────────────────────────────
+
+
+def test_route_id_is_not_a_foreign_key():
+    """A real FK makes the retention promise impossible: ON DELETE NO ACTION
+    refuses the delete, and any cascade that permits it destroys or blanks the
+    audit row. Same convention as incident_management_*.customer_code."""
+    fks = SQLModel.metadata.tables["notification_dispatch_log"].c.route_id.foreign_keys
+
+    assert not fks
+
+
+def test_route_id_is_still_not_null():
+    """Attribution has to survive the route. An orphaned row that cannot say
+    which route sent it is not much of an audit trail."""
+    assert SQLModel.metadata.tables["notification_dispatch_log"].c.route_id.nullable is False
+
+
+def test_route_id_is_still_indexed():
+    """The dispatch-log view filters on it; dropping the FK must not drop the
+    index that made those queries cheap."""
+    indexed = {tuple(ix.columns.keys()) for ix in SQLModel.metadata.tables["notification_dispatch_log"].indexes}
+
+    assert ("route_id",) in indexed
+
+
+def test_neither_side_of_the_route_relationship_exists():
+    """Their mere existence was cause #1: SQLAlchemy loaded the collection on
+    delete and nullified it. Neither was ever traversed."""
+    assert not hasattr(CustomerNotificationRoute, "dispatches")
+    assert "route" not in sa_inspect(NotificationDispatchLog).relationships
+
+
+# ── the actual deletion ───────────────────────────────────────────────────
+
+
+def test_deleting_a_route_with_history_succeeds():
+    """The reported bug. Before the fix this raised IntegrityError."""
+
+    async def scenario(session):
+        route_id = await _seed_route_with_history(session)
+        await svc.delete_route(route_id, CC, session)
+        return (await session.get(CustomerNotificationRoute, route_id)), await _remaining_logs(session)
+
+    route, logs = _run(scenario)
+
+    assert route is None
+    assert len(logs) == 3
+
+
+def test_the_log_rows_keep_pointing_at_the_deleted_route():
+    """ "Dispatch log entries will be retained" — with attribution intact, so the
+    history still answers "which route sent this"."""
+
+    async def scenario(session):
+        route_id = await _seed_route_with_history(session)
+        await svc.delete_route(route_id, CC, session)
+        return route_id, await _remaining_logs(session)
+
+    route_id, logs = _run(scenario)
+
+    assert {log.route_id for log in logs} == {route_id}
+    assert all(log.status == "sent" for log in logs)
+
+
+def test_deleting_an_internal_route_with_history_succeeds():
+    """The same defect, reached through the other endpoint. Internal routes are
+    where assignment notifications land, so they accumulate history fastest."""
+
+    async def scenario(session):
+        route_id = await _seed_route_with_history(session, scope="internal", customer_code=None)
+        await svc.delete_internal_route(route_id, session)
+        return (await session.get(CustomerNotificationRoute, route_id)), await _remaining_logs(session)
+
+    route, logs = _run(scenario)
+
+    assert route is None
+    assert len(logs) == 3
+
+
+def test_deleting_a_route_that_never_dispatched_still_works():
+    """The only case that worked before — it must keep working."""
+
+    async def scenario(session):
+        route = _route()
+        session.add(route)
+        await session.commit()
+        await svc.delete_route(route.id, CC, session)
+        return await session.get(CustomerNotificationRoute, route.id)
+
+    assert _run(scenario) is None
+
+
+def test_another_routes_history_is_untouched():
+    """Deleting one route must not disturb a sibling's log rows."""
+
+    async def scenario(session):
+        doomed = await _seed_route_with_history(session, entries=2)
+        keeper = await _seed_route_with_history(session, entries=4)
+        await svc.delete_route(doomed, CC, session)
+        logs = await _remaining_logs(session)
+        return keeper, doomed, logs
+
+    keeper, doomed, logs = _run(scenario)
+
+    assert len([log for log in logs if log.route_id == keeper]) == 4
+    assert len([log for log in logs if log.route_id == doomed]) == 2
+
+
+def test_deleting_a_route_from_the_wrong_customer_is_still_a_404():
+    """The tenant check happens before the delete; loosening the FK must not
+    loosen that."""
+    from fastapi import HTTPException
+
+    async def scenario(session):
+        route_id = await _seed_route_with_history(session)
+        with pytest.raises(HTTPException) as exc:
+            await svc.delete_route(route_id, "SOMEONE_ELSE", session)
+        return exc.value.status_code, await _remaining_logs(session)
+
+    status, logs = _run(scenario)
+
+    assert status == 404
+    assert len(logs) == 3, "a refused delete must not touch the history either"


### PR DESCRIPTION
Closes #1057.

> ⚠️ **Contains a migration.** `b4c7e2a91f38_drop_dispatch_log_route_fk.py`, chaining from `e5b8f31d0c47` (the current single head, which matches the dev DB). **I have not run it anywhere.** Please review before merging or applying.

## The bug

Deleting any route that had ever dispatched failed:

```
(pymysql.err.IntegrityError) (1048, "Column 'route_id' cannot be null")
[SQL: UPDATE notification_dispatch_log SET route_id=%s WHERE ... id = %s]
```

Only a route with **no history** could be deleted, which is why it survived — every route in testing was freshly created. Both `delete_route` and `delete_internal_route` were affected.

## Two stacked causes

**1. The ORM nullified the children.** `CustomerNotificationRoute.dispatches` was a one-to-many with no cascade configured, so `session.delete(route)` loaded the collection and tried to de-associate each row by setting `route_id = NULL` — a column declared `NOT NULL`.

**2. The FK would have refused anyway.** `notification_dispatch_log_ibfk_1` is `ON DELETE NO ACTION`, so even with the ORM silenced MySQL would have rejected the delete.

Fixing either alone leaves the bug.

## The promise the schema never supported

The dialog says *"Delete this route? Dispatch log entries will be retained."* That's the right behaviour — the log is an append-only record of what was sent to which customer, so it has to outlive the route that wrote it. With a real FK it was impossible.

`route_id` becomes a **plain indexed column with no FK**, matching the convention CLAUDE.md documents for `incident_management_*.customer_code`, `monitoring_alerts` and `customer_integrations`. It stays `NOT NULL` so an orphaned row still records *which* route sent it.

Both relationships are removed. Neither was ever traversed — their own comments said so — and the collection's existence is cause #1.

## The migration

- Looks the constraint name up from `information_schema` rather than hardcoding it. MySQL auto-names these and the number depends on creation order, so `notification_dispatch_log_ibfk_1` here is not guaranteed elsewhere. No-ops on SQLite.
- `route_id` keeps two usable indexes independent of the FK (`ix_notification_dispatch_log_route_id`, and `uq_notif_dispatch_idem` which leads with it) — verified against the dev DB, so query plans are unaffected.
- Downgrade recreates the constraint and **fails loudly if orphaned rows exist**, with the diagnostic query in the docstring. Deliberate: the alternative is silently deleting audit rows.
- No data change. Existing rows keep their `route_id`; only the constraint goes.

## Verification

455 tests pass, up from 445. 10 new, using a **real in-memory SQLite database** — the bug was in what the ORM emitted on flush, which a mocked session cannot express, since `session.delete` would just be an AsyncMock recording the call.

**I confirmed the tests catch the bug**: reverting the model to its pre-fix shape reproduces the exact `IntegrityError` and fails 6 of the 10.

Covered: deletion with history succeeds; log rows survive with `route_id` intact; the internal-route path; a route with no history still deletes; a sibling route's history is untouched; a cross-tenant delete is still a 404 and leaves the history alone; and the four model-shape invariants the fix rests on.

pre-commit clean.

## Not covered

No live verification against MySQL — the fix is exercised on SQLite, and the migration hasn't been run. Worth deleting a real route on the dev deployment once the migration is applied, since the FK behaviour is the MySQL-specific half.