### PR TITLE
feat(runtime-config): enable dynamic user menu links via env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
         image: ghcr.io/socfortress/copilot-frontend:latest
         environment:
             - SERVER_HOST=${SERVER_HOST:-localhost} # Set the domain name of your server
+            # Optional: retarget the external entries in the user menu (applied on start, no rebuild).
+            # Unset entries keep their defaults. Only http(s) URLs are accepted.
+            # - VITE_DOCUMENTATION_LABEL=${VITE_DOCUMENTATION_LABEL:-}
+            # - VITE_DOCUMENTATION_URL=${VITE_DOCUMENTATION_URL:-}
+            # - VITE_CONTACT_LABEL=${VITE_CONTACT_LABEL:-}
+            # - VITE_CONTACT_URL=${VITE_CONTACT_URL:-}
         ports:
             - "80:80"
             - "443:443"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,3 +9,15 @@ VITE_UNCOMMITTED_JOURNAL_ENTRIES_THRESHOLD=50000
 
 # value in seconds
 VITE_HEALTHCHECKS_INTERVAL=120
+
+# external entries in the user menu — all optional, defaults shown.
+# point the contact one at your own issue tracker / support desk in production.
+# only http(s) URLs are accepted; anything else falls back to the default.
+#
+# these are build-time values. on the published image, set the SAME names under `environment:`
+# for copilot-frontend in docker-compose.yml instead — they are applied on container start and
+# need no rebuild.
+# VITE_DOCUMENTATION_LABEL=Documentation
+# VITE_DOCUMENTATION_URL=https://docs.socfortress.co/
+# VITE_CONTACT_LABEL=Contact SOCFortress
+# VITE_CONTACT_URL=https://www.socfortress.co/contact-us

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -55,6 +55,11 @@ ENV TLS_KEY_PATH=/etc/nginx/certs.d/server.key
 COPY build/docker-entrypoint.d/90-copilot-ssl.sh /docker-entrypoint.d/90-copilot-ssl.sh
 RUN chmod +x /docker-entrypoint.d/90-copilot-ssl.sh
 
+# Runtime configuration: rewrites /config.js from env on every start, so the user-menu links
+# stay configurable on a prebuilt image. Must run after the static files are in place.
+COPY build/docker-entrypoint.d/91-copilot-runtime-config.sh /docker-entrypoint.d/91-copilot-runtime-config.sh
+RUN chmod +x /docker-entrypoint.d/91-copilot-runtime-config.sh
+
 # Setup template
 RUN mkdir /etc/nginx/templates
 COPY build/etc/nginx/sites-enabled/default.conf /etc/nginx/templates/default.conf.template

--- a/frontend/build/docker-entrypoint.d/91-copilot-runtime-config.sh
+++ b/frontend/build/docker-entrypoint.d/91-copilot-runtime-config.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Regenerates /config.js from the container environment on every start.
+#
+# The frontend is shipped as a prebuilt image, so VITE_* variables are baked in at build time by CI
+# and an operator who pulls the image cannot change them. This writes the same settings to a small
+# file the SPA reads at boot, making them configurable through `environment:` in docker-compose
+# without rebuilding anything.
+#
+# A variable that is unset emits no key, so the frontend keeps its compiled-in default.
+
+set -e
+
+CONFIG_FILE="${CONFIG_FILE:-/var/www/copilot/config.js}"
+
+# Escape for embedding in a double-quoted JS string literal.
+js_escape() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr -d '\n\r'
+}
+
+emit_entry() {
+    # $1 = key, $2 = value. Skips unset/empty values so the default survives.
+    [ -n "$2" ] || return 0
+    printf '\t%s: "%s",\n' "$1" "$(js_escape "$2")" >> "$CONFIG_FILE"
+}
+
+printf 'window.__COPILOT_CONFIG__ = {\n' > "$CONFIG_FILE"
+emit_entry documentationLabel "${VITE_DOCUMENTATION_LABEL}"
+emit_entry documentationUrl "${VITE_DOCUMENTATION_URL}"
+emit_entry contactLabel "${VITE_CONTACT_LABEL}"
+emit_entry contactUrl "${VITE_CONTACT_URL}"
+printf '}\n' >> "$CONFIG_FILE"
+
+echo "Runtime config written to ${CONFIG_FILE}"

