### PR TITLE
feat(stack-provisioning): auto-provision InfluxDB monitoring checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,10 @@ SUBLIME_API_KEY=dummy
 INFLUXDB_URL=http://127.1.1.1
 INFLUXDB_API_KEY=dummy
 INFLUXDB_ORG_AND_BUCKET=dummy,dummy
+# Verify TLS certificates on the InfluxDB v2 REST API calls used by check provisioning.
+# Off by default because a stack's InfluxDB is normally a co-located appliance with a
+# self-signed certificate. Set to True where InfluxDB is fronted by a trusted CA.
+INFLUXDB_VERIFY_SSL=False
 
 GRAFANA_URL=http://127.1.1.1
 GRAFANA_USERNAME=dummy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,22 @@ Consequence: refreshing CoPilot Searches refreshes the Stories surface; Wazuh ru
 - Frontend supporting files: `src/types/detectionCatalog.d.ts`, `src/api/endpoints/detectionCatalog.ts`
 - Three authorized cross-cutting edits and only these three: nav entry in `app-layouts/common/Navbar/items.tsx`, route in `router/index.ts`, barrel registration in `api/index.ts`. Nothing else outside the catalog namespace should change for this feature.
 
+### Stack provisioning: Graylog content packs and InfluxDB checks
+
+`app/stack_provisioning/` holds two independent provisioners that share a shape (JSON templates on disk + `routes / services / schema`) but nothing else:
+
+- **`graylog/`** — content packs, streams, inputs, pipelines. Templates are Graylog content-pack exports.
+- **`influxdb/`** — the four SOCFortress monitoring checks (CPU, memory, disk, critical systemd services). Templates under `influxdb/templates/` are **literal `POST /api/v2/checks` bodies** with two placeholders, `REPLACE_ORG_ID` and `REPLACE_BUCKET`, substituted at provision time.
+
+Things to keep straight in the InfluxDB half:
+
+- **The connector stores the org *name*, the checks API wants the org *ID*.** `connector_extra_data` is `"ORG,BUCKET"` (e.g. `SOCFORTRESS,telegraf`); `get_influxdb_org_id()` resolves name → ID via `GET /api/v2/orgs` on every provision run. Don't pass the name into a check payload — InfluxDB accepts it and then the check belongs to no org.
+- **`influxdb_client`'s async client exposes only the query and write APIs.** Checks, notification endpoints and notification rules are not on it, so `app/connectors/influxdb/utils/universal.py` carries plain `httpx` helpers (`send_get_request` / `send_post_request` / `send_put_request` / `send_delete_request`) that authenticate with `Authorization: Token <key>`. Anything touching those three APIs goes through them, not the SDK.
+- **Provisioning skips an existing check unless `overwrite=true`.** Stacks are routinely built by hand before CoPilot is pointed at them — `CPU CHECK` in particular usually already exists — and a blind PUT would discard an engineer's tuning. The CPU template is therefore a byte-for-byte copy of the hand-built check so that overwriting it is genuinely a no-op.
+- **No new read path is needed and none should be added.** Checks write their results into InfluxDB's `_monitoring` bucket as the `statuses` measurement, which the pre-existing `GET /influxdb/alerts` already queries — so a provisioned check surfaces in the Healthcheck UI automatically.
+- **A unit that doesn't exist on a host produces no rows, not a false alert**, which is why the critical-services template carries a superset of SOCFortress stack units rather than being tailored per deployment. Don't "fix" it by trimming the list.
+- **Checks alone notify nobody.** InfluxDB only sends anywhere once notification endpoints + rules exist, and CoPilot provisions neither. Creating checks is safe on a live stack.
+
 ### Frontend essentials
 
 - `src/api/httpClient.ts` (axios) and `src/api/sseClient.ts` (`@microsoft/fetch-event-source`) — backend traffic. Wrappers in `src/api/endpoints/`.

--- a/backend/app/connectors/influxdb/utils/universal.py
+++ b/backend/app/connectors/influxdb/utils/universal.py
@@ -1,7 +1,10 @@
+import os
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
+import httpx
 from fastapi import HTTPException
 from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 from loguru import logger
@@ -102,10 +105,15 @@ async def create_influxdb_client(connector_name: str) -> InfluxDBClientAsync:
         )
 
 
-async def get_influxdb_organization() -> str:
+async def get_influxdb_attributes() -> Dict[str, Any]:
     """
-    Read the `connector_extra_data` from the database and return the organization name.
-    which is the first item. For example: `SOCFORTRESS,telegraf`.
+    Read the InfluxDB connector row from the database.
+
+    Returns:
+        Dict[str, Any]: The connector attributes (url, api key, extra data, ...).
+
+    Raises:
+        HTTPException: If the InfluxDB connector is not configured.
     """
     async with get_db_session() as session:  # This will correctly enter the context manager
         attributes = await get_connector_info_from_db("InfluxDB", session)
@@ -114,7 +122,156 @@ async def get_influxdb_organization() -> str:
             status_code=500,
             detail="No InfluxDB connector found in the database",
         )
+    return attributes
+
+
+async def get_influxdb_organization() -> str:
+    """
+    Read the `connector_extra_data` from the database and return the organization name.
+    which is the first item. For example: `SOCFORTRESS,telegraf`.
+    """
+    attributes = await get_influxdb_attributes()
     return attributes["connector_extra_data"].split(",")[0]
