### PR TITLE
fix(notifications): show the real channel on a route instead of always Shuffle

### DIFF
--- a/frontend/src/components/agents/agentFlow/AgentFlowItem.vue
+++ b/frontend/src/components/agents/agentFlow/AgentFlowItem.vue
@@ -169,7 +169,6 @@
 </template>
 
 <script setup lang="ts">
-import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 import type { FlowResult } from "@/types/flow"
 import _pick from "lodash/pick"
 import { NEmpty, NInput, NModal, NPopover, NScrollbar, NTabPane, NTabs } from "naive-ui"
@@ -180,8 +179,8 @@ import CardEntity from "@/components/common/cards/CardEntity.vue"
 import CardKV from "@/components/common/cards/CardKV.vue"
 import Icon from "@/components/common/Icon.vue"
 import { useSettingsStore } from "@/stores/settings"
-import dayjs from "@/utils/dayjs"
 import { formatDate } from "@/utils/format"
+import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 import "@/assets/scss/overrides/vuesjv-override.scss"
 
 const { flow, embedded } = defineProps<{ flow: FlowResult; embedded?: boolean }>()

--- a/frontend/src/components/agents/agentFlow/AgentFlowQueryStat.vue
+++ b/frontend/src/components/agents/agentFlow/AgentFlowQueryStat.vue
@@ -85,7 +85,6 @@
 </template>
 
 <script setup lang="ts">
-import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 import type { FlowQueryStat } from "@/types/flow"
 import _pick from "lodash/pick"
 import { NInput, NModal, NTabPane, NTabs } from "naive-ui"
@@ -94,8 +93,8 @@ import Badge from "@/components/common/Badge.vue"
 import CardEntity from "@/components/common/cards/CardEntity.vue"
 import CardKV from "@/components/common/cards/CardKV.vue"
 import { useSettingsStore } from "@/stores/settings"
-import dayjs from "@/utils/dayjs"
 import { formatDate } from "@/utils/format"
+import { formatNanosecondsDuration } from "@/utils/formatNanosecondsDuration"
 
 const { stat, embedded } = defineProps<{ stat: FlowQueryStat; embedded?: boolean }>()
 

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteDetails.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteDetails.vue
@@ -221,7 +221,7 @@ import { useNavigation } from "@/composables/useNavigation"
 import { useSettingsStore } from "@/stores/settings"
 import { getApiErrorMessage } from "@/utils"
 import { formatDate } from "@/utils/format"