--- a/frontend/build/etc/nginx/sites-enabled/default.conf
+++ b/frontend/build/etc/nginx/sites-enabled/default.conf
@@ -1,3 +1,13 @@
+# /config.js is rewritten from the container environment on every start, so a cached copy would keep
+# serving the previous values after an operator changes them. Driving Cache-Control from a map keeps
+# this a server-level add_header: putting it in a `location` block instead would silently drop every
+# security header inherited from the server for that response. nginx omits the header when the
+# mapped value is empty, so every other response is unaffected.
+map $uri $copilot_cache_control {
+    default    "";
+    /config.js "no-store";
+}
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
@@ -49,6 +59,7 @@ server {
     add_header X-Permitted-Cross-Domain-Policies "none" always;
     add_header X-Robots-Tag "none" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    add_header Cache-Control $copilot_cache_control always;
 
     # remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,10 @@
 		<meta name="HandheldFriendly" content="true" />
 
 		<title>SOCFortress CoPilot</title>
+
+		<!-- Runtime configuration, regenerated from container env on every start. Classic script on
+		     purpose: it must have run before the deferred module bundle reads window.__COPILOT_CONFIG__. -->
+		<script src="/config.js"></script>
 	</head>
 
 	<body>

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,0 +1,12 @@
+/**
+ * Runtime configuration, read by the app at boot before the bundle loads.
+ *
+ * In a container this file is regenerated from environment variables on every start by
+ * build/docker-entrypoint.d/91-copilot-runtime-config.sh, which is what lets an operator running
+ * the prebuilt image retarget the user-menu links without rebuilding the frontend.
+ *
+ * This checked-in copy is the no-override default: it ships with the bundle so `pnpm dev` and any
+ * non-Docker deployment serve a real file instead of a 404. Keep it empty — the actual defaults
+ * live in src/utils/index.ts, next to the code that consumes them.
+ */
+window.__COPILOT_CONFIG__ = {}

--- a/frontend/src/app-layouts/common/Toolbar/Avatar.vue
+++ b/frontend/src/app-layouts/common/Toolbar/Avatar.vue
@@ -9,7 +9,7 @@ import { NAvatar, NDropdown } from "naive-ui"
 import { h, ref } from "vue"
 import { useRouter } from "vue-router"
 import { useAuthStore } from "@/stores/auth"
-import { renderIcon } from "@/utils"
+import { getContactLink, getDocumentationLink, renderIcon } from "@/utils"
 
 const UserIcon = "ion:person-outline"
 const LicenseIcon = "carbon:license"
@@ -28,6 +28,8 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const userPic = authStore.userPic
+const documentationLink = getDocumentationLink()
+const contactLink = getContactLink()
 
 const options = ref([
 	{
@@ -110,11 +112,11 @@ const options = ref([
 			h(
 				"a",
 				{
-					href: "https://docs.socfortress.co/",
+					href: documentationLink.url,
 					target: "_blank",
 					rel: "noopener noreferrer"
 				},
-				"Documentation"
+				documentationLink.label
 			),
 		key: "documentation",
 		icon: renderIcon(DocsIcon)
@@ -124,11 +126,11 @@ const options = ref([
 			h(
 				"a",
 				{
-					href: "https://www.socfortress.co/contact-us",
+					href: contactLink.url,
 					target: "_blank",
 					rel: "noopener noreferrer"
 				},
-				"Contact SOCFortress"
+				contactLink.label
 			),
 		key: "contact-socfortress",
 		icon: renderIcon(ContactIcon)

--- a/frontend/src/utils/__tests__/externalLinks.spec.ts
+++ b/frontend/src/utils/__tests__/externalLinks.spec.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { EXTERNAL_LINK_DEFAULTS, getContactLink, getDocumentationLink } from "../index"
+
+function setRuntimeConfig(config: CopilotRuntimeConfig | undefined) {
+	window.__COPILOT_CONFIG__ = config
+}
+
+afterEach(() => {
+	setRuntimeConfig(undefined)
+})
+
+describe("user-menu external links", () => {
+	it("falls back to the shipped defaults when nothing overrides them", () => {
+		expect(getDocumentationLink()).toEqual(EXTERNAL_LINK_DEFAULTS.documentation)
+		expect(getContactLink()).toEqual(EXTERNAL_LINK_DEFAULTS.contact)
+	})
+
+	it("applies a runtime override", () => {
+		setRuntimeConfig({
+			contactLabel: "Report an issue on GitHub",
+			contactUrl: "https://github.com/socfortress/CoPilot/issues"
+		})
+
+		expect(getContactLink()).toEqual({
+			label: "Report an issue on GitHub",
+			url: "https://github.com/socfortress/CoPilot/issues"
+		})
+	})
+
+	it("overrides each entry independently", () => {
+		setRuntimeConfig({ documentationUrl: "https://wiki.example.org/soc" })
+
+		// url overridden, label kept; the contact entry is untouched
+		expect(getDocumentationLink()).toEqual({
+			label: EXTERNAL_LINK_DEFAULTS.documentation.label,
+			url: "https://wiki.example.org/soc"
+		})
+		expect(getContactLink()).toEqual(EXTERNAL_LINK_DEFAULTS.contact)
+	})
+
+	it("rejects a non-http(s) url instead of rendering it", () => {
+		// the runtime file is generated from container env, so a bad value must not become an href
+		setRuntimeConfig({ contactUrl: "javascript:alert(1)" })
+		expect(getContactLink().url).toBe(EXTERNAL_LINK_DEFAULTS.contact.url)
+
+		setRuntimeConfig({ contactUrl: "not a url at all" })
+		expect(getContactLink().url).toBe(EXTERNAL_LINK_DEFAULTS.contact.url)
+	})
+
+	it("ignores blank and whitespace-only values", () => {
+		setRuntimeConfig({ contactLabel: "   ", contactUrl: "  " })
+		expect(getContactLink()).toEqual(EXTERNAL_LINK_DEFAULTS.contact)
+	})
+
+	it("trims surrounding whitespace from accepted values", () => {
+		setRuntimeConfig({ contactLabel: "  Support  ", contactUrl: "  https://support.example.org  " })
+
+		expect(getContactLink()).toEqual({ label: "Support", url: "https://support.example.org" })
+	})
+})

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -126,6 +126,71 @@ export function getBaseUrl() {
 	return _trim(import.meta.env.VITE_API_URL, "/")
 }
 
+export interface ExternalLink {
+	label: string
+	url: string
+}
+
+/**
+ * Where the external entries in the user menu point. The contact default is the SOCFortress
+ * pre-sale form, which suits a demo but not a production deployment whose operators want bug
+ * reports to land somewhere they control — see #1051.
+ */
+export const EXTERNAL_LINK_DEFAULTS = {
+	documentation: { label: "Documentation", url: "https://docs.socfortress.co/" },
+	contact: { label: "Contact SOCFortress", url: "https://www.socfortress.co/contact-us" }
+} as const
+
+/** Only http(s) is accepted, so a malformed or hostile override cannot become a `javascript:` URL. */
+function isSafeHttpUrl(value: string): boolean {
+	try {
+		const { protocol } = new URL(value)
+		return protocol === "http:" || protocol === "https:"
+	} catch {
+		return false
+	}
+}
+
+function resolveExternalLink(fallback: ExternalLink, label?: string, url?: string): ExternalLink {
+	const candidateUrl = _trim(url)
+
+	return {
+		label: _trim(label) || fallback.label,
+		url: isSafeHttpUrl(candidateUrl) ? candidateUrl : fallback.url
+	}
+}
+
+/**
+ * Resolution order is runtime config → build-time env → compiled-in default.
+ *
+ * The runtime layer is what makes these configurable on the published image: `/config.js` is
+ * regenerated from container environment variables on every start, whereas `VITE_*` values are
+ * substituted at build time and therefore frozen for anyone who pulls rather than builds.
+ */
+function getRuntimeConfig(): CopilotRuntimeConfig | undefined {
+	return typeof window === "undefined" ? undefined : window.__COPILOT_CONFIG__
+}
+
+export function getDocumentationLink(): ExternalLink {
+	const runtime = getRuntimeConfig()
+
+	return resolveExternalLink(
+		EXTERNAL_LINK_DEFAULTS.documentation,
+		runtime?.documentationLabel ?? import.meta.env.VITE_DOCUMENTATION_LABEL,
+		runtime?.documentationUrl ?? import.meta.env.VITE_DOCUMENTATION_URL
+	)
+}
+
+export function getContactLink(): ExternalLink {
+	const runtime = getRuntimeConfig()
+
+	return resolveExternalLink(
+		EXTERNAL_LINK_DEFAULTS.contact,
+		runtime?.contactLabel ?? import.meta.env.VITE_CONTACT_LABEL,
+		runtime?.contactUrl ?? import.meta.env.VITE_CONTACT_URL
+	)
+}
+
 export function getNameInitials(name: string, cap?: number) {
 	let initials = name.slice(0, 2)
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,5 +1,36 @@
 /// <reference types="vite/client" />
 
+/**
+ * Build-time overrides for the external entries in the user menu. Frozen into the bundle by Vite,
+ * so on a prebuilt image the runtime layer below is the one that applies.
+ */
+interface ImportMetaEnv {
+	/** Label of the documentation entry. Falls back to "Documentation". */
+	readonly VITE_DOCUMENTATION_LABEL?: string
+	/** URL the documentation entry opens. Falls back to the SOCFortress docs site. */
+	readonly VITE_DOCUMENTATION_URL?: string
+	/** Label of the support entry. Falls back to "Contact SOCFortress". */
+	readonly VITE_CONTACT_LABEL?: string
+	/** URL the support entry opens. Falls back to the SOCFortress contact page. */
+	readonly VITE_CONTACT_URL?: string
+}
+
+/**
+ * Runtime overrides, served by /config.js and regenerated from container environment variables on
+ * every start by build/docker-entrypoint.d/91-copilot-runtime-config.sh. Each key is optional; an
+ * absent one leaves the build-time value or the compiled-in default in place.
+ */
+interface CopilotRuntimeConfig {
+	documentationLabel?: string
+	documentationUrl?: string
+	contactLabel?: string
+	contactUrl?: string
+}
+
+interface Window {
+	__COPILOT_CONFIG__?: CopilotRuntimeConfig
+}
+
 declare module "*.vue" {
 	import type { DefineComponent } from "vue"
 


### PR DESCRIPTION
Introduces a new runtime configuration mechanism that allows the user menu links for documentation and contact to be dynamically set through environment variables. This is achieved by adding a script that generates a config file at container start, ensuring that the links can be updated without rebuilding the frontend. The changes include updates to the Dockerfile, new scripts for runtime configuration, and modifications to the frontend components to utilize these dynamic links. Additionally, tests have been added to verify the functionality of the new link resolution logic.