+
+
+async def get_influxdb_bucket() -> str:
+    """
+    Read the `connector_extra_data` from the database and return the bucket name,
+    which is the second item. For example: `SOCFORTRESS,telegraf`.
+
+    Returns:
+        str: The bucket holding the Telegraf metrics.
+
+    Raises:
+        HTTPException: If `connector_extra_data` is not in the expected `ORG,BUCKET` format.
+    """
+    attributes = await get_influxdb_attributes()
+    parts = attributes["connector_extra_data"].split(",")
+    if len(parts) < 2:
+        raise HTTPException(
+            status_code=500,
+            detail="Invalid connector_extra_data format for InfluxDB. Expected 'ORG,BUCKET'.",
+        )
+    return parts[1].strip()
+
+
+async def get_influxdb_org_id() -> str:
+    """
+    Resolve the InfluxDB organization *ID* from the organization *name* stored on the connector.
+
+    The connector only persists the org name (`connector_extra_data`), but the InfluxDB
+    `/api/v2/checks` API keys everything off the org ID, so it has to be looked up.
+
+    Returns:
+        str: The InfluxDB organization ID.
+
+    Raises:
+        HTTPException: If the organization cannot be found.
+    """
+    org_name = await get_influxdb_organization()
+    response = await send_get_request("/api/v2/orgs", params={"org": org_name})
+    orgs = response.get("orgs", [])
+    for org in orgs:
+        if org.get("name") == org_name:
+            logger.info(f"Resolved InfluxDB organization {org_name} to ID {org['id']}")
+            return org["id"]
+    raise HTTPException(
+        status_code=404,
+        detail=f"InfluxDB organization {org_name} not found",
+    )
+
+
+# ! HTTP HELPERS FOR THE INFLUXDB v2 REST API
+# The `influxdb_client` async client only wraps the query/write APIs — the checks,
+# notification endpoint and notification rule APIs are not exposed on it, so anything
+# touching those has to go over plain HTTP.
+#
+# TLS verification is OFF by default, matching `create_influxdb_client()` above: InfluxDB
+# in a SOCFortress stack is a co-located appliance that effectively always serves a
+# self-signed certificate, so verifying would fail every provisioning call out of the box.
+# Deployments that front InfluxDB with a certificate from a trusted CA should set
+# INFLUXDB_VERIFY_SSL=True.
+
+
+def _influxdb_verify_ssl() -> bool:
+    """Whether to verify TLS certificates when calling the InfluxDB REST API."""
+    return os.getenv("INFLUXDB_VERIFY_SSL", "False").lower() in ("true", "1", "yes")
+
+
+async def _influxdb_request(
+    method: str,
+    endpoint: str,
+    params: Optional[Dict[str, Any]] = None,
+    data: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """
+    Send a request to the InfluxDB v2 REST API using the stored connector credentials.
+
+    Args:
+        method (str): The HTTP method to use.
+        endpoint (str): The API endpoint, e.g. `/api/v2/checks`.
+        params (Optional[Dict[str, Any]]): Optional query string parameters.
+        data (Optional[Dict[str, Any]]): Optional JSON body.
+
+    Returns:
+        Any: The decoded JSON response, or None for empty (204) responses.
+
+    Raises:
+        HTTPException: If InfluxDB is unreachable or returns a non-2xx response.
+    """
+    attributes = await get_influxdb_attributes()
+    url = f"{attributes['connector_url'].rstrip('/')}{endpoint}"
+    headers = {
+        "Authorization": f"Token {attributes['connector_api_key']}",
+        "Content-Type": "application/json",
+    }
+    logger.info(f"Sending {method} request to InfluxDB: {url}")
+    try:
+        async with httpx.AsyncClient(verify=_influxdb_verify_ssl(), timeout=60.0) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=headers,
+                params=params,
+                json=data,
+            )
+    except Exception as e:
+        logger.error(f"Failed to reach InfluxDB at {url}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to reach InfluxDB: {e}",
+        )
+
+    if response.status_code >= 300:
+        logger.error(f"InfluxDB {method} {endpoint} failed ({response.status_code}): {response.text}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"InfluxDB request failed ({response.status_code}): {response.text}",
+        )
+
+    if not response.content:
+        return None
+    return response.json()
+
+
+async def send_get_request(endpoint: str, params: Optional[Dict[str, Any]] = None) -> Any:
+    """Send a GET request to the InfluxDB v2 REST API."""
+    return await _influxdb_request("GET", endpoint, params=params)
+
+
+async def send_post_request(endpoint: str, data: Dict[str, Any]) -> Any:
+    """Send a POST request to the InfluxDB v2 REST API."""
+    return await _influxdb_request("POST", endpoint, data=data)
+
+
+async def send_put_request(endpoint: str, data: Dict[str, Any]) -> Any:
+    """Send a PUT request to the InfluxDB v2 REST API."""
+    return await _influxdb_request("PUT", endpoint, data=data)
+
+
+async def send_delete_request(endpoint: str) -> Any:
+    """Send a DELETE request to the InfluxDB v2 REST API."""
+    return await _influxdb_request("DELETE", endpoint)
 
 
 # ! RUN A TEST QUERY TO FETCH ALERTS AND VERIFY THE CONNECTION

--- a/backend/app/routers/stack_provisioning.py
+++ b/backend/app/routers/stack_provisioning.py
@@ -15,6 +15,12 @@ from app.stack_provisioning.graylog.routes.sentinelone import (
 from app.stack_provisioning.graylog.routes.sonicwall import (
     stack_provisioning_graylog_sonicwall_router,
 )
+from app.stack_provisioning.influxdb.routes.decommission import (
+    stack_decommissioning_influxdb_router,
+)
+from app.stack_provisioning.influxdb.routes.provision import (
+    stack_provisioning_influxdb_router,
+)
 
 # Instantiate the APIRouter
 router = APIRouter()
@@ -52,4 +58,18 @@ router.include_router(
     stack_provisioning_graylog_sentinelone_router,
     prefix="/stack_provisioning",
     tags=["Stack Provisioning"],
+)
+
+# Include the InfluxDB Stack Provisioning related routes
+router.include_router(
+    stack_provisioning_influxdb_router,
+    prefix="/stack_provisioning",
+    tags=["Stack Provisioning"],
+)
+
+# Include the InfluxDB Stack Decommissioning related routes
+router.include_router(
+    stack_decommissioning_influxdb_router,
+    prefix="/stack_decommissioning",
+    tags=["Stack Decommissioning"],
 )

--- a/backend/app/stack_provisioning/influxdb/routes/decommission.py
+++ b/backend/app/stack_provisioning/influxdb/routes/decommission.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter
+from fastapi import HTTPException
+from fastapi import Security
+from loguru import logger
+
+from app.auth.utils import AuthHandler
+from app.stack_provisioning.influxdb.schema.provision import AvailableInfluxDBChecks
+from app.stack_provisioning.influxdb.schema.provision import (
+    DecommissionInfluxDBCheckResponse,
+)
+from app.stack_provisioning.influxdb.services.provision import decommission_check
+
+stack_decommissioning_influxdb_router = APIRouter()
+
+
+@stack_decommissioning_influxdb_router.delete(
+    "/influxdb/check/{check_name}",
+    response_model=DecommissionInfluxDBCheckResponse,
+    description="Delete a provisioned monitoring check from the InfluxDB instance",
+    dependencies=[Security(AuthHandler().require_any_scope("admin"))],
+)
+async def decommission_check_route(check_name: str) -> DecommissionInfluxDBCheckResponse:
+    """
+    Delete a provisioned monitoring check from the InfluxDB instance.
+
+    `check_name` is the template name (e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK`), not the
+    name the check carries inside InfluxDB — so only checks CoPilot knows how to
+    provision can be removed through this route.
+    """
+    if check_name not in AvailableInfluxDBChecks.__members__:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Check {check_name} is not available. Please choose from the available checks.",
+        )
+    logger.info(f"Decommissioning InfluxDB check {check_name}...")
+    return await decommission_check(check_name)

