### PR TITLE
fix(auth): make customer assignments authoritative for analysts (#1050)

### DIFF
--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -69,6 +69,7 @@ from app.db.universal_models import Agents
 from app.incidents.schema.db_operations import CaseOutResponse
 from app.incidents.services.db_operations import list_cases_by_asset_name
 from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_customer_code_access
 from app.middleware.customer_query import customer_codes_query
 from app.middleware.search_query import SearchParams
 from app.middleware.search_query import apply_search_limit
@@ -1468,7 +1469,10 @@ async def sync_vulnerabilities_route(
 @agents_router.post(
     "/sync/vulnerabilities/{customer_code}",
     description="Sync agent vulnerabilities",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def sync_vulnerabilities_customer_code_route(
     customer_code: str,

--- a/backend/app/agents/vulnerabilities/routes/vulnerabilities.py
+++ b/backend/app/agents/vulnerabilities/routes/vulnerabilities.py
@@ -64,6 +64,9 @@ from app.auth.routes.auth import AuthHandler
 from app.db.db_session import get_db
 from app.db.db_session import get_db_session
 from app.db.universal_models import VulnerabilityReport
+from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_customer_code_access
+from app.middleware.customer_access import verify_optional_customer_code_access
 from app.middleware.customer_query import customer_codes_query
 
 # Create router for vulnerability endpoints
@@ -196,11 +199,15 @@ async def get_agent_vulnerabilities(
     "/stats",
     response_model=VulnerabilityStatsResponse,
     description="Get vulnerability statistics",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
     deprecated=True,  # Marking this endpoint as deprecated in favor of more specific ones
 )
 async def get_vulnerability_stats(
     customer_code: Optional[str] = Query(None, description="Filter by customer code"),
+    current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> VulnerabilityStatsResponse:
     """
@@ -217,7 +224,8 @@ async def get_vulnerability_stats(
 
     try:
         # Use the standalone function directly
-        return await get_vulnerability_statistics(db_session=db, customer_code=customer_code)
+        accessible = await customer_access_handler.get_user_accessible_customers(current_user, db)
+        return await get_vulnerability_statistics(db_session=db, customer_code=customer_code, accessible_customers=accessible)
 
     except Exception as e:
         logger.error(f"Error getting vulnerability statistics: {e}")
@@ -228,7 +236,10 @@ async def get_vulnerability_stats(
     "/sync/customer/{customer_code}",
     response_model=VulnerabilitySyncResponse,
     description="Sync vulnerabilities for all agents of a specific customer",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
     deprecated=True,  # Marking this endpoint as deprecated in favor of more specific ones
 )
 async def sync_customer_vulnerabilities(
@@ -274,7 +285,10 @@ async def sync_customer_vulnerabilities(
     "/sync/agent/{agent_name}",
     response_model=VulnerabilitySyncResponse,
     description="Sync vulnerabilities for a specific agent with performance options",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
     deprecated=True,  # Marking this endpoint as deprecated in favor of more specific ones
 )
 async def sync_agent_vulnerabilities(

--- a/backend/app/agents/vulnerabilities/services/vulnerabilities.py
+++ b/backend/app/agents/vulnerabilities/services/vulnerabilities.py
@@ -688,7 +688,11 @@ async def get_vulnerabilities_by_agent(
         raise HTTPException(status_code=500, detail=f"Failed to get vulnerabilities for agent {agent_id}: {e}")
 
 
-async def get_vulnerability_statistics(db_session: AsyncSession, customer_code: Optional[str] = None) -> VulnerabilityStatsResponse:
+async def get_vulnerability_statistics(
+    db_session: AsyncSession,
+    customer_code: Optional[str] = None,
+    accessible_customers: Optional[List[str]] = None,
+) -> VulnerabilityStatsResponse:
     """
     Get vulnerability statistics
 
@@ -703,6 +707,9 @@ async def get_vulnerability_statistics(db_session: AsyncSession, customer_code: 
         query = select(AgentVulnerabilities)
         if customer_code:
             query = query.filter(AgentVulnerabilities.customer_code == customer_code)
+        elif accessible_customers is not None and "*" not in accessible_customers:
+            # Unfiltered stats must still be bounded by the caller's tenants.
+            query = query.filter(AgentVulnerabilities.customer_code.in_(accessible_customers))
 
         result = await db_session.execute(query)
         vulnerabilities = result.scalars().all()

--- a/backend/app/ai_analyst/routes/ai_analyst.py
+++ b/backend/app/ai_analyst/routes/ai_analyst.py
@@ -69,6 +69,7 @@ from app.connectors.talon.services.talon import (
 )
 from app.db.db_session import get_db
 from app.db.universal_models import AiAnalystReport
+from app.middleware.customer_access import verify_customer_code_access
 from app.middleware.customer_query import customer_codes_query
 
 ai_analyst_router = APIRouter()
@@ -138,7 +139,10 @@ async def list_jobs_by_alert_route(
     "/jobs/customer/{customer_code}",
     response_model=JobListResponse,
     description="List all AI analyst jobs for a customer",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_jobs_by_customer_route(
     customer_code: str,
@@ -228,7 +232,10 @@ async def list_iocs_by_alert_route(
     "/iocs/customer/{customer_code}",
     response_model=IocListResponse,
     description="List IOCs for a customer, optionally filtered by VT verdict",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_iocs_by_customer_route(
     customer_code: str,
@@ -464,7 +471,10 @@ async def get_review_by_id_route(
     "/reviews/customer/{customer_code}",
     response_model=ReviewListResponse,
     description="Review dashboard feed for a customer (newest first, with per-IOC reviews)",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_reviews_by_customer_route(
     customer_code: str,
@@ -482,7 +492,10 @@ async def list_reviews_by_customer_route(
     "/reviews/customer/{customer_code}/stats",
     response_model=ReviewStatsResponse,
     description="Aggregate review metrics (feedback dashboard) for a customer — SQL-side rollup",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_review_stats_route(
     customer_code: str,
@@ -501,7 +514,10 @@ async def get_review_stats_route(
     "/palace_lessons/customer/{customer_code}",
     response_model=PalaceSearchResponse,
     description="Preview similar MemPalace lessons for a customer (proxies to Talon /palace/search)",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def search_palace_lessons_route(
     customer_code: str,
@@ -540,7 +556,10 @@ async def search_palace_lessons_route(
         "groups by room, flags near-duplicate pairs, and surfaces one-offs about "
         "to be swept. Pure read-only; no Talon round-trip."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_palace_consolidation_route(
     customer_code: str,

--- a/backend/app/customer_portal/routes/ai_reports.py
+++ b/backend/app/customer_portal/routes/ai_reports.py
@@ -26,6 +26,7 @@ from app.customer_portal.services.ai_reports import is_ai_reports_enabled_for_us
 from app.customer_portal.services.ai_reports import upsert_ai_report_settings
 from app.db.db_session import get_db
 from app.db.universal_models import Customers
+from app.middleware.customer_access import verify_customer_code_access
 
 customer_portal_ai_reports_router = APIRouter()
 
@@ -69,7 +70,10 @@ def _settings_schema(customer_code: str, settings) -> PortalAiReportSettings:
     "/ai_reports/settings/{customer_code}",
     response_model=PortalAiReportSettingsResponse,
     description="Get whether a customer's portal users can see AI analyst findings",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_ai_report_settings(
     customer_code: str,

--- a/backend/app/customer_portal/routes/branding.py
+++ b/backend/app/customer_portal/routes/branding.py
@@ -34,6 +34,7 @@ from app.customer_portal.services.branding import resolve_effective_branding
 from app.customer_portal.services.branding import upsert_branding_override
 from app.db.db_session import get_db
 from app.db.universal_models import Customers
+from app.middleware.customer_access import verify_customer_code_access
 
 customer_portal_branding_router = APIRouter()
 
@@ -127,7 +128,10 @@ async def list_customer_branding(
     "/branding/{customer_code}",
     response_model=CustomerBrandingResponse,
     description="Get a customer's branding override (if any) plus the branding that currently resolves for it.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_branding(
     customer_code: str,

--- a/backend/app/customer_provisioning/routes/provision.py
+++ b/backend/app/customer_provisioning/routes/provision.py
@@ -30,6 +30,7 @@ from app.customer_provisioning.services.provision import provision_wazuh_worker
 from app.db.db_session import get_db
 from app.db.universal_models import Customers
 from app.db.universal_models import CustomersMeta
+from app.middleware.customer_access import verify_customer_code_access
 
 customer_provisioning_router = APIRouter()
 
@@ -299,7 +300,10 @@ async def get_subscriptions_route():
     "/provision/{customer_code}",
     response_model=CustomersMetaResponse,
     description="Get Customer Meta",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_meta(
     customer_code: str,
@@ -373,7 +377,10 @@ async def provision_dashboards_route(
     "/update/office365_org_id/{customer_code}",
     response_model=UpdateOffice365OrgIdResponse,
     description="Update Office 365 organization ID",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def update_office_365_org_id(
     customer_code: str,
@@ -413,7 +420,10 @@ async def update_office_365_org_id(
     "/edr_install_commands/{customer_code}",
     response_model=EDRInstallCommandsResponse,
     description="Generate the Windows and Linux EDR agent install commands for a customer",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_edr_install_commands(
     customer_code: str,

--- a/backend/app/customers/routes/customers.py
+++ b/backend/app/customers/routes/customers.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from starlette.status import HTTP_401_UNAUTHORIZED
 
+from app.auth.models.users import User
 from app.auth.utils import AuthHandler
 
 # App specific imports
@@ -29,6 +30,8 @@ from app.healthchecks.agents.schema.agents import AgentHealthCheckResponse
 from app.healthchecks.agents.schema.agents import TimeCriteriaModel
 from app.healthchecks.agents.services.agents import velociraptor_agents_healthcheck
 from app.healthchecks.agents.services.agents import wazuh_agents_healthcheck
+from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_customer_code_access
 from app.middleware.license import get_license_seat_allowance
 from app.middleware.license import is_feature_enabled
 from app.middleware.search_query import SearchParams
@@ -249,6 +252,7 @@ async def create_customer(
 )
 async def get_customers(
     search_params: SearchParams = Depends(search_query),
+    current_user: User = Depends(AuthHandler().get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> CustomersResponse:
     """
@@ -257,6 +261,10 @@ async def get_customers(
     ``search``/``limit`` (see ``search_query``) narrow the result to customers whose
     code or name contains the string and cap the count — so the global search palette
     never pulls the whole customer list to filter client-side.
+
+    The result is scoped to the caller's customer access, which makes this the source
+    of truth for every customer picker in the UI: an analyst assigned to one customer
+    cannot pick, or even see, another one.
 
     Args:
         session (AsyncSession): The async session object used to interact with the database.
@@ -267,6 +275,12 @@ async def get_customers(
     logger.info(f"Fetching customers (search={search_params.search or 'none'})")
 
     query = apply_search_limit(select(Customers), search_params, Customers.customer_code, Customers.customer_name)
+    query = await customer_access_handler.filter_query_by_customer_access(
+        current_user,
+        session,
+        query,
+        Customers.customer_code,
+    )
     result = await session.execute(query)
     customers = result.scalars().all()
 
@@ -293,7 +307,10 @@ async def get_customers(
     "/{customer_code}",
     response_model=CustomerResponse,
     description="Get customer by customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer(
     customer_code: str,
@@ -523,7 +540,10 @@ async def add_customer_meta(
     "/{customer_code}/meta",
     response_model=CustomerMetaResponse,
     description="Get customer meta by customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
     deprecated=True,
 )
 async def get_customer_meta(
@@ -675,7 +695,10 @@ async def delete_customer_meta(
     "/{customer_code}/full",
     response_model=CustomerFullResponse,
     description="Get customer and customer meta by customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_full(
     customer_code: str,
@@ -732,7 +755,10 @@ async def get_customer_full(
     "/{customer_code}/agents",
     response_model=AgentsResponse,
     description="Get agents for the given customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_agents(
     customer_code: str,
@@ -780,7 +806,10 @@ async def get_agents(
     "/{customer_code}/agents/healthcheck/wazuh",
     response_model=AgentHealthCheckResponse,
     description="Get agents healthcheck for the given customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_wazuh_agents_healthcheck(
     customer_code: str,
@@ -837,7 +866,10 @@ async def get_wazuh_agents_healthcheck(
     "/{customer_code}/agents/healthcheck/velociraptor",
     response_model=AgentHealthCheckResponse,
     description="Get agents healthcheck for the given customer_code",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_velociraptor_agents_healthcheck(
     customer_code: str,

--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -246,6 +246,7 @@ from app.incidents.services.incident_case import handle_customer_notifications_c
 from app.incidents.services.notification_enrichment import extract_rule_level
 from app.incidents.services.notification_enrichment import severity_from_rule_level
 from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_customer_code_access
 from app.middleware.customer_query import customer_codes_query
 from app.notifications.services.emit import emit
 from app.notifications.services.event_builders import alert_assigned_event
@@ -257,7 +258,10 @@ incidents_db_operations_router = APIRouter()
 @incidents_db_operations_router.get(
     "/ai_trigger/{customer_code}",
     response_model=AITriggerResponse,
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_ai_trigger_endpoint(
     customer_code: str,
@@ -292,7 +296,10 @@ async def put_customer_ai_trigger_endpoint(
 @incidents_db_operations_router.get(
     "/notification/{customer_code}",
     response_model=NotificationResponse,
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_notification_endpoint(
     customer_code: str,
@@ -2813,7 +2820,9 @@ async def _ensure_customer_access(customer_code: str, current_user: User, db: As
 
     ``customer_code`` is taken from request input; this asserts the caller is
     actually entitled to that tenant. A None/blank code resolves to "no access"
-    for scoped (customer_user) callers while admin/analyst keep wildcard access.
+    for any scoped caller — a customer_user, or an analyst who has been assigned
+    specific customers. Admins, and analysts with no assignments, keep wildcard
+    access; see ``CustomerAccessHandler.get_user_accessible_customers``.
     """
     if not await customer_access_handler.check_customer_access(current_user, customer_code, db):
         raise HTTPException(

--- a/backend/app/incidents/routes/incident_report.py
+++ b/backend/app/incidents/routes/incident_report.py
@@ -39,6 +39,7 @@ from app.incidents.services.reports_pdf import create_case_context_pdf
 from app.incidents.services.reports_pdf import create_file_response_pdf
 from app.incidents.services.reports_pdf import download_template_pdf
 from app.incidents.services.reports_pdf import render_html_template
+from app.middleware.customer_access import verify_customer_code_access
 
 incidents_report_router = APIRouter()
 
@@ -202,7 +203,10 @@ async def get_cases_export_all_route(
 @incidents_report_router.post(
     "/generate-report-csv/{customer_code}",
     description="Generate a report for a customer. Optionally filter by year and month.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_cases_export_customer_route(
     customer_code: str,

--- a/backend/app/integrations/alert_creation_settings/routes/alert_creation_settings.py
+++ b/backend/app/integrations/alert_creation_settings/routes/alert_creation_settings.py
@@ -35,6 +35,7 @@ from app.integrations.alert_creation_settings.schema.alert_creation_settings imp
 from app.integrations.alert_creation_settings.schema.alert_creation_settings import (
     EventOrderResponse,
 )
+from app.middleware.customer_access import verify_customer_code_access
 from app.utils import get_customer_alert_event_configs
 
 alert_creation_settings_router = APIRouter()
@@ -44,7 +45,10 @@ alert_creation_settings_router = APIRouter()
     "/{customer_code}/event_configs",
     response_model=List[List[AlertCreationEventConfigResponse]],
     description="Get all alert event configs for a customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_event_configs(
     customer_code: str,

--- a/backend/app/integrations/copilot_searches/routes/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/routes/copilot_searches.py
@@ -140,6 +140,7 @@ from app.integrations.copilot_searches.services.detection_catalog import (
 from app.integrations.copilot_searches.services.detection_catalog import run_log_test
 from app.integrations.copilot_searches.services.mitre_coverage import get_coverage
 from app.integrations.copilot_searches.services.mitre_coverage import mitre_matrix
+from app.middleware.customer_access import verify_optional_customer_code_access
 from app.middleware.search_query import SearchParams
 from app.middleware.search_query import filter_and_limit
 from app.middleware.search_query import search_query
@@ -1017,7 +1018,10 @@ async def get_catalog_story_detail_endpoint(story_name: str) -> CatalogStoryDeta
         "response carries ``available=false`` + ``unavailable_reason`` so "
         "the UI can render an inline empty state instead of erroring."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user")),
+        Depends(verify_optional_customer_code_access),
+    ],
 )
 async def list_catalog_wazuh_rules_endpoint(
     customer_code: Optional[str] = Query(

--- a/backend/app/integrations/github_audit/routes/github_audit.py
+++ b/backend/app/integrations/github_audit/routes/github_audit.py
@@ -13,6 +13,7 @@ from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.models.users import User
 from app.auth.utils import AuthHandler
 from app.db.db_session import get_db
 from app.integrations.github_audit.model import GitHubAuditBaseline
@@ -41,6 +42,8 @@ from app.integrations.github_audit.schema.github_audit import GitHubAuditRespons
 from app.integrations.github_audit.schema.github_audit import GitHubAuditSummaryResponse
 from app.integrations.github_audit.services.github_audit import run_github_audit
 from app.integrations.github_audit.services.github_audit import run_github_audit_summary
+from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_optional_customer_code_access
 from app.middleware.customer_query import customer_codes_query
 
 github_audit_router = APIRouter()
@@ -431,7 +434,10 @@ async def run_audit_summary_from_config(
     "/reports",
     response_model=GitHubAuditReportListResponse,
     description="Get list of GitHub audit reports",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
 )
 async def get_reports(
     customer_code: Optional[str] = Query(None, description="Filter by customer code"),
@@ -440,6 +446,7 @@ async def get_reports(
     status: Optional[str] = Query(None, description="Filter by status"),
     limit: int = Query(50, ge=1, le=200, description="Maximum number of reports"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
+    current_user: User = Depends(AuthHandler().get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> GitHubAuditReportListResponse:
     """Get list of GitHub audit reports with optional filters."""
@@ -470,6 +477,15 @@ async def get_reports(
         GitHubAuditReport.triggered_by,
         GitHubAuditReport.triggered_by_user,
     ).order_by(GitHubAuditReport.audit_started_at.desc())
+
+    # Bound the listing to the caller's tenants, so an unfiltered browse does not
+    # surface another customer's audit history.
+    query = await customer_access_handler.filter_query_by_customer_access(
+        current_user,
+        session,
+        query,
+        GitHubAuditReport.customer_code,
+    )
 
     if customer_code:
         query = query.where(GitHubAuditReport.customer_code == customer_code)

--- a/backend/app/integrations/routes.py
+++ b/backend/app/integrations/routes.py
@@ -52,6 +52,7 @@ from app.integrations.schema import IntegrationWithAuthKeys
 from app.integrations.schema import UpdateCustomerIntegration
 from app.integrations.schema import UpdateMetaAutoRequest
 from app.integrations.schema import UpdateMetaResponse
+from app.middleware.customer_access import verify_customer_code_access
 from app.network_connectors.models.network_connectors import (
     CustomerNetworkConnectorsMeta,
 )
@@ -704,7 +705,10 @@ async def get_customer_integrations_meta(session: AsyncSession = Depends(get_db)
     "/customer_integrations/{customer_code}",
     response_model=CustomerIntegrationsResponse,
     description="Get a list of customer integrations for a specific customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_integrations_by_customer_code(
     customer_code: str,
@@ -738,7 +742,10 @@ async def get_customer_integrations_by_customer_code(
     "/customer_integrations_meta/{customer_code}",
     response_model=CustomerIntegrationsMetaResponse,
     description="Get a list of customer integrations metadata for a specific customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_integrations_meta_by_customer_code(
     customer_code: str,
@@ -875,7 +882,10 @@ async def create_integration_meta(
     "/update_integration/{customer_code}",
     response_model=CustomerIntegrationCreateResponse,
     description="Update a customer integration.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def update_integration(
     customer_code: str,
@@ -1257,7 +1267,10 @@ async def get_customer_by_auth_key(
 @integration_settings_router.get(
     "/meta_auto/{customer_code}/{integration_name}",
     description="Get integration or network connector metadata automatically based on integration name",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_meta_auto(
     customer_code: str,

--- a/backend/app/middleware/customer_access.py
+++ b/backend/app/middleware/customer_access.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from fastapi import Depends
 from fastapi import HTTPException
+from fastapi import Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,15 +17,36 @@ from app.db.db_session import get_db
 
 class CustomerAccessHandler:
     async def get_user_accessible_customers(self, user: User, session: AsyncSession) -> List[str]:
-        """Get all customer codes accessible to a user"""
-        # Admin and analyst users have access to all customers
-        if user.role_id in [RoleEnum.admin, RoleEnum.analyst]:
+        """Get all customer codes accessible to a user.
+
+        Returns ``["*"]`` for deployment-wide access, or a concrete list of codes.
+
+        Roles differ in how an *empty* ``user_customer_access`` set is read, and the
+        difference is deliberate:
+
+        - **admin** — always deployment-wide. Assignments are never consulted, so an
+          admin cannot lock themselves out of the tenant they administer.
+        - **analyst** — scoped to their assignments *when they have any*, otherwise
+          deployment-wide. Assigning customers to an analyst is what opts that analyst
+          into scoping (#1050); without this, an upgrade would silently strip every
+          existing analyst of all access, since no deployment has assigned them rows.
+        - **customer_user** — always scoped to their assignments, and no assignments
+          means no access. A portal user must never fall back to seeing everything.
+        """
+        # Admins are unconditionally deployment-wide.
+        if user.role_id == RoleEnum.admin:
             return ["*"]  # Wildcard for all customers
 
-        # Customer users only see their assigned customers
-        if user.role_id == RoleEnum.customer_user:
+        if user.role_id in [RoleEnum.analyst, RoleEnum.customer_user]:
             result = await session.execute(select(UserCustomerAccess.customer_code).where(UserCustomerAccess.user_id == user.id))
-            return result.scalars().all()
+            assigned_customers = list(result.scalars().all())
+
+            # An unassigned analyst keeps the deployment-wide access they had before
+            # scoping existed; an unassigned portal user gets nothing.
+            if not assigned_customers and user.role_id == RoleEnum.analyst:
+                return ["*"]
+
+            return assigned_customers
 
         return []  # No access by default
 
@@ -97,6 +119,15 @@ class CustomerAccessHandler:
         # No access / requested subset resolved to nothing - return empty result
         return base_query.where(False)
 
+    async def enforce_customer_access(self, user: User, customer_code: str, session: AsyncSession) -> None:
+        """Raise 403 unless ``user`` may see ``customer_code``.
+
+        The counterpart to ``filter_query_by_customer_access`` for single-tenant
+        routes, where there is no query to narrow — the tenant is named in the path.
+        """
+        if not await self.check_customer_access(user, customer_code, session):
+            raise HTTPException(status_code=403, detail=f"Access denied to customer {customer_code}")
+
     def require_customer_access(self, customer_code: Optional[str] = None):
         """FastAPI dependency to enforce customer access"""
 
@@ -111,3 +142,35 @@ class CustomerAccessHandler:
 
 # Create a singleton instance
 customer_access_handler = CustomerAccessHandler()
+
+
+async def verify_customer_code_access(
+    customer_code: str,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> str:
+    """Route dependency enforcing access to the ``{customer_code}`` path parameter.
+
+    Add to ``dependencies=[...]`` alongside the scope check on any route keyed by a
+    customer code: the scope check answers "may this role reach the route at all",
+    this answers "is this caller entitled to *this* tenant".
+    """
+    await customer_access_handler.enforce_customer_access(current_user, customer_code, session)
+    return customer_code
+
+
+async def verify_optional_customer_code_access(
+    customer_code: Optional[str] = Query(None),
+    current_user: User = Depends(AuthHandler().get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> Optional[str]:
+    """Route dependency for a ``?customer_code=`` filter that is optional.
+
+    Enforces access to the code when one is supplied, so a scoped caller cannot
+    read another tenant by naming it. It deliberately does **not** constrain the
+    no-code case: that means "everything the caller may see", and narrowing an
+    aggregate is the calling service's job, not a dependency's.
+    """
+    if customer_code:
+        await customer_access_handler.enforce_customer_access(current_user, customer_code, session)
+    return customer_code

--- a/backend/app/network_connectors/routes.py
+++ b/backend/app/network_connectors/routes.py
@@ -20,6 +20,7 @@ from app.db.universal_models import CustomersMeta
 from app.integrations.alert_creation_settings.models.alert_creation_settings import (
     AlertCreationSettings,
 )
+from app.middleware.customer_access import verify_customer_code_access
 from app.network_connectors.models.network_connectors import AvailableNetworkConnectors
 from app.network_connectors.models.network_connectors import CustomerNetworkConnectors
 from app.network_connectors.models.network_connectors import (
@@ -626,7 +627,10 @@ async def get_customer_network_connectors_meta(session: AsyncSession = Depends(g
     "/customer_network_connectors/{customer_code}",
     response_model=CustomerNetworkConnectorsResponse,
     description="Get a list of customer network_connectors for a specific customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_network_connectors_by_customer_code(
     customer_code: str,
@@ -660,7 +664,10 @@ async def get_customer_network_connectors_by_customer_code(
     "/customer_network_connectors_meta/{customer_code}",
     response_model=CustomerNetworkConnectorsMetaResponse,
     description="Get a list of customer network_connectors metadata for a specific customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def get_customer_network_connectors_meta_by_customer_code(
     customer_code: str,
@@ -790,7 +797,10 @@ async def create_network_connector_meta(
     "/update_network_connector/{customer_code}",
     response_model=CustomerNetworkConnectorsCreateResponse,
     description="Update a customer network_connector.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def update_network_connector(
     customer_code: str,

--- a/backend/app/notifications/routes/notifications.py
+++ b/backend/app/notifications/routes/notifications.py
@@ -30,6 +30,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.models.users import User
 from app.auth.utils import AuthHandler
 from app.db.db_session import get_db
+from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_customer_code_access
+from app.middleware.customer_access import verify_optional_customer_code_access
 from app.notifications.channels import CHANNEL_REGISTRY
 from app.notifications.schema.notifications import ChannelDescriptor
 from app.notifications.schema.notifications import ChannelListResponse
@@ -74,7 +77,10 @@ notifications_router = APIRouter()
     "/customers/{customer_code}/notification_routes",
     response_model=NotificationRouteListResponse,
     description="List notification routes for a customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_routes_route(
     customer_code: str,
@@ -92,7 +98,10 @@ async def list_routes_route(
     "/customers/{customer_code}/notification_routes",
     response_model=NotificationRouteResponse,
     description="Create a new notification route for a customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def create_route_route(
     customer_code: str,
@@ -118,7 +127,10 @@ async def create_route_route(
     "/customers/{customer_code}/notification_routes/{route_id}",
     response_model=NotificationRouteResponse,
     description="Update an existing notification route. Only fields included in the body are modified.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def update_route_route(
     customer_code: str,
@@ -137,7 +149,10 @@ async def update_route_route(
 @notifications_router.delete(
     "/customers/{customer_code}/notification_routes/{route_id}",
     description="Delete a notification route. Dispatch log entries for the route are retained.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def delete_route_route(
     customer_code: str,
@@ -155,7 +170,10 @@ async def delete_route_route(
         "Send a real test notification through this route. Consumes provider quota and is "
         "recorded in the dispatch log, exactly like a live notification."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def test_route(
     customer_code: str,
@@ -378,7 +396,10 @@ async def list_channels_route() -> ChannelListResponse:
         "the API key is shared, so every customer's routes draw from one allowance. "
         "Pass customer_code for a display-only breakdown."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
 )
 async def resend_quota_route(
     customer_code: Optional[str] = None,
@@ -418,7 +439,10 @@ async def resend_quota_route(
     "/customers/{customer_code}/notification_dispatch_log",
     response_model=DispatchLogListResponse,
     description="Recent notification dispatch attempts for a customer (newest first, capped at 100).",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_dispatch_log_route(
     customer_code: str,
@@ -469,7 +493,10 @@ async def list_shuffle_orgs_route(
     "/customers/{customer_code}/shuffle_integrations",
     response_model=ShuffleIntegrationListResponse,
     description="List Shuffle integrations (per-customer Org-Id rows) for a customer.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_shuffle_integrations_route(
     customer_code: str,
@@ -487,7 +514,10 @@ async def list_shuffle_integrations_route(
     "/customers/{customer_code}/shuffle_integrations",
     response_model=ShuffleIntegrationResponse,
     description="Create a new Shuffle integration for a customer (records the customer's Shuffle Org-Id).",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def create_shuffle_integration_route(
     customer_code: str,
@@ -513,7 +543,10 @@ async def create_shuffle_integration_route(
     "/customers/{customer_code}/shuffle_integrations/{integration_id}",
     response_model=ShuffleIntegrationResponse,
     description="Update an existing Shuffle integration. Only fields included in the body are modified.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def update_shuffle_integration_route(
     customer_code: str,
@@ -532,7 +565,10 @@ async def update_shuffle_integration_route(
 @notifications_router.delete(
     "/customers/{customer_code}/shuffle_integrations/{integration_id}",
     description="Delete a Shuffle integration. Refused if any notification routes reference it.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def delete_shuffle_integration_route(
     customer_code: str,
@@ -551,7 +587,10 @@ async def delete_shuffle_integration_route(
         "by the route form's app picker so admins can pick from a list "
         "instead of hand-typing UUIDs."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def list_shuffle_apps_route(
     customer_code: str,
@@ -570,7 +609,10 @@ async def list_shuffle_apps_route(
     "/customers/{customer_code}/shuffle_integrations/{integration_id}/verify",
     response_model=ShuffleVerifyResponse,
     description="Probe Shuffle with the integration's Org-Id to confirm the connector is reachable and the org is valid.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_customer_code_access),
+    ],
 )
 async def verify_shuffle_integration_route(
     customer_code: str,
@@ -626,14 +668,24 @@ async def dispatch_route(
         "List reusable message templates. Filter to a customer (returns their own plus the shared ones) "
         "and/or to a trigger (returns templates scoped to it plus the trigger-agnostic ones)."
     ),
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
 )
 async def list_templates_route(
     customer_code: Optional[str] = None,
     trigger: Optional[str] = None,
+    current_user: User = Depends(AuthHandler().get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> NotificationTemplateListResponse:
-    templates = await templates_svc.list_templates(session, customer_code=customer_code, trigger=trigger)
+    accessible = await customer_access_handler.get_user_accessible_customers(current_user, session)
+    templates = await templates_svc.list_templates(
+        session,
+        customer_code=customer_code,
+        trigger=trigger,
+        accessible_customers=accessible,
+    )
     return NotificationTemplateListResponse(
         success=True,
         message=f"{len(templates)} template(s) retrieved",

--- a/backend/app/notifications/services/templates.py
+++ b/backend/app/notifications/services/templates.py
@@ -56,18 +56,31 @@ async def list_templates(
     *,
     customer_code: Optional[str] = None,
     trigger: Optional[str] = None,
+    accessible_customers: Optional[List[str]] = None,
 ) -> List[NotificationTemplate]:
     """Templates available to a customer: their own plus the shared ones.
 
     A NULL `customer_code` means shared, so the filter is deliberately an OR
     rather than an equality — omitting the shared ones would hide every built-in
     default from every customer.
+
+    ``accessible_customers`` is the caller's tenant scope (``["*"]`` for
+    deployment-wide). It bounds the listing when no single ``customer_code`` was
+    asked for, so a scoped analyst browsing "all templates" sees only their own
+    tenants' — plus the shared ones, which are shared with them too.
     """
     stmt = select(NotificationTemplate)
     if customer_code:
         stmt = stmt.where(
             or_(
                 NotificationTemplate.customer_code == customer_code,
+                NotificationTemplate.customer_code.is_(None),
+            ),
+        )
+    elif accessible_customers is not None and "*" not in accessible_customers:
+        stmt = stmt.where(
+            or_(
+                NotificationTemplate.customer_code.in_(accessible_customers),
                 NotificationTemplate.customer_code.is_(None),
             ),
         )

--- a/backend/app/siem/routes/dashboards.py
+++ b/backend/app/siem/routes/dashboards.py
@@ -15,6 +15,7 @@ from app.auth.utils import AuthHandler
 from app.db.db_session import get_db
 from app.db.universal_models import Customers
 from app.middleware.customer_access import customer_access_handler
+from app.middleware.customer_access import verify_optional_customer_code_access
 from app.siem.schema.custom_dashboards import CustomDashboardCreateRequest
 from app.siem.schema.custom_dashboards import CustomDashboardDeleteResponse
 from app.siem.schema.custom_dashboards import CustomDashboardExportResponse
@@ -196,14 +197,19 @@ async def disable_dashboard_endpoint(
     "/custom",
     response_model=CustomDashboardsListResponse,
     description="List custom dashboard templates. With customer_code, returns that customer's templates plus the globally shared ones.",
-    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+    dependencies=[
+        Security(AuthHandler().require_any_scope("admin", "analyst")),
+        Depends(verify_optional_customer_code_access),
+    ],
 )
 async def list_custom_dashboards_endpoint(
     customer_code: Optional[str] = Query(None, description="Scope the listing to one customer (plus global templates)"),
+    current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> CustomDashboardsListResponse:
     logger.info(f"Listing custom dashboards (customer_code={customer_code})")
-    rows = await list_custom_dashboards(customer_code, db)
+    accessible = await customer_access_handler.get_user_accessible_customers(current_user, db)
+    rows = await list_custom_dashboards(customer_code, db, accessible_customers=accessible)
     return CustomDashboardsListResponse(
         custom_dashboards=[CustomDashboardResponse.model_validate(row) for row in rows],
         success=True,

--- a/backend/app/siem/services/custom_dashboards.py
+++ b/backend/app/siem/services/custom_dashboards.py
@@ -67,18 +67,29 @@ def _panels_as_dicts(panels: List[Any]) -> List[Dict[str, Any]]:
 async def list_custom_dashboards(
     customer_code: Optional[str],
     db: AsyncSession,
+    accessible_customers: Optional[List[str]] = None,
 ) -> List[CustomDashboardTemplates]:
     """List custom templates.
 
     With ``customer_code`` set, returns the templates usable by that customer —
-    its own plus every globally-shared one. Without it, returns all of them
-    (the admin-wide view).
+    its own plus every globally-shared one. Without it, returns everything the
+    caller is entitled to: all templates for a deployment-wide caller, and only
+    the assigned tenants' (plus the shared ones) for a scoped one.
+
+    ``accessible_customers`` carries that scope — ``["*"]`` means deployment-wide.
     """
     query = select(CustomDashboardTemplates)
     if customer_code:
         query = query.where(
             or_(
                 CustomDashboardTemplates.customer_code == customer_code,
+                CustomDashboardTemplates.customer_code.is_(None),
+            ),
+        )
+    elif accessible_customers is not None and "*" not in accessible_customers:
+        query = query.where(
+            or_(
+                CustomDashboardTemplates.customer_code.in_(accessible_customers),
                 CustomDashboardTemplates.customer_code.is_(None),
             ),
         )

--- a/backend/tests/e2e/analyst_scoping_e2e.py
+++ b/backend/tests/e2e/analyst_scoping_e2e.py
@@ -1,0 +1,278 @@
+"""E2E per #1050 — NON raccolto da pytest (serve un MySQL vivo); si lancia a mano.
+
+    docker run -d --name copilot-e2e-mysql -p 13306:3306 \
+        -e MYSQL_ROOT_PASSWORD=e2eroot -e MYSQL_DATABASE=copilot \
+        -e MYSQL_USER=copilot -e MYSQL_PASSWORD=e2epass mysql:8.0
+
+    cd backend && export MYSQL_URL=127.0.0.1:13306 MYSQL_USER=copilot \
+        MYSQL_PASSWORD=e2epass MYSQL_ROOT_PASSWORD=e2eroot \
+        JWT_SECRET=e2e-test-secret-not-the-default PYTHONPATH=$PWD
+    .venv/bin/python -c "from app.db.db_setup import apply_migrations; apply_migrations()"
+    .venv/bin/python tests/e2e/analyst_scoping_e2e.py
+
+Punta a un'istanza usa-e-getta sulla porta 13306: mai al MySQL della .env.
+
+Verifica le due assunzioni:
+  A) analyst SENZA clienti assegnati -> vede tutto
+  B) analyst CON clienti assegnati  -> vede solo quelli, anche quando la lista
+     viene chiamata senza customer_code
+"""
+import asyncio
+import datetime
+import os
+
+os.environ.setdefault("MYSQL_URL", "127.0.0.1:13306")
+os.environ.setdefault("MYSQL_USER", "copilot")
+os.environ.setdefault("MYSQL_PASSWORD", "e2epass")
+os.environ.setdefault("MYSQL_ROOT_PASSWORD", "e2eroot")
+os.environ.setdefault("JWT_SECRET", "e2e-test-secret-not-the-default")
+
+import httpx  # noqa: E402
+from fastapi import APIRouter  # noqa: E402
+from fastapi import FastAPI
+from sqlalchemy import delete  # noqa: E402
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+
+from app.auth.models.users import Role  # noqa: E402
+from app.auth.models.users import User
+from app.auth.models.users import UserCustomerAccess
+from app.auth.utils import AuthHandler  # noqa: E402
+from app.db.db_session import async_engine  # noqa: E402
+from app.db.universal_models import Agents  # noqa: E402
+from app.db.universal_models import AgentVulnerabilities
+from app.db.universal_models import CustomDashboardTemplates
+from app.db.universal_models import Customers
+from app.db.universal_models import NotificationTemplate
+
+PASSWORD = "E2ePassw0rd!x"
+CUST_A, CUST_B, CUST_C = "E2E_A", "E2E_B", "E2E_C"
+SCOPED = "e2e_scoped_analyst"  # assegnato a E2E_A
+UNSCOPED = "e2e_unscoped_analyst"  # nessuna assegnazione
+ADMIN = "e2e_admin"
+
+NOW = datetime.datetime(2026, 1, 1)
+results = []
+
+
+def check(name, passed, detail=""):
+    results.append((name, passed, detail))
+    print(f"  {'PASS' if passed else 'FAIL'}  {name}" + (f"  [{detail}]" if detail else ""))
+
+
+async def seed():
+    auth = AuthHandler()
+    async with AsyncSession(async_engine) as s:
+        # ruoli
+        for rid, rname in [(1, "admin"), (2, "analyst"), (3, "scheduler"), (4, "customer_user")]:
+            if not (await s.execute(select(Role).where(Role.id == rid))).scalars().first():
+                s.add(Role(id=rid, name=rname, description=rname))
+        await s.commit()
+
+        # pulizia da run precedenti
+        for uname in (SCOPED, UNSCOPED, ADMIN):
+            u = (await s.execute(select(User).where(User.username == uname))).scalars().first()
+            if u:
+                await s.execute(delete(UserCustomerAccess).where(UserCustomerAccess.user_id == u.id))
+                await s.delete(u)
+        await s.execute(delete(AgentVulnerabilities).where(AgentVulnerabilities.customer_code.in_([CUST_A, CUST_B, CUST_C])))
+        await s.execute(delete(Agents).where(Agents.customer_code.in_([CUST_A, CUST_B, CUST_C])))
+        await s.execute(delete(CustomDashboardTemplates).where(CustomDashboardTemplates.template_key.like("e2e_%")))
+        await s.execute(delete(NotificationTemplate).where(NotificationTemplate.name.like("e2e_%")))
+        await s.commit()
+        for code in (CUST_A, CUST_B, CUST_C):
+            c = (await s.execute(select(Customers).where(Customers.customer_code == code))).scalars().first()
+            if c:
+                await s.delete(c)
+        await s.commit()
+
+        # 3 clienti
+        for code in (CUST_A, CUST_B, CUST_C):
+            s.add(
+                Customers(
+                    customer_code=code,
+                    customer_name=f"Customer {code}",
+                    contact_first_name="E2E",
+                    contact_last_name="Tester",
+                    phone="000",
+                    address_line1="a",
+                    address_line2="b",
+                    city="c",
+                    state="d",
+                    postal_code="1",
+                    country="IT",
+                    customer_type="MSSP",
+                    logo_file="",
+                ),
+            )
+        await s.commit()
+
+        # un agente per cliente, per provare una lista diversa da /customers
+        for i, code in enumerate((CUST_A, CUST_B, CUST_C), start=1):
+            s.add(
+                Agents(
+                    agent_id=f"e2e{i}",
+                    ip_address=f"10.0.0.{i}",
+                    os="Linux",
+                    hostname=f"host-{code}",
+                    label=f"host-{code}",
+                    critical_asset=False,
+                    customer_code=code,
+                    quarantined=False,
+                    velociraptor_id="",
+                    velociraptor_org="root",
+                    wazuh_last_seen=NOW,
+                    velociraptor_last_seen=NOW,
+                    wazuh_agent_version="4.x",
+                    velociraptor_agent_version="0.7",
+                ),
+            )
+        await s.commit()
+
+        # una dashboard custom e un template per E2E_A e per E2E_B
+        for code in (CUST_A, CUST_B):
+            s.add(
+                AgentVulnerabilities(
+                    agent_id=("e2e1" if code == CUST_A else "e2e2"),
+                    customer_code=code,
+                    cve_id=f"CVE-{code}",
+                    severity="High",
+                    title=f"v {code}",
+                    references="",
+                    discovered_at=NOW,
+                ),
+            )
+            s.add(CustomDashboardTemplates(template_key=f"e2e_dash_{code}", customer_code=code, title=f"Dash {code}", panels=[]))
+            s.add(NotificationTemplate(name=f"e2e_tpl_{code}", customer_code=code, body_template="x"))
+        await s.commit()
+
+        # utenti
+        pw = auth.get_password_hash(PASSWORD)
+        s.add(User(username=ADMIN, password=pw, email=f"{ADMIN}@e2e.local", role_id=1))
+        s.add(User(username=SCOPED, password=pw, email=f"{SCOPED}@e2e.local", role_id=2))
+        s.add(User(username=UNSCOPED, password=pw, email=f"{UNSCOPED}@e2e.local", role_id=2))
+        await s.commit()
+
+        scoped = (await s.execute(select(User).where(User.username == SCOPED))).scalars().first()
+        s.add(UserCustomerAccess(user_id=scoped.id, customer_code=CUST_A))
+        await s.commit()
+        print(f"seed: 3 clienti, 3 agenti, analyst '{SCOPED}' assegnato a {CUST_A}, analyst '{UNSCOPED}' senza assegnazioni")
+
+
+def build_app():
+    """Monta i router reali senza gli hook di startup (MinIO/connettori)."""
+    from app.customers.routes.customers import customers_router
+    from app.notifications.routes.notifications import notifications_router
+    from app.routers.agents import router as agents_aggregate_router
+    from app.siem.routes.dashboards import dashboards_router
+
+    api = APIRouter()
+    api.include_router(customers_router, prefix="/customers", tags=["customers"])
+    api.include_router(agents_aggregate_router)
+    api.include_router(notifications_router, prefix="/notifications", tags=["notifications"])
+    api.include_router(dashboards_router, prefix="/siem/dashboards", tags=["siem"])
+    app = FastAPI()
+    app.include_router(api)
+    return app
+
+
+async def token_for(username):
+    return await AuthHandler().encode_token(username)
+
+
+async def main():
+    await seed()
+    app = build_app()
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://e2e") as client:
+        t_scoped = await token_for(SCOPED)
+        t_unscoped = await token_for(UNSCOPED)
+        t_admin = await token_for(ADMIN)
+        H = lambda t: {"Authorization": f"Bearer {t}"}  # noqa: E731
+
+        print("\n=== A) analyst SENZA clienti assegnati ===")
+        r = await client.get("/customers", headers=H(t_unscoped))
+        codes = {c["customer_code"] for c in r.json().get("customers", [])} if r.status_code == 200 else set()
+        check(
+            "GET /customers -> vede tutti e 3",
+            r.status_code == 200 and {CUST_A, CUST_B, CUST_C} <= codes,
+            f"{r.status_code} {sorted(codes)}",
+        )
+
+        r = await client.get(f"/customers/{CUST_B}", headers=H(t_unscoped))
+        check("GET /customers/E2E_B -> 200", r.status_code == 200, str(r.status_code))
+
+        print("\n=== B) analyst CON un cliente assegnato (E2E_A) ===")
+        r = await client.get("/customers", headers=H(t_scoped))
+        codes = {c["customer_code"] for c in r.json().get("customers", [])} if r.status_code == 200 else set()
+        check("GET /customers -> solo E2E_A", r.status_code == 200 and codes == {CUST_A}, f"{r.status_code} {sorted(codes)}")
+
+        r = await client.get(f"/customers/{CUST_A}", headers=H(t_scoped))
+        check("GET /customers/E2E_A (suo) -> 200", r.status_code == 200, str(r.status_code))
+
+        r = await client.get(f"/customers/{CUST_B}", headers=H(t_scoped))
+        check("GET /customers/E2E_B (altrui) -> 403", r.status_code == 403, str(r.status_code))
+
+        r = await client.get(f"/customers/{CUST_B}/agents", headers=H(t_scoped))
+        check("GET /customers/E2E_B/agents (altrui) -> 403", r.status_code == 403, str(r.status_code))
+
+        r = await client.get(f"/notifications/customers/{CUST_B}/notification_routes", headers=H(t_scoped))
+        check("GET /notifications/.../E2E_B/... (altrui) -> 403", r.status_code == 403, str(r.status_code))
+
+        print("\n=== B2) liste SENZA customer_code: filtrano da sole? ===")
+        r = await client.get("/agents", headers=H(t_scoped))
+        body = r.json() if r.status_code == 200 else {}
+        agent_codes = {a.get("customer_code") for a in body.get("agents", [])}
+        check(
+            "GET /agents (nessun codice) -> solo E2E_A",
+            r.status_code == 200 and agent_codes == {CUST_A},
+            f"{r.status_code} {sorted(c for c in agent_codes if c)}",
+        )
+
+        r = await client.get("/siem/dashboards/custom", headers=H(t_scoped))
+        keys = {d.get("template_key") for d in (r.json().get("custom_dashboards", []) if r.status_code == 200 else [])}
+        e2e_keys = {k for k in keys if k and k.startswith("e2e_dash_")}
+        check(
+            "GET /siem/dashboards/custom (nessun codice) -> solo E2E_A",
+            e2e_keys == {f"e2e_dash_{CUST_A}"},
+            f"{r.status_code} {sorted(e2e_keys)}",
+        )
+
+        r = await client.get("/notifications/notifications/templates", headers=H(t_scoped))
+        names = {t.get("name") for t in (r.json().get("templates", []) if r.status_code == 200 else [])}
+        e2e_names = {n for n in names if n and n.startswith("e2e_tpl_")}
+        check(
+            "GET /notifications/templates (nessun codice) -> solo E2E_A",
+            e2e_names == {f"e2e_tpl_{CUST_A}"},
+            f"{r.status_code} {sorted(e2e_names)}",
+        )
+
+        r = await client.get("/vulnerabilities/stats", headers=H(t_scoped))
+        total = r.json().get("total_vulnerabilities") if r.status_code == 200 else None
+        check(
+            "GET /vulnerabilities/stats (nessun codice) -> conta solo E2E_A",
+            r.status_code == 200 and total == 1,
+            f"{r.status_code} total={total}",
+        )
+
+        print("\n=== C) admin non regredisce ===")
+        r = await client.get("/customers", headers=H(t_admin))
+        codes = {c["customer_code"] for c in r.json().get("customers", [])} if r.status_code == 200 else set()
+        check(
+            "admin GET /customers -> vede tutti",
+            r.status_code == 200 and {CUST_A, CUST_B, CUST_C} <= codes,
+            f"{r.status_code} {sorted(codes)}",
+        )
+
+        r = await client.get(f"/customers/{CUST_B}", headers=H(t_admin))
+        check("admin GET /customers/E2E_B -> 200", r.status_code == 200, str(r.status_code))
+
+    passed = sum(1 for _, p, _ in results if p)
+    print(f"\n{'=' * 60}\nRISULTATO: {passed}/{len(results)} verifiche superate")
+    for n, p, d in results:
+        if not p:
+            print(f"  FALLITA: {n} [{d}]")
+
+
+asyncio.run(main())

--- a/backend/tests/test_analyst_customer_scoping.py
+++ b/backend/tests/test_analyst_customer_scoping.py
@@ -1,0 +1,245 @@
+"""Regression tests for #1050 — assigning customers to an analyst had no effect.
+
+``CustomerAccessHandler.get_user_accessible_customers`` returned the ``["*"]``
+wildcard for every analyst, so the rows written by *Users -> Assign Customer*
+were stored and then ignored: an analyst assigned to one customer still saw all
+of them.
+
+The fix makes assignments authoritative for analysts, while keeping an analyst
+with *no* assignments deployment-wide so upgrading a deployment does not strip
+access from every existing analyst.
+
+These are unit tests against the handler with a mocked session; no real DB.
+
+Run with: cd backend && python -m pytest tests/test_analyst_customer_scoping.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.auth.models.users import RoleEnum  # noqa: E402
+from app.middleware.customer_access import CustomerAccessHandler  # noqa: E402
+
+ASSIGNED = "TENANT_A"
+FOREIGN = "TENANT_B"
+
+
+def _user(role_id):
+    return SimpleNamespace(id=7, username="user", role_id=role_id)
+
+
+def _session(assigned_codes):
+    """AsyncSession whose single query returns ``assigned_codes``."""
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = assigned_codes
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+def _accessible(role_id, assigned_codes):
+    session = _session(assigned_codes)
+    codes = asyncio.run(CustomerAccessHandler().get_user_accessible_customers(_user(role_id), session))
+    return codes, session
+
+
+# ── the bug: an assigned analyst must lose the wildcard ───────────────────
+
+
+def test_analyst_with_assignments_is_scoped_to_them():
+    codes, _ = _accessible(RoleEnum.analyst, [ASSIGNED])
+    assert codes == [ASSIGNED]
+    assert "*" not in codes
+
+
+def test_analyst_without_assignments_keeps_deployment_wide_access():
+    # backwards compatibility: no deployment has assigned analysts before this change
+    codes, _ = _accessible(RoleEnum.analyst, [])
+    assert codes == ["*"]
+
+
+def test_admin_ignores_assignments_entirely():
+    codes, session = _accessible(RoleEnum.admin, [ASSIGNED])
+    assert codes == ["*"]
+    # an admin must not be scopeable by accident, so the table is never consulted
+    session.execute.assert_not_called()
+
+
+def test_customer_user_without_assignments_gets_nothing():
+    # a portal user must never fall back to the wildcard
+    codes, _ = _accessible(RoleEnum.customer_user, [])
+    assert codes == []
+
+
+def test_customer_user_with_assignments_is_unchanged():
+    codes, _ = _accessible(RoleEnum.customer_user, [ASSIGNED])
+    assert codes == [ASSIGNED]
+
+
+def test_scheduler_role_has_no_access():
+    codes, _ = _accessible(RoleEnum.scheduler, [ASSIGNED])
+    assert codes == []
+
+
+# ── the consequences for callers ─────────────────────────────────────────
+
+
+def test_scoped_analyst_is_denied_a_foreign_customer():
+    handler = CustomerAccessHandler()
+    allowed = asyncio.run(handler.check_customer_access(_user(RoleEnum.analyst), FOREIGN, _session([ASSIGNED])))
+    assert allowed is False
+
+
+def test_scoped_analyst_is_allowed_their_own_customer():
+    handler = CustomerAccessHandler()
+    allowed = asyncio.run(handler.check_customer_access(_user(RoleEnum.analyst), ASSIGNED, _session([ASSIGNED])))
+    assert allowed is True
+
+
+def test_unassigned_analyst_still_reaches_every_customer():
+    handler = CustomerAccessHandler()
+    allowed = asyncio.run(handler.check_customer_access(_user(RoleEnum.analyst), FOREIGN, _session([])))
+    assert allowed is True
+
+
+def test_enforce_customer_access_raises_403_for_scoped_analyst():
+    from fastapi import HTTPException
+
+    handler = CustomerAccessHandler()
+    try:
+        asyncio.run(handler.enforce_customer_access(_user(RoleEnum.analyst), FOREIGN, _session([ASSIGNED])))
+    except HTTPException as exc:
+        assert exc.status_code == 403
+        assert FOREIGN in exc.detail
+    else:
+        raise AssertionError("expected a 403 for a customer the analyst is not assigned to")
+
+
+def test_requested_subset_cannot_widen_a_scoped_analyst():
+    # a stale/hostile customer_code from the client must not escape the assignment
+    handler = CustomerAccessHandler()
+    effective = asyncio.run(
+        handler.resolve_effective_customers(
+            _user(RoleEnum.analyst),
+            [ASSIGNED, FOREIGN],
+            _session([ASSIGNED]),
+        ),
+    )
+    assert effective == [ASSIGNED]
+
+
+def test_query_is_narrowed_for_a_scoped_analyst():
+    handler = CustomerAccessHandler()
+    base_query = MagicMock()
+    column = MagicMock()
+
+    asyncio.run(
+        handler.filter_query_by_customer_access(
+            _user(RoleEnum.analyst),
+            _session([ASSIGNED]),
+            base_query,
+            column,
+        ),
+    )
+
+    column.in_.assert_called_once_with([ASSIGNED])
+    base_query.where.assert_called_once()
+
+
+def test_unfiltered_listings_are_bounded_by_scope_but_keep_shared_rows():
+    """The aggregate case: no customer_code asked for.
+
+    A scoped caller must get their tenants' rows plus the explicitly-shared ones
+    (``customer_code IS NULL``), never another tenant's. Asserted on the SQL the
+    services build, since the e2e that exercises them needs a live MySQL.
+    """
+    from app.notifications.services.templates import list_templates
+    from app.siem.services.custom_dashboards import list_custom_dashboards
+
+    for service, kwargs in (
+        (list_custom_dashboards, {"customer_code": None, "accessible_customers": [ASSIGNED]}),
+        (list_templates, {"customer_code": None, "accessible_customers": [ASSIGNED]}),
+    ):
+        session = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result)
+
+        if service is list_custom_dashboards:
+            asyncio.run(service(kwargs["customer_code"], session, accessible_customers=kwargs["accessible_customers"]))
+        else:
+            asyncio.run(service(session, **kwargs))
+
+        sql = str(session.execute.call_args.args[0])
+        assert "IN (" in sql, f"{service.__name__} does not bound the listing to the caller's tenants"
+        assert "IS NULL" in sql, f"{service.__name__} drops the globally-shared rows"
+
+
+def test_unfiltered_listings_are_untouched_for_deployment_wide_callers():
+    from app.siem.services.custom_dashboards import list_custom_dashboards
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+
+    asyncio.run(list_custom_dashboards(None, session, accessible_customers=["*"]))
+
+    sql = str(session.execute.call_args.args[0])
+    assert "WHERE" not in sql
+
+
+def test_optional_code_dependency_enforces_a_supplied_code():
+    from fastapi import HTTPException
+
+    from app.middleware.customer_access import verify_optional_customer_code_access
+
+    try:
+        asyncio.run(
+            verify_optional_customer_code_access(
+                customer_code=FOREIGN,
+                current_user=_user(RoleEnum.analyst),
+                session=_session([ASSIGNED]),
+            ),
+        )
+    except HTTPException as exc:
+        assert exc.status_code == 403
+    else:
+        raise AssertionError("a scoped analyst must not read another tenant by naming it in the query")
+
+
+def test_optional_code_dependency_passes_through_when_absent():
+    # no code means "everything the caller may see" — narrowing that is the service's job
+    from app.middleware.customer_access import verify_optional_customer_code_access
+
+    result = asyncio.run(
+        verify_optional_customer_code_access(
+            customer_code=None,
+            current_user=_user(RoleEnum.analyst),
+            session=_session([ASSIGNED]),
+        ),
+    )
+    assert result is None
+
+
+def test_query_is_untouched_for_an_unassigned_analyst():
+    handler = CustomerAccessHandler()
+    base_query = MagicMock()
+    column = MagicMock()
+
+    returned = asyncio.run(
+        handler.filter_query_by_customer_access(
+            _user(RoleEnum.analyst),
+            _session([]),
+            base_query,
+            column,
+        ),
+    )
+
+    assert returned is base_query
+    base_query.where.assert_not_called()


### PR DESCRIPTION
Assigning customers to an analyst via Users -> Assign Customer had no effect: `CustomerAccessHandler.get_user_accessible_customers` returned the `["*"]` wildcard for every analyst, so the `user_customer_access` rows were written and then ignored.

Assignments now scope the analyst. The empty-set semantics differ per role on purpose:

- admin: always deployment-wide, assignments are never consulted, so an admin cannot be locked out of the tenant they administer
- analyst: scoped to their assignments when they have any, otherwise deployment-wide — no deployment has assigned analysts today, so scoping them unconditionally would strip access from every existing analyst on upgrade
- customer_user: unchanged, always scoped, no assignments means no access

Hiding a customer from a list is not enough if it stays readable by URL, so an AST scan located every analyst-reachable route keyed by a customer code with no access check — 44 of them:

- 36 routes with `{customer_code}` in the path now carry the new `verify_customer_code_access` dependency
- 7 routes with an optional `?customer_code=` carry `verify_optional_customer_code_access`, which enforces a supplied code
- 1 was a false positive (`/ai_reports/availability` already checks internally)

`GET /customers` performed no filtering at all, which is what made the customer pickers show every tenant; it is now scoped, along with the five per-customer routes beside it.

Four aggregate listings returned other tenants' rows when called without a customer code — proven by the e2e, not assumed. Custom dashboards, notification templates, vulnerability stats and GitHub audit reports are now bounded by the caller's scope, while keeping rows explicitly shared with everyone (`customer_code IS NULL`) visible.

Still open, and untested here because both need external services: the deployment-wide aggregates of `/catalog/wazuh-rules` (firing stats) and `/notification_channels/resend/quota`. Both enforce a supplied code.

Tests: 17 unit tests plus a manual e2e (real MySQL, real schema, real routers, real JWT) covering both directions — unassigned analyst keeps full reach, assigned analyst is confined, admin does not regress. The e2e is deliberately not named `test_*`: it connects at import and would break pytest collection.