-import { describeRouteDestination } from "./destination"
+import { describeRouteChannel, describeRouteDestination } from "./destination"
 
 const props = defineProps<{
 	entity: NotificationRoute
@@ -262,27 +262,14 @@ const loadingTemplate = ref(false)
 const namedTemplate = ref<NotificationTemplate | null>(null)
 
 const isInternalScope = computed(() => props.scope === "internal" || entity.value.customer_code === null)
-const isWebhook = computed(() => entity.value.channel === "webhook")
 const destination = computed(() => describeRouteDestination(entity.value))
 const hasConfig = computed(() => Object.keys(entity.value.config ?? {}).length > 0)
 
 const triggerLabel = computed(() => TRIGGER_LABELS[entity.value.trigger] ?? entity.value.trigger)
 
-const channelIcon = computed(() => (isWebhook.value ? "carbon:webhook" : "carbon:integration"))
-const channelLabel = computed(() => {
-	if (isWebhook.value) {
-		try {
-			return `Webhook · ${new URL((entity.value.config?.url as string) ?? "").host}`
-		} catch {
-			return "Webhook"
-		}
-	}
-	if (entity.value.channel === "shuffle") {
-		const appName = entity.value.config?.app_name as string | undefined
-		return appName ? `Shuffle · ${appName}` : "Shuffle"
-	}
-	return entity.value.channel
-})
+// Shared with the list row so the two can't disagree about what a route is.
+const channelIcon = computed(() => describeRouteChannel(entity.value).icon)
+const channelLabel = computed(() => describeRouteChannel(entity.value).label)
 
 const severityColor = computed<"danger" | "warning" | "success">(() => {
 	if (entity.value.min_severity === "Critical" || entity.value.min_severity === "High") return "danger"

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/CustomerAiNotificationRouteItem.vue
@@ -163,7 +163,7 @@ import { useSettingsStore } from "@/stores/settings"
 import { getApiErrorMessage } from "@/utils"
 import { formatDate } from "@/utils/format"
 import CustomerAiNotificationRouteOverview from "./CustomerAiNotificationRouteOverview.vue"
-import { describeRouteDestination } from "./destination"
+import { describeRouteChannel, describeRouteDestination } from "./destination"
 
 const props = defineProps<{
 	route: NotificationRoute
@@ -206,21 +206,9 @@ const hasCustomHeaders = computed(() => Object.keys(webhookConfig.value.headers 
 
 const destination = computed(() => describeRouteDestination(props.route))
 
-// Shuffle routes cache the app name on the row at form-submit time so we
-// can render "Shuffle · Slack" without a roundtrip; webhook routes show
-// the URL host so the list is scannable at a glance.
-const channelIcon = computed(() => (isWebhook.value ? "carbon:webhook" : "carbon:integration"))
-const channelLabel = computed(() => {
-	if (isWebhook.value) {
-		try {
-			return `Webhook · ${new URL((props.route.config?.url as string) ?? "").host}`
-		} catch {
-			return "Webhook"
-		}
-	}
-	const appName = props.route.config?.app_name as string | undefined
-	return appName ? `Shuffle · ${appName}` : "Shuffle"
-})
+// Shared with the detail panel so the two can't disagree about what a route is.
+const channelIcon = computed(() => describeRouteChannel(props.route).icon)
+const channelLabel = computed(() => describeRouteChannel(props.route).label)
 
 const severityColor = computed<"danger" | "warning" | "success">(() => {
 	if (props.route.min_severity === "Critical" || props.route.min_severity === "High") return "danger"

--- a/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/destination.ts
+++ b/frontend/src/components/customers/aiNotifications/CustomerAiNotificationRoutes/destination.ts
@@ -17,6 +17,51 @@ export interface RouteDestination {
 	note?: string
 }
 
+export interface RouteChannel {
+	/** Human label, e.g. "Email (Resend)". */
+	label: string
+	/** Iconify name. Only `carbon:`, `mdi:` and `logos:` are bundled. */
+	icon: string
+}
+
+// How a route's channel is named in the UI.
+//
+// This used to be `isWebhook ? "Webhook" : "Shuffle"` — written when those were
+// the only two channels, and duplicated in both the list row and the detail
+// panel. Every channel added since (resend, teams) fell into the else branch and
+// rendered as "Shuffle", so an email route claimed to be a Shuffle one while
+// correctly sending email.
+//
+// The labels mirror each provider's `display_name` in the backend channel
+// catalog. The default branch deliberately names no channel: guessing is what
+// caused the original bug, so an unrecognised key shows itself instead.
+export function describeRouteChannel(route: NotificationRoute): RouteChannel {
+	const config = route.config ?? {}
+
+	switch (route.channel) {
+		case "webhook": {
+			// The host makes a list of webhook routes scannable at a glance.
+			try {
+				return { label: `Webhook · ${new URL((config.url as string) ?? "").host}`, icon: "carbon:webhook" }
+			} catch {
+				return { label: "Webhook", icon: "carbon:webhook" }
+			}
+		}
+		case "resend":
+			return { label: "Email (Resend)", icon: "carbon:email" }
+		case "teams":
+			return { label: "Microsoft Teams", icon: "mdi:microsoft-teams" }
+		case "shuffle": {
+			// Shuffle routes cache the app name on the row at submit time, so
+			// "Shuffle · Slack" needs no extra round-trip.
+			const appName = config.app_name as string | undefined
+			return { label: appName ? `Shuffle · ${appName}` : "Shuffle", icon: "carbon:integration" }
+		}
+		default:
+			return { label: route.channel || "Unknown channel", icon: "carbon:send" }
+	}
+}
+
 export function describeRouteDestination(route: NotificationRoute): RouteDestination {
 	const config = route.config ?? {}
 


### PR DESCRIPTION
The route list rendered **every non-webhook route as "Shuffle"**, so a Resend route claimed to be a Shuffle one while correctly sending email.

## Cause

`channelLabel` was a two-branch computed written when webhook and Shuffle were the only channels:

```js
isWebhook
  ? `Webhook · ${host}`
  : (appName ? `Shuffle · ${appName}` : "Shuffle")
```

Every channel added since — resend (#1026), teams (#1032) — fell into the else branch. `channelIcon` had the same shape, so both also wore Shuffle's integration glyph.

The **detail panel carried a near-copy** of the logic and was wrong differently: it had a `shuffle` case and fell through to the raw channel key, showing `resend` rather than `Email (Resend)`. That divergence is exactly what `destination.ts` was created to prevent — its own comment says *"One resolver, so the list row and the detail page can't disagree."*

## Fix

`describeRouteChannel()` alongside `describeRouteDestination()`, with both components pointing at it.

| Channel | Label | Icon |
|---|---|---|
| resend | Email (Resend) | `carbon:email` |
| teams | Microsoft Teams | `mdi:microsoft-teams` |
| shuffle | Shuffle · *app* | `carbon:integration` |
| webhook | Webhook · *host* | `carbon:webhook` |
| *unknown* | the channel key itself | `carbon:send` |

Two deliberate choices:

- Labels mirror each provider's `display_name` in the backend channel catalog.
- **The default branch names no channel.** Guessing is what caused this bug, so an unrecognised key shows itself rather than impersonating something. A future channel will look unstyled, not wrong.

Icons stay within the bundled `carbon:` / `mdi:` collections, per the note in CLAUDE.md — `mdi:` is already used elsewhere in the app.

Also drops an `isWebhook` computed left unused in the detail panel.

## Verification

`pnpm lint` and pre-commit clean. No backend change, no test change — this is presentation logic with no service behaviour behind it.

## Unrelated: `pnpm type-check` is currently red on main

Not caused by this PR, and not fixed here:

```
src/components/agents/agentFlow/AgentFlowItem.vue(183,1): error TS6133: 'dayjs' is declared but its value is never read.
src/components/agents/agentFlow/AgentFlowQueryStat.vue(97,1): error TS6133: 'dayjs' is declared but its value is never read.
```

Both files were last touched by #1055 (Velociraptor durations). The Docker image builds with `build:only` (`vite build`, no `vue-tsc`), so releases are unaffected — but `pnpm build` and `pnpm lint-type-format` fail locally for everyone until those two imports go. Happy to fix in a follow-up.