--- a/backend/app/stack_provisioning/influxdb/routes/provision.py
+++ b/backend/app/stack_provisioning/influxdb/routes/provision.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter
+from fastapi import Security
+from loguru import logger
+
+from app.auth.utils import AuthHandler
+from app.stack_provisioning.influxdb.schema.provision import (
+    AvailableInfluxDBChecksResponse,
+)
+from app.stack_provisioning.influxdb.schema.provision import (
+    ProvisionInfluxDBAllChecksRequest,
+)
+from app.stack_provisioning.influxdb.schema.provision import (
+    ProvisionInfluxDBCheckRequest,
+)
+from app.stack_provisioning.influxdb.schema.provision import ProvisionInfluxDBResponse
+from app.stack_provisioning.influxdb.services.provision import get_available_checks
+from app.stack_provisioning.influxdb.services.provision import provision_all_checks
+from app.stack_provisioning.influxdb.services.provision import provision_check
+
+stack_provisioning_influxdb_router = APIRouter()
+
+
+@stack_provisioning_influxdb_router.get(
+    "/influxdb/available/checks",
+    response_model=AvailableInfluxDBChecksResponse,
+    description="Get the InfluxDB monitoring checks available for provisioning",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def get_available_checks_route() -> AvailableInfluxDBChecksResponse:
+    """
+    Get the InfluxDB monitoring checks available for provisioning
+    """
+    logger.info("Getting available InfluxDB checks...")
+    return await get_available_checks()
+
+
+@stack_provisioning_influxdb_router.post(
+    "/influxdb/provision/check",
+    response_model=ProvisionInfluxDBResponse,
+    description="Provision a monitoring check in the InfluxDB instance",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def provision_check_route(
+    check_request: ProvisionInfluxDBCheckRequest,
+) -> ProvisionInfluxDBResponse:
+    """
+    Provision a monitoring check in the InfluxDB instance
+    """
+    logger.info(f"Provisioning InfluxDB check {check_request.check_name.name}...")
+    return await provision_check(check_request)
+
+
+@stack_provisioning_influxdb_router.post(
+    "/influxdb/provision/checks",
+    response_model=ProvisionInfluxDBResponse,
+    description="Provision all available monitoring checks in the InfluxDB instance",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def provision_all_checks_route(
+    check_request: ProvisionInfluxDBAllChecksRequest,
+) -> ProvisionInfluxDBResponse:
+    """
+    Provision all available monitoring checks in the InfluxDB instance
+    """
+    logger.info("Provisioning all InfluxDB checks...")
+    return await provision_all_checks(check_request.overwrite)

--- a/backend/app/stack_provisioning/influxdb/schema/provision.py
+++ b/backend/app/stack_provisioning/influxdb/schema/provision.py
@@ -1,0 +1,122 @@
+from enum import Enum
+from typing import Any
+from typing import List
+from typing import Optional
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class AvailableInfluxDBChecks(str, Enum):
+    """
+    The InfluxDB checks CoPilot can provision. The enum *name* is the template file stem
+    under `app/stack_provisioning/influxdb/templates/`, the value is the operator-facing
+    description.
+    """
+
+    SOCFORTRESS_INFLUXDB_CPU_CHECK = (
+        "Threshold check on CPU idle time (`cpu`/`usage_idle`). Raises INFO below 25% idle,"
+        " WARN below 15% and CRIT below 5%, evaluated every minute per host."
+    )
+    SOCFORTRESS_INFLUXDB_MEMORY_CHECK = (
+        "Threshold check on available memory (`mem`/`available_percent`). Raises INFO below 25%"
+        " available, WARN below 15% and CRIT below 10%, evaluated every minute per host."
+    )
+    SOCFORTRESS_INFLUXDB_DISK_CHECK = (
+        "Threshold check on filesystem usage (`disk`/`used_percent`), excluding pseudo filesystems."
+        " Raises INFO above 75% used, WARN above 85% and CRIT above 90%, evaluated every 5 minutes"
+        " per host and mount point."
+    )
+    SOCFORTRESS_INFLUXDB_CRITICAL_SERVICES_CHECK = (
+        "Threshold check on the critical SIEM stack systemd units (`systemd_units`/`active_code`)."
+        " Raises CRIT the moment a watched unit reports any state other than active, evaluated"
+        " every minute per host and unit."
+    )
+
+
+class InfluxDBCheck(BaseModel):
+    name: str = Field(..., description="The template name of the check")
+    description: str = Field(..., description="What the check does and when it fires")
+    check_name: str = Field(
+        ...,
+        examples=["CPU CHECK"],
+        description="The name the check is created with inside InfluxDB",
+    )
+    provisioned: bool = Field(
+        ...,
+        examples=[False],
+        description="Whether a check with this name already exists in InfluxDB",
+    )
+
+
+class AvailableInfluxDBChecksResponse(BaseModel):
+    available_checks: List[InfluxDBCheck] = Field(
+        ...,
+        description="The InfluxDB checks available for provisioning",
+    )
+    success: bool = Field(..., examples=[True])
+    message: str = Field(..., examples=["Available InfluxDB checks retrieved successfully"])
+
+
+class ProvisionInfluxDBCheckRequest(BaseModel):
+    check_name: AvailableInfluxDBChecks = Field(
+        ...,
+        examples=[AvailableInfluxDBChecks.SOCFORTRESS_INFLUXDB_CPU_CHECK],
+        description="The name of the check to provision in InfluxDB",
+    )
+    overwrite: bool = Field(
+        False,
+        examples=[False],
+        description=(
+            "Overwrite the check if one with the same name already exists. Defaults to False so that"
+            " hand-tuned checks on an existing stack are never silently replaced."
+        ),
+    )
+
+    def __init__(self, **data: Any):
+        check_name = data.get("check_name")
+        try:
+            data["check_name"] = AvailableInfluxDBChecks[check_name]
+        except KeyError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Check {check_name} is not available. Please choose from the available checks.",
+            )
+        super().__init__(**data)
+
+
+class ProvisionInfluxDBAllChecksRequest(BaseModel):
+    overwrite: bool = Field(
+        False,
+        examples=[False],
+        description="Overwrite checks that already exist in InfluxDB",
+    )
+
+
+class ProvisionedInfluxDBCheck(BaseModel):
+    name: str = Field(..., description="The template name of the check")
+    check_name: str = Field(..., description="The name of the check inside InfluxDB")
+    action: str = Field(
+        ...,
+        examples=["created"],
+        description="What happened to the check: `created`, `updated` or `skipped`",
+    )
+    check_id: Optional[str] = Field(
+        None,
+        description="The InfluxDB ID of the check, absent when the check was skipped",
+    )
+
+
+class ProvisionInfluxDBResponse(BaseModel):
+    results: List[ProvisionedInfluxDBCheck] = Field(
+        default_factory=list,
+        description="Per-check outcome of the provisioning run",
+    )
+    success: bool = Field(..., examples=[True])
+    message: str = Field(..., examples=["InfluxDB check provisioned successfully"])
+
+
+class DecommissionInfluxDBCheckResponse(BaseModel):
+    success: bool = Field(..., examples=[True])
+    message: str = Field(..., examples=["InfluxDB check decommissioned successfully"])

--- a/backend/app/stack_provisioning/influxdb/services/provision.py
+++ b/backend/app/stack_provisioning/influxdb/services/provision.py
@@ -1,0 +1,263 @@
+import json
+from pathlib import Path
+from typing import Dict
+from typing import List
+
+from fastapi import HTTPException
+from loguru import logger
+
+from app.connectors.influxdb.utils.universal import get_influxdb_bucket
+from app.connectors.influxdb.utils.universal import get_influxdb_org_id
+from app.connectors.influxdb.utils.universal import send_delete_request
+from app.connectors.influxdb.utils.universal import send_get_request
+from app.connectors.influxdb.utils.universal import send_post_request
+from app.connectors.influxdb.utils.universal import send_put_request
+from app.stack_provisioning.influxdb.schema.provision import AvailableInfluxDBChecks
+from app.stack_provisioning.influxdb.schema.provision import (
+    AvailableInfluxDBChecksResponse,
+)
+from app.stack_provisioning.influxdb.schema.provision import (
+    DecommissionInfluxDBCheckResponse,
+)
+from app.stack_provisioning.influxdb.schema.provision import InfluxDBCheck
+from app.stack_provisioning.influxdb.schema.provision import ProvisionedInfluxDBCheck
+from app.stack_provisioning.influxdb.schema.provision import (
+    ProvisionInfluxDBCheckRequest,
+)
+from app.stack_provisioning.influxdb.schema.provision import ProvisionInfluxDBResponse
+
+# Placeholders substituted into the check templates at provisioning time. The org ID is
+# resolved from the org *name* on the connector, the bucket is the second half of
+# `connector_extra_data`.
+REPLACE_ORG_ID = "REPLACE_ORG_ID"
+REPLACE_BUCKET = "REPLACE_BUCKET"
+
+
+def get_check_template_path(file_name: str) -> Path:
+    """
+    Return the path to a check template JSON file.
+
+    Args:
+        file_name (str): The template file name, e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK.json`.
+
+    Returns:
+        Path: The path to the template file.
+    """
+    current_file = Path(__file__)  # Path to the current file
+    base_dir = current_file.parent.parent  # Move up to the 'influxdb' directory
+    return base_dir / "templates" / file_name
+
+
+def load_raw_check_template(template_name: str) -> dict:
+    """
+    Load a check template straight off disk, placeholders intact.
+
+    Used when only the metadata is needed (e.g. the InfluxDB check name for the available
+    checks listing), so that listing does not have to hit the InfluxDB API to resolve the
+    org ID first.
+
+    Args:
+        template_name (str): The template name, e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK`.
+
+    Returns:
+        dict: The raw template.
+
+    Raises:
+        HTTPException: If the template file is missing or is not valid JSON.
+    """
+    file_path = get_check_template_path(f"{template_name}.json")
+    try:
+        with open(file_path, "r") as file:
+            return json.load(file)
+    except FileNotFoundError:
+        logger.error(f"InfluxDB check template not found at {file_path}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"InfluxDB check template {template_name} not found",
+        )
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode InfluxDB check template {file_path}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"InfluxDB check template {template_name} is not valid JSON: {e}",
+        )
+
+
+async def render_check_template(template_name: str) -> dict:
+    """
+    Load a check template and substitute the deployment specific placeholders.
+
+    Args:
+        template_name (str): The template name, e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK`.
+
+    Returns:
+        dict: The check payload ready to be POSTed/PUT to InfluxDB.
+    """
+    logger.info(f"Rendering InfluxDB check template: {template_name}")
+    template = load_raw_check_template(template_name)
+    org_id = await get_influxdb_org_id()
+    bucket = await get_influxdb_bucket()
+    rendered = json.dumps(template).replace(REPLACE_ORG_ID, org_id).replace(REPLACE_BUCKET, bucket)
+    return json.loads(rendered)
+
+
+async def get_existing_checks() -> Dict[str, str]:
+    """
+    Fetch the checks that already exist in InfluxDB, keyed by name.
+
+    Returns:
+        Dict[str, str]: A mapping of check name to check ID.
+    """
+    response = await send_get_request("/api/v2/checks", params={"limit": 100})
+    checks = (response or {}).get("checks", [])
+    return {check["name"]: check["id"] for check in checks if check.get("name")}
+
+
+async def get_available_checks() -> AvailableInfluxDBChecksResponse:
+    """
+    List the checks CoPilot can provision, flagging the ones already present in InfluxDB.
+
+    Returns:
+        AvailableInfluxDBChecksResponse: The available checks and their provisioning state.
+    """
+    logger.info("Getting available InfluxDB checks...")
+    existing_checks = await get_existing_checks()
+
+    available_checks: List[InfluxDBCheck] = []
+    for check in AvailableInfluxDBChecks:
+        template = load_raw_check_template(check.name)
+        check_name = template["name"]
+        available_checks.append(
+            InfluxDBCheck(
+                name=check.name,
+                description=check.value,
+                check_name=check_name,
+                provisioned=check_name in existing_checks,
+            ),
+        )
+
+    return AvailableInfluxDBChecksResponse(
+        available_checks=available_checks,
+        success=True,
+        message="Available InfluxDB checks retrieved successfully",
+    )
+
+
+async def provision_single_check(template_name: str, overwrite: bool) -> ProvisionedInfluxDBCheck:
+    """
+    Create or update a single InfluxDB check from its template.
+
+    A check that already exists is left untouched unless `overwrite` is set — SOCFortress
+    stacks are frequently built by hand first, and blindly PUTting the template over an
+    existing check would discard whatever tuning an engineer did in the InfluxDB UI.
+
+    Args:
+        template_name (str): The template name, e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK`.
+        overwrite (bool): Whether to replace an existing check of the same name.
+
+    Returns:
+        ProvisionedInfluxDBCheck: The outcome for this check.
+    """
+    payload = await render_check_template(template_name)
+    check_name = payload["name"]
+    existing_checks = await get_existing_checks()
+    existing_id = existing_checks.get(check_name)
+
+    if existing_id and not overwrite:
+        logger.info(f"InfluxDB check {check_name} already exists, skipping")
+        return ProvisionedInfluxDBCheck(
+            name=template_name,
+            check_name=check_name,
+            action="skipped",
+            check_id=existing_id,
+        )
+
+    if existing_id:
+        logger.info(f"Updating existing InfluxDB check {check_name} ({existing_id})")
+        response = await send_put_request(f"/api/v2/checks/{existing_id}", data=payload)
+        action = "updated"
+    else:
+        logger.info(f"Creating InfluxDB check {check_name}")
+        response = await send_post_request("/api/v2/checks", data=payload)
+        action = "created"
+
+    return ProvisionedInfluxDBCheck(
+        name=template_name,
+        check_name=check_name,
+        action=action,
+        check_id=(response or {}).get("id"),
+    )
+
+
+async def provision_check(request: ProvisionInfluxDBCheckRequest) -> ProvisionInfluxDBResponse:
+    """
+    Provision a single InfluxDB check.
+
+    Args:
+        request (ProvisionInfluxDBCheckRequest): The check to provision.
+
+    Returns:
+        ProvisionInfluxDBResponse: The outcome of the provisioning run.
+    """
+    result = await provision_single_check(request.check_name.name, request.overwrite)
+    if result.action == "skipped":
+        message = f"{result.check_name} already exists in InfluxDB and was left unchanged. Set overwrite to replace it."
+    else:
+        message = f"{result.check_name} {result.action} successfully"
+    return ProvisionInfluxDBResponse(results=[result], success=True, message=message)
+
+
+async def provision_all_checks(overwrite: bool) -> ProvisionInfluxDBResponse:
+    """
+    Provision every available InfluxDB check.
+
+    Args:
+        overwrite (bool): Whether to replace checks that already exist.
+
+    Returns:
+        ProvisionInfluxDBResponse: The per-check outcomes of the provisioning run.
+    """
+    logger.info("Provisioning all InfluxDB checks...")
+    results = [await provision_single_check(check.name, overwrite) for check in AvailableInfluxDBChecks]
+
+    created = sum(1 for result in results if result.action == "created")
+    updated = sum(1 for result in results if result.action == "updated")
+    skipped = sum(1 for result in results if result.action == "skipped")
+
+    return ProvisionInfluxDBResponse(
+        results=results,
+        success=True,
+        message=f"InfluxDB checks provisioned: {created} created, {updated} updated, {skipped} skipped",
+    )
+
+
+async def decommission_check(template_name: str) -> DecommissionInfluxDBCheckResponse:
+    """
+    Delete a provisioned InfluxDB check.
+
+    Args:
+        template_name (str): The template name, e.g. `SOCFORTRESS_INFLUXDB_CPU_CHECK`.
+
+    Returns:
+        DecommissionInfluxDBCheckResponse: The outcome of the deletion.
+
+    Raises:
+        HTTPException: If the check does not exist in InfluxDB.
+    """
+    template = load_raw_check_template(template_name)
+    check_name = template["name"]
+    existing_checks = await get_existing_checks()
+    existing_id = existing_checks.get(check_name)
+
+    if not existing_id:
+        raise HTTPException(
+            status_code=404,
+            detail=f"InfluxDB check {check_name} does not exist",
+        )
+
+    logger.info(f"Deleting InfluxDB check {check_name} ({existing_id})")
+    await send_delete_request(f"/api/v2/checks/{existing_id}")
+    return DecommissionInfluxDBCheckResponse(
+        success=True,
+        message=f"{check_name} decommissioned successfully",
+    )

--- a/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_CPU_CHECK.json
+++ b/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_CPU_CHECK.json
@@ -1,0 +1,78 @@
+{
+    "name": "CPU CHECK",
+    "orgID": "REPLACE_ORG_ID",
+    "type": "threshold",
+    "status": "active",
+    "every": "1m",
+    "offset": "0s",
+    "statusMessageTemplate": "${ r._level }: ${ r._check_name }\nHost: ${r.host}\nCPU Usage(%): ${100.0 - r.usage_idle}",
+    "query": {
+        "text": "from(bucket: \"REPLACE_BUCKET\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"cpu\")\n  |> filter(fn: (r) => r[\"_field\"] == \"usage_idle\")\n  |> filter(fn: (r) => r[\"cpu\"] == \"cpu-total\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+        "editMode": "builder",
+        "name": "",
+        "builderConfig": {
+            "buckets": [
+                "REPLACE_BUCKET"
+            ],
+            "tags": [
+                {
+                    "key": "_measurement",
+                    "values": [
+                        "cpu"
+                    ],
+                    "aggregateFunctionType": "filter"
+                },
+                {
+                    "key": "_field",
+                    "values": [
+                        "usage_idle"
+                    ],
+                    "aggregateFunctionType": "filter"
+                },
+                {
+                    "key": "cpu",
+                    "values": [
+                        "cpu-total"
+                    ],
+                    "aggregateFunctionType": "filter"
+                },
+                {
+                    "key": "host",
+                    "values": [],
+                    "aggregateFunctionType": "filter"
+                }
+            ],
+            "functions": [
+                {
+                    "name": "mean"
+                }
+            ],
+            "aggregateWindow": {
+                "period": "1m",
+                "fillValues": false
+            }
+        }
+    },
+    "thresholds": [
+        {
+            "allValues": false,
+            "level": "INFO",
+            "value": 25,
+            "type": "lesser"
+        },
+        {
+            "allValues": false,
+            "level": "WARN",
+            "value": 15,
+            "type": "lesser"
+        },
+        {
+            "allValues": false,
+            "level": "CRIT",
+            "value": 5,
+            "type": "lesser"
+        }
+    ],
+    "tags": [],
+    "labels": []
+}

--- a/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_CRITICAL_SERVICES_CHECK.json
+++ b/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_CRITICAL_SERVICES_CHECK.json
@@ -1,0 +1,24 @@
+{
+    "name": "CRITICAL SERVICES CHECK",
+    "orgID": "REPLACE_ORG_ID",
+    "type": "threshold",
+    "status": "active",
+    "every": "1m",
+    "offset": "0s",
+    "statusMessageTemplate": "${ r._level }: ${ r._check_name }\nHost: ${r.host}\nService: ${ r.name }\nActive Code: ${ r.active_code }",
+    "query": {
+        "text": "from(bucket: \"REPLACE_BUCKET\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"systemd_units\")\n  |> filter(fn: (r) => r[\"_field\"] == \"active_code\")\n  |> filter(fn: (r) => r[\"name\"] == \"graylog-server.service\" or r[\"name\"] == \"grafana-server.service\" or r[\"name\"] == \"mongod.service\" or r[\"name\"] == \"nginx.service\" or r[\"name\"] == \"socfortress-wazuh-utils.service\" or r[\"name\"] == \"socfortress-workerprovisioning.service\" or r[\"name\"] == \"telegraf.service\" or r[\"name\"] == \"velociraptor_server.service\" or r[\"name\"] == \"wazuh-dashboard.service\" or r[\"name\"] == \"wazuh-indexer.service\" or r[\"name\"] == \"wazuh-manager.service\" or r[\"name\"] == \"haproxy.service\" or r[\"name\"] == \"fluent-bit.service\" or r[\"name\"] == \"influxdb.service\" or r[\"name\"] == \"docker.service\")\n  |> aggregateWindow(every: 1m, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+        "editMode": "advanced",
+        "name": ""
+    },
+    "thresholds": [
+        {
+            "allValues": false,
+            "level": "CRIT",
+            "value": 0,
+            "type": "greater"
+        }
+    ],
+    "tags": [],
+    "labels": []
+}

--- a/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_DISK_CHECK.json
+++ b/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_DISK_CHECK.json
@@ -1,0 +1,36 @@
+{
+    "name": "DISK USAGE CHECK",
+    "orgID": "REPLACE_ORG_ID",
+    "type": "threshold",
+    "status": "active",
+    "every": "5m",
+    "offset": "0s",
+    "statusMessageTemplate": "${ r._level }: ${ r._check_name }\nHost: ${r.host}\nPath: ${ r.path }\nDisk Used(%): ${ r.used_percent }",
+    "query": {
+        "text": "from(bucket: \"REPLACE_BUCKET\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"disk\")\n  |> filter(fn: (r) => r[\"_field\"] == \"used_percent\")\n  |> filter(fn: (r) => r[\"fstype\"] != \"tmpfs\" and r[\"fstype\"] != \"devtmpfs\" and r[\"fstype\"] != \"overlay\" and r[\"fstype\"] != \"squashfs\" and r[\"fstype\"] != \"iso9660\")\n  |> aggregateWindow(every: 5m, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
+        "editMode": "advanced",
+        "name": ""
+    },
+    "thresholds": [
+        {
+            "allValues": false,
+            "level": "INFO",
+            "value": 75,
+            "type": "greater"
+        },
+        {
+            "allValues": false,
+            "level": "WARN",
+            "value": 85,
+            "type": "greater"
+        },
+        {
+            "allValues": false,
+            "level": "CRIT",
+            "value": 90,
+            "type": "greater"
+        }
+    ],
+    "tags": [],
+    "labels": []
+}

--- a/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_MEMORY_CHECK.json
+++ b/backend/app/stack_provisioning/influxdb/templates/SOCFORTRESS_INFLUXDB_MEMORY_CHECK.json
@@ -1,0 +1,71 @@
+{
+    "name": "MEMORY CHECK",
+    "orgID": "REPLACE_ORG_ID",
+    "type": "threshold",
+    "status": "active",
+    "every": "1m",
+    "offset": "0s",
+    "statusMessageTemplate": "${ r._level }: ${ r._check_name }\nHost: ${r.host}\nMemory Available(%): ${ r.available_percent }",
+    "query": {
+        "text": "from(bucket: \"REPLACE_BUCKET\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"mem\")\n  |> filter(fn: (r) => r[\"_field\"] == \"available_percent\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+        "editMode": "builder",
+        "name": "",
+        "builderConfig": {
+            "buckets": [
+                "REPLACE_BUCKET"
+            ],
+            "tags": [
+                {
+                    "key": "_measurement",
+                    "values": [
+                        "mem"
+                    ],
+                    "aggregateFunctionType": "filter"
+                },
+                {
+                    "key": "_field",
+                    "values": [
+                        "available_percent"
+                    ],
+                    "aggregateFunctionType": "filter"
+                },
+                {
+                    "key": "host",
+                    "values": [],
+                    "aggregateFunctionType": "filter"
+                }
+            ],
+            "functions": [
+                {
+                    "name": "mean"
+                }
+            ],
+            "aggregateWindow": {
+                "period": "1m",
+                "fillValues": false
+            }
+        }
+    },
+    "thresholds": [
+        {
+            "allValues": false,
+            "level": "INFO",
+            "value": 25,
+            "type": "lesser"
+        },
+        {
+            "allValues": false,
+            "level": "WARN",
+            "value": 15,
+            "type": "lesser"
+        },
+        {
+            "allValues": false,
+            "level": "CRIT",
+            "value": 10,
+            "type": "lesser"
+        }
+    ],
+    "tags": [],
+    "labels": []
+}

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -47,3 +47,16 @@ SQLALCHEMY_TRACK_MODIFICATIONS = env.bool(
 MDR_ENABLED = env.bool("MDR_ENABLED", default=False)
 MDR_SERVER_URL = env.str("MDR_SERVER_URL", default="https://mdr-server.socfortress.co")
 MDR_COLLECTOR_UUID = env.str("MDR_COLLECTOR_UUID", default="")
+
+# ---------------------------------------------------------------------------
+# InfluxDB REST API TLS
+# ---------------------------------------------------------------------------
+# Certificate verification for the direct HTTP calls to InfluxDB's v2 REST API
+# (checks / notification endpoints / notification rules — the APIs the influxdb_client
+# async SDK does not expose).
+#
+# Defaults to False: InfluxDB in a SOCFortress stack is a co-located appliance that
+# effectively always serves a self-signed certificate, so verifying would fail every
+# provisioning call out of the box. This matches the SDK client, which hardcodes
+# verify_ssl=False. Set to True where InfluxDB is fronted by a trusted CA.
+INFLUXDB_VERIFY_SSL = env.bool("INFLUXDB_VERIFY_SSL", default=False)

--- a/backend/tests/test_influxdb_check_templates.py
+++ b/backend/tests/test_influxdb_check_templates.py
@@ -1,0 +1,122 @@
+"""Structural guarantees for the provisionable InfluxDB check templates.
+
+The templates under app/stack_provisioning/influxdb/templates/ are literal
+`POST /api/v2/checks` request bodies with two placeholders — REPLACE_ORG_ID and
+REPLACE_BUCKET — substituted at provisioning time. InfluxDB accepts a payload
+that still carries a placeholder (it just creates a check owned by no org, or
+one querying a bucket named "REPLACE_BUCKET"), and the failure only shows up
+later as a check that silently never fires. So the placeholders, and the
+enum <-> template correspondence that drives the whole feature, are asserted
+here rather than discovered in production.
+
+No DB, no network — these read the template files off disk.
+
+Run with: cd backend && python -m pytest tests/test_influxdb_check_templates.py
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.stack_provisioning.influxdb.schema.provision import (  # noqa: E402
+    AvailableInfluxDBChecks,
+)
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "app" / "stack_provisioning" / "influxdb" / "templates"
+
+VALID_LEVELS = {"OK", "INFO", "WARN", "CRIT"}
+VALID_THRESHOLD_TYPES = {"greater", "lesser", "range"}
+
+
+def _load(template_name: str) -> dict:
+    return json.loads((TEMPLATE_DIR / f"{template_name}.json").read_text())
+
+
+def test_every_enum_member_has_a_template():
+    """The enum name is the template file stem — a missing file is a 404 at provision time."""
+    for check in AvailableInfluxDBChecks:
+        assert (TEMPLATE_DIR / f"{check.name}.json").is_file(), f"No template file for {check.name}"
+
+
+def test_every_template_has_an_enum_member():
+    """An orphaned template is unreachable — nothing can request it."""
+    member_names = set(AvailableInfluxDBChecks.__members__)
+    for template_file in TEMPLATE_DIR.glob("*.json"):
+        assert template_file.stem in member_names, f"Template {template_file.name} has no enum member"
+
+
+def test_enum_descriptions_are_unique():
+    """str-Enum members sharing a value are silently aliased, which would drop a check
+    from the available list without any error."""
+    assert len(set(AvailableInfluxDBChecks.__members__)) == len(list(AvailableInfluxDBChecks))
+
+
+def test_templates_carry_both_placeholders():
+    for check in AvailableInfluxDBChecks:
+        template = _load(check.name)
+        assert template["orgID"] == "REPLACE_ORG_ID", f"{check.name} does not use the org ID placeholder"
+        assert "REPLACE_BUCKET" in template["query"]["text"], f"{check.name} query does not use the bucket placeholder"
+        # Builder-mode checks repeat the bucket in builderConfig; the InfluxDB UI reads it
+        # from there, so a hardcoded bucket would show the wrong source on the edit screen.
+        builder_config = template["query"].get("builderConfig")
+        if builder_config is not None:
+            assert builder_config["buckets"] == ["REPLACE_BUCKET"], f"{check.name} builderConfig has a hardcoded bucket"
+
+
+def test_templates_are_well_formed_threshold_checks():
+    for check in AvailableInfluxDBChecks:
+        template = _load(check.name)
+        assert template["type"] == "threshold"
+        assert template["status"] == "active"
+        assert template["every"], f"{check.name} has no schedule"
+        assert template["name"], f"{check.name} has no InfluxDB check name"
+        assert "${ r._check_name }" in template["statusMessageTemplate"], f"{check.name} status message omits the check name"
+
+        thresholds = template["thresholds"]
+        assert thresholds, f"{check.name} has no thresholds and would never fire"
+        for threshold in thresholds:
+            assert threshold["level"] in VALID_LEVELS
+            assert threshold["type"] in VALID_THRESHOLD_TYPES
+            assert isinstance(threshold["value"], (int, float))
+
+
+def test_influxdb_check_names_are_unique():
+    """Provisioning matches existing checks by name, so two templates sharing a name would
+    make the second overwrite the first."""
+    names = [_load(check.name)["name"] for check in AvailableInfluxDBChecks]
+    assert len(names) == len(set(names)), f"Duplicate InfluxDB check names: {names}"
+
+
+def test_cpu_template_matches_the_hand_built_check():
+    """The CPU check already exists on stacks built before CoPilot was pointed at them.
+    The template mirrors it exactly so that overwriting is a genuine no-op — if these
+    thresholds drift, an overwrite silently re-tunes every existing deployment."""
+    template = _load(AvailableInfluxDBChecks.SOCFORTRESS_INFLUXDB_CPU_CHECK.name)
+    assert template["name"] == "CPU CHECK"
+    assert template["every"] == "1m"
+    assert [(t["level"], t["value"], t["type"]) for t in template["thresholds"]] == [
+        ("INFO", 25, "lesser"),
+        ("WARN", 15, "lesser"),
+        ("CRIT", 5, "lesser"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("template_name", "measurement", "field"),
+    [
+        ("SOCFORTRESS_INFLUXDB_CPU_CHECK", "cpu", "usage_idle"),
+        ("SOCFORTRESS_INFLUXDB_MEMORY_CHECK", "mem", "available_percent"),
+        ("SOCFORTRESS_INFLUXDB_DISK_CHECK", "disk", "used_percent"),
+        ("SOCFORTRESS_INFLUXDB_CRITICAL_SERVICES_CHECK", "systemd_units", "active_code"),
+    ],
+)
+def test_templates_query_the_expected_telegraf_series(template_name, measurement, field):
+    """These are the measurement/field pairs Telegraf actually emits on a SOCFortress stack.
+    A threshold check whose query returns nothing never alerts and never errors."""
+    query = _load(template_name)["query"]["text"]
+    assert f'"_measurement"] == "{measurement}"' in query
+    assert f'"_field"] == "{field}"' in query

--- a/frontend/src/api/endpoints/stack-provisioning.ts
+++ b/frontend/src/api/endpoints/stack-provisioning.ts
@@ -1,5 +1,5 @@
 import type { FlaskBaseResponse } from "@/types/flask"
-import type { AvailableContentPack } from "@/types/stack-provisioning"
+import type { AvailableContentPack, AvailableInfluxDbCheck, ProvisionedInfluxDbCheck } from "@/types/stack-provisioning"
 import { HttpClient } from "../http-client"
 
 export default {
@@ -12,5 +12,28 @@ export default {
 		return HttpClient.post<FlaskBaseResponse>(`/stack_provisioning/graylog/provision/content_pack`, {
 			content_pack_name: contentPackName
 		})
+	},
+	getAvailableInfluxDbChecks() {
+		return HttpClient.get<FlaskBaseResponse & { available_checks: AvailableInfluxDbCheck[] }>(
+			`/stack_provisioning/influxdb/available/checks`
+		)
+	},
+	provisionInfluxDbCheck(checkName: string, overwrite: boolean = false) {
+		return HttpClient.post<FlaskBaseResponse & { results: ProvisionedInfluxDbCheck[] }>(
+			`/stack_provisioning/influxdb/provision/check`,
+			{
+				check_name: checkName,
+				overwrite
+			}
+		)
+	},
+	provisionInfluxDbChecks(overwrite: boolean = false) {
+		return HttpClient.post<FlaskBaseResponse & { results: ProvisionedInfluxDbCheck[] }>(
+			`/stack_provisioning/influxdb/provision/checks`,
+			{ overwrite }
+		)
+	},
+	decommissionInfluxDbCheck(checkName: string) {
+		return HttpClient.delete<FlaskBaseResponse>(`/stack_decommissioning/influxdb/check/${checkName}`)
 	}
 }

--- a/frontend/src/components/stackProvisioning/StackProvisioningButton.vue
+++ b/frontend/src/components/stackProvisioning/StackProvisioningButton.vue
@@ -11,19 +11,27 @@
 		display-directive="show"
 		preset="card"
 		:style="{ maxWidth: 'min(600px, 90vw)', minHeight: 'min(300px, 90vh)', overflow: 'hidden' }"
-		title="Deploy Content Packs"
+		title="Stack Provisioning"
 		:bordered="false"
 		segmented
 	>
-		<StackProvisioningList />
+		<n-tabs type="line" animated>
+			<n-tab-pane name="graylog" tab="Graylog Content Packs" display-directive="show">
+				<StackProvisioningList />
+			</n-tab-pane>
+			<n-tab-pane name="influxdb" tab="InfluxDB Checks" display-directive="show">
+				<InfluxDbChecksList />
+			</n-tab-pane>
+		</n-tabs>
 	</n-modal>
 </template>
 
 <script setup lang="ts">
 import type { ButtonSize, ButtonType } from "naive-ui"
-import { NButton, NModal } from "naive-ui"
+import { NButton, NModal, NTabPane, NTabs } from "naive-ui"
 import { ref } from "vue"
 import Icon from "@/components/common/Icon.vue"
+import InfluxDbChecksList from "./influxdb/InfluxDbChecksList.vue"
 import StackProvisioningList from "./StackProvisioningList.vue"
 
 defineProps<{

--- a/frontend/src/components/stackProvisioning/influxdb/InfluxDbCheckItem.vue
+++ b/frontend/src/components/stackProvisioning/influxdb/InfluxDbCheckItem.vue
@@ -1,0 +1,72 @@
+<template>
+	<CardEntity embedded hoverable>
+		<template #headerMain>
+			<div class="flex items-center gap-2">
+				{{ check.check_name }}
+				<n-tag v-if="check.provisioned" type="success" size="small" round :bordered="false">Provisioned</n-tag>
+			</div>
+		</template>
+		<template #default>
+			{{ check.description }}
+		</template>
+		<template #headerExtra>
+			<n-button
+				:loading="loadingProvision"
+				:type="check.provisioned ? 'warning' : 'success'"
+				size="small"
+				secondary
+				@click="provision()"
+			>
+				<template #icon>
+					<Icon :name="check.provisioned ? OverwriteIcon : DeployIcon" />
+				</template>
+				{{ check.provisioned ? "Overwrite" : "Deploy" }}
+			</n-button>
+		</template>
+	</CardEntity>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { AvailableInfluxDbCheck } from "@/types/stack-provisioning"
+import { NButton, NTag, useMessage } from "naive-ui"
+import { ref } from "vue"
+import Api from "@/api"
+import CardEntity from "@/components/common/cards/CardEntity.vue"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+
+const { check } = defineProps<{ check: AvailableInfluxDbCheck }>()
+
+const emit = defineEmits<{
+	(e: "provisioned"): void
+}>()
+
+const DeployIcon = "mdi:package-variant-closed-check"
+const OverwriteIcon = "mdi:package-variant-plus"
+const loadingProvision = ref(false)
+const message = useMessage()
+
+function provision() {
+	loadingProvision.value = true
+
+	// A check that already exists is skipped by the backend unless overwrite is set, so an
+	// already-provisioned check has to opt in explicitly to replace whatever is in InfluxDB.
+	Api.stackProvisioning
+		.provisionInfluxDbCheck(check.name, check.provisioned)
+		.then(res => {
+			if (res.data.success) {
+				message.success(res.data?.message || "InfluxDB Check Provisioned Successfully")
+				emit("provisioned")
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			loadingProvision.value = false
+		})
+}
+</script>

--- a/frontend/src/components/stackProvisioning/influxdb/InfluxDbChecksList.vue
+++ b/frontend/src/components/stackProvisioning/influxdb/InfluxDbChecksList.vue
@@ -1,0 +1,87 @@
+<template>
+	<div class="influxdb-checks-list">
+		<n-spin :show="loading">
+			<div class="my-3 flex min-h-52 flex-col gap-2">
+				<template v-if="list.length">
+					<div class="flex justify-end">
+						<n-button :loading="loadingProvisionAll" type="success" size="small" @click="provisionAll()">
+							<template #icon>
+								<Icon :name="DeployIcon" />
+							</template>
+							Deploy all missing
+						</n-button>
+					</div>
+					<InfluxDbCheckItem v-for="item of list" :key="item.name" :check="item" @provisioned="getData()" />
+				</template>
+				<template v-else>
+					<n-empty v-if="!loading" description="No items found" class="h-48 justify-center" />
+				</template>
+			</div>
+		</n-spin>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { AvailableInfluxDbCheck } from "@/types/stack-provisioning"
+import { NButton, NEmpty, NSpin, useMessage } from "naive-ui"
+import { computed, onBeforeMount, ref } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+import InfluxDbCheckItem from "./InfluxDbCheckItem.vue"
+
+const DeployIcon = "mdi:package-variant-closed-check"
+const message = useMessage()
+const loadingList = ref(false)
+const loadingProvisionAll = ref(false)
+const list = ref<AvailableInfluxDbCheck[]>([])
+const loading = computed(() => loadingList.value || loadingProvisionAll.value)
+
+function getData() {
+	loadingList.value = true
+
+	Api.stackProvisioning
+		.getAvailableInfluxDbChecks()
+		.then(res => {
+			if (res.data.success) {
+				list.value = res.data.available_checks || []
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			loadingList.value = false
+		})
+}
+
+function provisionAll() {
+	loadingProvisionAll.value = true
+
+	// overwrite stays false here: bulk deploy fills in what is missing and leaves existing
+	// checks alone. Replacing one is a deliberate per-check action.
+	Api.stackProvisioning
+		.provisionInfluxDbChecks(false)
+		.then(res => {
+			if (res.data.success) {
+				message.success(res.data?.message || "InfluxDB Checks Provisioned Successfully")
+				getData()
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "An error occurred. Please try again later.")
+		})
+		.finally(() => {
+			loadingProvisionAll.value = false
+		})
+}
+
+onBeforeMount(() => {
+	getData()
+})
+</script>

--- a/frontend/src/types/stack-provisioning.ts
+++ b/frontend/src/types/stack-provisioning.ts
@@ -2,3 +2,17 @@ export interface AvailableContentPack {
 	name: string
 	description: string
 }
+
+export interface AvailableInfluxDbCheck {
+	name: string
+	description: string
+	check_name: string
+	provisioned: boolean
+}
+
+export interface ProvisionedInfluxDbCheck {
+	name: string
+	check_name: string
+	action: "created" | "updated" | "skipped"
+	check_id?: string | null
+}


### PR DESCRIPTION
Closes #1047.

Adds a second provisioner alongside the Graylog content packs, covering the four SOCFortress stack checks: **CPU**, **memory**, **disk usage** and **critical systemd services**.

## Shape

`app/stack_provisioning/influxdb/` mirrors the existing `graylog/` module (`templates/ schema/ services/ routes/`). Templates are literal `POST /api/v2/checks` bodies with two placeholders, `REPLACE_ORG_ID` and `REPLACE_BUCKET`, substituted at provision time.

| Check | Series | Thresholds |
|---|---|---|
| CPU CHECK | `cpu` / `usage_idle` | lesser 25 / 15 / 5, every 1m |
| MEMORY CHECK | `mem` / `available_percent` | lesser 25 / 15 / 10, every 1m |
| DISK USAGE CHECK | `disk` / `used_percent`, pseudo-fs excluded | greater 75 / 85 / 90, every 5m |
| CRITICAL SERVICES CHECK | `systemd_units` / `active_code` | CRIT greater 0, every 1m |

## API

- `GET /stack_provisioning/influxdb/available/checks` — list with per-check `provisioned` flag
- `POST /stack_provisioning/influxdb/provision/check` — `{check_name, overwrite}`
- `POST /stack_provisioning/influxdb/provision/checks` — bulk
- `DELETE /stack_decommissioning/influxdb/check/{check_name}` — admin only

## Design notes

- **Org name vs org ID.** The connector persists the org *name* (`connector_extra_data` is `"ORG,BUCKET"`) but the checks API keys off the org *ID*. `get_influxdb_org_id()` resolves name → ID on each run. Passing the name is accepted by InfluxDB and silently produces a check owned by no org.
- **The SDK can't do this.** `influxdb_client`'s async client exposes only the query/write APIs — checks, notification endpoints and notification rules are absent — so the connector's `universal.py` gained plain `httpx` helpers.
- **Existing checks are skipped unless `overwrite=true`.** Stacks are routinely built by hand before CoPilot is pointed at them, and `CPU CHECK` usually already exists. The CPU template is a byte-for-byte copy of the hand-built check so that overwriting is genuinely a no-op.
- **No new read path, and none should be added.** Checks write into the `_monitoring` bucket as the `statuses` measurement, which the pre-existing `GET /influxdb/alerts` already queries — provisioned checks surface in the Healthcheck UI automatically.
- **The critical-services list is intentionally a superset** of stack units. A unit absent from a host yields no rows, not a false alert, so the template does not need per-deployment tailoring.
- **Checks alone notify nobody.** InfluxDB only sends anywhere once notification endpoints + rules exist; this PR provisions neither, so deploying on a live stack is safe.
- **Fixes a bug in the script from the issue**, whose threshold was `{"value": 1, "type": "greater"}` — that is `active_code > 1` and misses `active_code == 1`. The template uses `value: 0`.
- **TLS.** The new REST calls honour `INFLUXDB_VERIFY_SSL`, defaulting off to match `create_influxdb_client()` (which hardcodes `verify_ssl=False`) and the self-signed certificates these co-located appliances serve. Deployments fronted by a trusted CA set it to `True`.

No database changes — checks live in InfluxDB and the template list is static in code.

## Frontend

The Stack Provisioning modal is now tabbed (Graylog Content Packs / InfluxDB Checks). Already-provisioned checks show a badge and their button becomes **Overwrite**; there is also a bulk **Deploy all missing**.

## Testing

- All four Flux queries were run against a live dev InfluxDB — `fstype` and `name` tags confirmed present, rows returned.
- The real upsert path was exercised against that instance: `CPU CHECK` correctly skipped as already-present, the other three created. All four subsequently reported `lastRunStatus=success` and wrote `ok` statuses into `_monitoring`.
- `backend/tests/test_influxdb_check_templates.py` — 11 structural tests (enum ↔ template correspondence, both placeholders intact, threshold validity, unique check names, expected Telegraf measurement/field pairs). No DB, no network.
- `pre-commit` clean; frontend `pnpm type-check` and eslint clean.

Not verified: the backend was not booted end-to-end locally (python deps aren't installed on the dev machine), so route registration rests on import-resolution and syntax checks rather than a live request. The InfluxDB payloads themselves are live-verified.
