### PR TITLE
feat(case-templates): smart template suggestions when creating cases (#935)

### DIFF
--- a/backend/app/incidents/routes/case_templates.py
+++ b/backend/app/incidents/routes/case_templates.py
@@ -29,12 +29,15 @@ from app.incidents.schema.case_templates import CaseTemplateLibraryRefreshRespon
 from app.incidents.schema.case_templates import CaseTemplateLibraryTask
 from app.incidents.schema.case_templates import CaseTemplateListResponse
 from app.incidents.schema.case_templates import CaseTemplateOperationResponse
+from app.incidents.schema.case_templates import CaseTemplateSuggestionListResponse
 from app.incidents.schema.case_templates import CaseTemplateTaskCreate
 from app.incidents.schema.case_templates import CaseTemplateTaskOperationResponse
 from app.incidents.schema.case_templates import CaseTemplateTaskUpdate
 from app.incidents.schema.case_templates import CaseTemplateUpdate
 from app.incidents.services import case_templates as service
 from app.incidents.services import template_library
+from app.incidents.services import template_suggestions as suggestion_service
+from app.incidents.services.template_suggestions import DEFAULT_SUGGESTION_LIMIT
 
 # Scope guard applied to every route on this router. Returns the username,
 # which we use as the audit actor for create operations.
@@ -248,8 +251,62 @@ async def import_library_entry_endpoint(
 
 
 # ---------------------------------------------------------------------------
+# Smart suggestions (issue #935)
+#
+# Also a static path, so it belongs above /{template_id} for the same reason
+# /library does.
+# ---------------------------------------------------------------------------
+
+
+@case_templates_router.get(
+    "/suggest",
+    response_model=CaseTemplateSuggestionListResponse,
+    description=(
+        "Rank case templates against the context of the case about to be created. "
+        "Pass alert_id when creating a case from an alert for full contextual scoring "
+        "(tags, MITRE techniques, rule groups, auto-apply conditions, title keywords); "
+        "pass customer_code and/or source for the manual-creation path, which scores on "
+        "scope, usage history and default status only. Never fails the caller: a lookup "
+        "error returns success=false with an empty list so the create-case form still works."
+    ),
+)
+async def suggest_case_templates(
+    alert_id: Optional[int] = Query(
+        None,
+        description=(
+            "Originating alert. When set, customer_code and source are read from the alert "
+            "itself and any values passed alongside are ignored."
+        ),
+    ),
+    customer_code: Optional[str] = Query(
+        None,
+        description="Customer context for the manual-creation path. Ignored when alert_id is set.",
+    ),
+    source: Optional[str] = Query(
+        None,
+        description="Alert-source context for the manual-creation path. Ignored when alert_id is set.",
+    ),
+    limit: int = Query(
+        DEFAULT_SUGGESTION_LIMIT,
+        ge=1,
+        le=50,
+        description="Maximum suggestions returned. total_candidates reports how many applied before the cut.",
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> CaseTemplateSuggestionListResponse:
+    return await suggestion_service.suggest_templates(
+        session=db,
+        alert_id=alert_id,
+        customer_code=customer_code,
+        source=source,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Wildcard /{template_id} routes — must be declared AFTER the static
-# /library routes above for the same reason FastAPI route ordering matters.
+# /library and /suggest routes above for the same reason FastAPI route
+# ordering matters.
 # ---------------------------------------------------------------------------
 
 

--- a/backend/app/incidents/schema/case_templates.py
+++ b/backend/app/incidents/schema/case_templates.py
@@ -180,6 +180,63 @@ class CaseTemplateTaskOperationResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Smart template suggestions (issue #935)
+#
+# Ranked-template shapes for the "Suggested templates" panel shown when a case
+# is created from an alert. Purely derived — see
+# ``app.incidents.services.template_suggestions`` for why no schema backs this.
+# ---------------------------------------------------------------------------
+
+
+class SuggestionReason(BaseModel):
+    """One explainable contribution to a template's score.
+
+    Shipped to the UI verbatim so the ranking can be audited by the analyst
+    reading it, rather than being an opaque number. ``points`` is the amount
+    this signal actually contributed *after* its cap was applied, so the
+    reasons always sum to ``CaseTemplateSuggestion.score``.
+    """
+
+    signal: str = Field(
+        ...,
+        description=(
+            "Machine-readable signal key: condition, condition_unverified, customer, source, "
+            "tag, mitre, mitre_parent, mitre_name, rule_group, keyword, usage, default."
+        ),
+    )
+    detail: str = Field(..., description="Human-readable explanation shown as a chip in the UI.")
+    points: int = Field(..., description="Points this signal contributed to the score (0 for informational reasons).")
+
+
+class CaseTemplateSuggestion(BaseModel):
+    """A ranked template, carrying its full definition.
+
+    The nested ``template`` is the complete ``CaseTemplateResponse``, tasks
+    included, specifically so the UI can render the "tasks that will be added"
+    preview without a second round-trip per suggestion.
+    """
+
+    template: CaseTemplateResponse
+    score: int = Field(..., description="Additive score. Unbounded in principle; ~110 is a realistic ceiling.")
+    confidence: str = Field(..., description="Bucketed score: high | medium | low.")
+    reasons: List[SuggestionReason] = Field(
+        default_factory=list,
+        description="Why this template ranked where it did, highest-scoring signal first.",
+    )
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CaseTemplateSuggestionListResponse(BaseModel):
+    suggestions: List[CaseTemplateSuggestion] = Field(default_factory=list)
+    total_candidates: int = Field(
+        0,
+        description="Applicable templates before the limit was applied. Lets the UI say 'showing 5 of 23'.",
+    )
+    success: bool
+    message: str
+
+
+# ---------------------------------------------------------------------------
 # CaseTask (case-side instance rows)
 # ---------------------------------------------------------------------------
 

--- a/backend/app/incidents/schema/case_templates.py
+++ b/backend/app/incidents/schema/case_templates.py
@@ -219,6 +219,15 @@ class CaseTemplateSuggestion(BaseModel):
     template: CaseTemplateResponse
     score: int = Field(..., description="Additive score. Unbounded in principle; ~110 is a realistic ceiling.")
     confidence: str = Field(..., description="Bucketed score: high | medium | low.")
+    condition_matched: bool = Field(
+        False,
+        description=(
+            "This template's auto-apply condition fired for this alert. Such templates are sorted "
+            "ahead of every other suggestion regardless of score — the same partition "
+            "pick_templates_for_alert applies — so a client that re-sorts purely by score will "
+            "disagree with what auto-apply would actually do."
+        ),
+    )
     reasons: List[SuggestionReason] = Field(
         default_factory=list,
         description="Why this template ranked where it did, highest-scoring signal first.",

--- a/backend/app/incidents/services/template_suggestions.py
+++ b/backend/app/incidents/services/template_suggestions.py
@@ -38,6 +38,14 @@ strictly better signal; it is not a precondition for the feature.
 Scoring is intentionally additive and explainable. Every point a template earns
 comes with a ``SuggestionReason`` naming the signal and the evidence, because a
 ranked list an analyst cannot audit is a ranked list an analyst will not trust.
+
+**Known limit, accepted deliberately.** Multi-word tags and compound Wazuh rule
+groups are matched as whole phrases, so the group ``ransomware_behaviour`` does
+*not* match a template whose text only says "ransomware". The looser rule —
+credit for any single shared token — would make groups like ``windows`` or
+``web`` match most of the library. Precision is worth more than recall here:
+one bad suggestion at the top of the list costs more trust than a missing
+signal on a template that still ranks on customer, source and MITRE.
 """
 
 from __future__ import annotations
@@ -80,13 +88,22 @@ from app.incidents.services.case_templates import _template_to_response
 # Tunable in one place on purpose. The absolute numbers matter less than their
 # ratios; what they encode is:
 #
-#   - A satisfied auto-apply condition outranks everything, because it is not a
-#     heuristic — it is the operator's own explicit rule firing.
 #   - Explicit scope (this customer / this source) outranks inferred topical
 #     overlap, because scope was configured deliberately and text overlap was
 #     not.
 #   - Topical signals are capped so a template that happens to name six MITRE
 #     techniques cannot bulldoze a correctly-scoped one.
+#
+# A satisfied auto-apply condition is deliberately NOT expressed as "a weight
+# big enough to win". It is a *partition* — see ``suggest_templates``, which
+# sorts condition-matched templates ahead of the rest regardless of score. That
+# mirrors ``pick_templates_for_alert``, where field-match templates win outright
+# and the scope-tier picker only runs when none of them fire. Encoding it as a
+# weight instead was an early bug: at 40 points a firing condition lost to a
+# template scoring customer (25) + source (20), so the panel could recommend
+# something different from what auto-apply would actually have applied. The
+# weight below still exists so the condition shows up in the score and reasons;
+# it just isn't what guarantees the ordering.
 # ---------------------------------------------------------------------------
 
 WEIGHT_CONDITION_MATCH = 40
@@ -910,13 +927,26 @@ async def suggest_templates(
                     template=_template_to_response(template),
                     score=score,
                     confidence=_confidence_for(score),
+                    condition_matched=condition_result is True,
                     reasons=sorted(reasons, key=lambda r: r.points, reverse=True),
                 ),
             )
 
-        # Ties broken by is_default then name, so repeated calls return a stable
-        # order — a list that reshuffles between renders reads as broken.
-        suggestions.sort(key=lambda s: (-s.score, not s.template.is_default, s.template.name.lower()))
+        # Condition-matched templates first, as a partition rather than a score
+        # comparison — the operator's explicit "when eventID == 11, use this"
+        # beats any amount of inferred overlap, and this is what keeps the panel
+        # agreeing with what auto-apply would have done. Then score, then
+        # is_default, then name: the last two make repeated calls return a
+        # stable order, since a list that reshuffles between renders reads as
+        # broken even when every score is right.
+        suggestions.sort(
+            key=lambda s: (
+                not s.condition_matched,
+                -s.score,
+                not s.template.is_default,
+                s.template.name.lower(),
+            ),
+        )
         top = suggestions[: max(0, limit)] if limit else suggestions
 
         return CaseTemplateSuggestionListResponse(

--- a/backend/app/incidents/services/template_suggestions.py
+++ b/backend/app/incidents/services/template_suggestions.py
@@ -72,7 +72,6 @@ from app.incidents.models import CaseTemplateTask
 from app.incidents.schema.case_templates import CaseTemplateSuggestion
 from app.incidents.schema.case_templates import CaseTemplateSuggestionListResponse
 from app.incidents.schema.case_templates import SuggestionReason
-from app.incidents.services.alert_severity import severity_of
 from app.incidents.services.case_templates import _template_to_response
 
 # ---------------------------------------------------------------------------
@@ -286,11 +285,16 @@ class AlertSignals:
     and there is no alert to read. Both paths score through the same function;
     the manual one simply has empty topical signals and therefore leans on
     scope, usage history and ``is_default``.
+
+    Severity is deliberately absent. Templates carry no severity dimension, so
+    the only way to score on it would be text-matching "critical" / "high"
+    against the template's prose — which fires on any playbook that happens to
+    use the word, and says nothing about whether it fits. Giving severity real
+    weight needs a real column on the template first.
     """
 
     customer_code: Optional[str] = None
     source: Optional[str] = None
-    severity: Optional[str] = None
     alert_id: Optional[int] = None
     alert_name: Optional[str] = None
     tags: List[str] = dataclass_field(default_factory=list)
@@ -376,7 +380,6 @@ async def build_alert_signals(
     signals.alert_name = alert.alert_name
     signals.customer_code = alert.customer_code
     signals.source = alert.source
-    signals.severity = severity_of(alert)
 
     signals.tags = await _load_alert_tags(alert.id, session)
 

--- a/backend/app/incidents/services/template_suggestions.py
+++ b/backend/app/incidents/services/template_suggestions.py
@@ -1,0 +1,945 @@
+"""
+Smart case-template suggestions (issue #935).
+
+Ranks the case templates already visible to an analyst against the context of
+the alert they are about to open a case for, so the common path is "accept the
+top suggestion" instead of "browse the whole library".
+
+**This module deliberately introduces no schema.** No table, no column, no
+Alembic migration. Every signal it scores on is derived from data that already
+exists:
+
+===================  ==========================================================
+Signal               Where it comes from
+===================  ==========================================================
+customer scope       ``CaseTemplate.customer_code`` vs the alert's
+source scope         ``CaseTemplate.source`` vs ``Alert.source``
+auto-apply condition ``CaseTemplate.match_field`` / ``match_value`` evaluated
+                     against the alert's originating document — the exact same
+                     check ``pick_templates_for_alert`` performs
+alert tags           ``incident_management_alert_to_tag`` → ``…_alerttag.tag``
+MITRE technique ids  ``incident_management_alertcontext.context`` (the ingest
+                     dictionary already stores ``rule_mitre_id`` and friends),
+                     falling back to the raw Wazuh document
+Wazuh rule groups    same context blob (``rule_groups``)
+alert title keywords ``Alert.alert_name``
+usage history        ``CaseTask.template_task_id`` → ``CaseTemplateTask`` →
+                     ``CaseTask.case_id`` → ``Case.customer_code``
+===================  ==========================================================
+
+The template side of every text comparison is a *corpus* built from the
+template's own name, description and task text (title + description +
+guidelines). That is what makes this work on day one: existing templates carry
+no tags or MITRE columns an operator would have to backfill, but a template
+called "Ransomware — host containment" whose tasks mention T1486 already says
+everything the scorer needs. Adding explicit metadata columns later would be a
+strictly better signal; it is not a precondition for the feature.
+
+Scoring is intentionally additive and explainable. Every point a template earns
+comes with a ``SuggestionReason`` naming the signal and the evidence, because a
+ranked list an analyst cannot audit is a ranked list an analyst will not trust.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+
+from loguru import logger
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.incidents.models import Alert
+from app.incidents.models import AlertContext
+from app.incidents.models import AlertTag
+from app.incidents.models import AlertToTag
+from app.incidents.models import Asset
+from app.incidents.models import Case
+from app.incidents.models import CaseTask
+from app.incidents.models import CaseTemplate
+from app.incidents.models import CaseTemplateTask
+from app.incidents.schema.case_templates import CaseTemplateSuggestion
+from app.incidents.schema.case_templates import CaseTemplateSuggestionListResponse
+from app.incidents.schema.case_templates import SuggestionReason
+from app.incidents.services.alert_severity import severity_of
+from app.incidents.services.case_templates import _template_to_response
+
+# ---------------------------------------------------------------------------
+# Weights
+#
+# Tunable in one place on purpose. The absolute numbers matter less than their
+# ratios; what they encode is:
+#
+#   - A satisfied auto-apply condition outranks everything, because it is not a
+#     heuristic — it is the operator's own explicit rule firing.
+#   - Explicit scope (this customer / this source) outranks inferred topical
+#     overlap, because scope was configured deliberately and text overlap was
+#     not.
+#   - Topical signals are capped so a template that happens to name six MITRE
+#     techniques cannot bulldoze a correctly-scoped one.
+# ---------------------------------------------------------------------------
+
+WEIGHT_CONDITION_MATCH = 40
+WEIGHT_CUSTOMER_MATCH = 25
+WEIGHT_SOURCE_MATCH = 20
+
+WEIGHT_TAG_MATCH = 10
+CAP_TAG_MATCH = 30
+
+WEIGHT_MITRE_MATCH = 15
+#: A template naming the parent technique (T1059) when the alert carries a
+#: sub-technique (T1059.001) is related but less precise. Partial credit.
+WEIGHT_MITRE_PARENT_MATCH = 7
+CAP_MITRE_MATCH = 30
+
+WEIGHT_RULE_GROUP_MATCH = 6
+CAP_RULE_GROUP_MATCH = 18
+
+WEIGHT_KEYWORD_MATCH = 4
+CAP_KEYWORD_MATCH = 12
+
+#: Usage history is a tiebreaker, not a driver — otherwise the template applied
+#: most often becomes self-reinforcing and nothing new ever surfaces. Log-scaled
+#: so the 40th application counts for far less than the 2nd.
+WEIGHT_USAGE_HISTORY_MAX = 12
+
+WEIGHT_IS_DEFAULT = 5
+
+#: Confidence buckets, reported alongside the raw score so the UI can style the
+#: top suggestion differently without hard-coding thresholds of its own.
+CONFIDENCE_HIGH_THRESHOLD = 55
+CONFIDENCE_MEDIUM_THRESHOLD = 25
+
+DEFAULT_SUGGESTION_LIMIT = 5
+
+# ---------------------------------------------------------------------------
+# Text handling
+# ---------------------------------------------------------------------------
+
+#: ``T1059`` / ``T1059.001``. Wazuh emits the bare technique id; templates tend
+#: to mention it inline in a task description ("…see T1486…").
+_MITRE_ID_PATTERN = re.compile(r"\bT\d{4}(?:\.\d{3})?\b", re.IGNORECASE)
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+#: Dropped from alert-title keyword extraction. Deliberately short: this is not
+#: a search engine, and an over-eager stoplist silently deletes signal. These
+#: are the words that appear in so many alert titles that matching on them tells
+#: us nothing about which playbook applies.
+_KEYWORD_STOPWORDS: Set[str] = {
+    "a",
+    "alert",
+    "an",
+    "and",
+    "at",
+    "by",
+    "detected",
+    "detection",
+    "event",
+    "for",
+    "from",
+    "has",
+    "in",
+    "is",
+    "of",
+    "on",
+    "or",
+    "possible",
+    "potential",
+    "rule",
+    "suspicious",
+    "the",
+    "to",
+    "was",
+    "with",
+}
+
+#: Wazuh tags every alert with a handful of structural groups that carry no
+#: topical meaning. Matching a template on "syslog" would fire on everything.
+_GENERIC_RULE_GROUPS: Set[str] = {
+    "attack",
+    "attacks",
+    "gdpr",
+    "gpg13",
+    "hipaa",
+    "ids",
+    "nist_800_53",
+    "pci_dss",
+    "sca",
+    "syscheck",
+    "syslog",
+    "tsc",
+    "wazuh",
+}
+
+#: Context keys inspected for Wazuh rule groups. The ingest dictionary is
+#: operator-configured, so which of these is actually present varies.
+_RULE_GROUP_KEYS = ("rule_groups", "rule_group", "rule.groups")
+
+#: Context keys inspected for MITRE display names (tactic / technique). The ids
+#: themselves are picked up by regex over every value, so these only add the
+#: human-readable side ("Command and Scripting Interpreter").
+_MITRE_NAME_KEYS = (
+    "rule_mitre_technique",
+    "rule_mitre_tactic",
+    "rule.mitre.technique",
+    "rule.mitre.tactic",
+)
+
+#: Minimum length for a token to be worth matching on. Two-character tokens
+#: ("ad", "ps") produce far more false positives than signal inside free text.
+_MIN_TOKEN_LENGTH = 3
+
+
+def _tokenize(text: str) -> List[str]:
+    return _TOKEN_PATTERN.findall(text.lower())
+
+
+def _as_string_list(value: Any) -> List[str]:
+    """Flatten a context value into a list of strings.
+
+    Ingest writes these blobs straight through from the source document, so the
+    same logical field arrives as a list on one deployment and a delimited
+    string on another. Handle both rather than guessing.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part for part in re.split(r"[,;|]", value) if part.strip()]
+    if isinstance(value, (list, tuple, set)):
+        out: List[str] = []
+        for item in value:
+            out.extend(_as_string_list(item))
+        return out
+    return [str(value)]
+
+
+def _flatten_values(value: Any, out: List[str]) -> None:
+    """Collect every scalar inside a nested context value as a string."""
+    if value is None:
+        return
+    if isinstance(value, dict):
+        for nested in value.values():
+            _flatten_values(nested, out)
+    elif isinstance(value, (list, tuple, set)):
+        for nested in value:
+            _flatten_values(nested, out)
+    else:
+        out.append(str(value))
+
+
+def _normalize_mitre_id(value: str) -> str:
+    return value.strip().upper()
+
+
+def _extract_mitre_ids(text: str) -> Set[str]:
+    return {_normalize_mitre_id(m) for m in _MITRE_ID_PATTERN.findall(text)}
+
+
+def _mitre_parent(technique_id: str) -> Optional[str]:
+    """``T1059.001`` → ``T1059``. Returns None for an already-parent id."""
+    if "." in technique_id:
+        return technique_id.split(".", 1)[0]
+    return None
+
+
+def _contains_phrase(corpus_tokens: Set[str], corpus_text: str, phrase: str) -> bool:
+    """Does ``corpus_text`` contain ``phrase`` as whole word(s)?
+
+    Alert tags and rule groups use every separator convention there is
+    (``lateral-movement``, ``lateral_movement``, ``LateralMovement``), so the
+    phrase is compared token-wise: a single token is a set membership test, a
+    multi-token phrase falls back to a whitespace-tolerant regex over the
+    normalized corpus so word order still has to match.
+    """
+    tokens = _tokenize(phrase)
+    tokens = [t for t in tokens if len(t) >= _MIN_TOKEN_LENGTH]
+    if not tokens:
+        return False
+    if len(tokens) == 1:
+        return tokens[0] in corpus_tokens
+    return re.search(r"\b" + r"\W+".join(re.escape(t) for t in tokens) + r"\b", corpus_text) is not None
+
+
+# ---------------------------------------------------------------------------
+# Signal extraction
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AlertSignals:
+    """Everything the scorer knows about the case-to-be.
+
+    Populated from an alert when one is supplied, or from bare
+    ``customer_code`` / ``source`` when the analyst is creating a case manually
+    and there is no alert to read. Both paths score through the same function;
+    the manual one simply has empty topical signals and therefore leans on
+    scope, usage history and ``is_default``.
+    """
+
+    customer_code: Optional[str] = None
+    source: Optional[str] = None
+    severity: Optional[str] = None
+    alert_id: Optional[int] = None
+    alert_name: Optional[str] = None
+    tags: List[str] = dataclass_field(default_factory=list)
+    mitre_ids: Set[str] = dataclass_field(default_factory=set)
+    mitre_names: List[str] = dataclass_field(default_factory=list)
+    rule_groups: List[str] = dataclass_field(default_factory=list)
+    keywords: List[str] = dataclass_field(default_factory=list)
+    #: Merged key/value bag used to evaluate ``match_field`` / ``match_value``.
+    #: Empty dict means "we could not read the document", which is scored
+    #: differently from "we read it and the condition was false".
+    document: Dict[str, Any] = dataclass_field(default_factory=dict)
+    document_available: bool = False
+
+
+async def _load_alert_tags(alert_id: int, session: AsyncSession) -> List[str]:
+    stmt = select(AlertTag.tag).join(AlertToTag, AlertToTag.tag_id == AlertTag.id).where(AlertToTag.alert_id == alert_id)
+    return [row for row in (await session.execute(stmt)).scalars().all() if row]
+
+
+async def _load_alert_context(alert_id: int, session: AsyncSession) -> Dict[str, Any]:
+    """Merge the stored context blobs of every asset on this alert.
+
+    ``incident_management_alertcontext`` is written at ingest from the
+    operator-configured field dictionary, so it is a local read — no OpenSearch
+    round-trip — and it is where ``rule_mitre_id`` already lives. An alert with
+    several assets normally has identical context on each; where they differ the
+    lowest asset id wins, matching ``_fetch_raw_event_for_alert``'s tie-break.
+    """
+    stmt = (
+        select(AlertContext.context)
+        .join(Asset, Asset.alert_context_id == AlertContext.id)
+        .where(Asset.alert_linked == alert_id)
+        .order_by(Asset.id.asc())
+    )
+    merged: Dict[str, Any] = {}
+    for context in (await session.execute(stmt)).scalars().all():
+        if not isinstance(context, dict):
+            continue
+        for key, value in context.items():
+            merged.setdefault(key, value)
+    return merged
+
+
+def _signals_from_document(signals: AlertSignals, document: Dict[str, Any]) -> None:
+    """Fold MITRE ids/names and rule groups out of a context/raw-event blob."""
+    for key in _MITRE_NAME_KEYS:
+        signals.mitre_names.extend(_as_string_list(document.get(key)))
+
+    for key in _RULE_GROUP_KEYS:
+        signals.rule_groups.extend(_as_string_list(document.get(key)))
+
+    # MITRE ids can be under any of several key spellings, and are sometimes
+    # only present inline in a description field. One regex sweep over every
+    # scalar in the blob catches all of them without a key allow-list that
+    # would need updating per source.
+    scalars: List[str] = []
+    _flatten_values(document, scalars)
+    for scalar in scalars:
+        signals.mitre_ids |= _extract_mitre_ids(scalar)
+
+
+async def build_alert_signals(
+    session: AsyncSession,
+    alert: Optional[Alert] = None,
+    customer_code: Optional[str] = None,
+    source: Optional[str] = None,
+) -> AlertSignals:
+    """Collect scoring signals for an alert, or for a bare customer/source pair.
+
+    Database reads only — tags plus the stored alert context. The raw
+    originating event is a separate, opt-in step (``enrich_with_raw_event``)
+    because it costs an indexer round-trip that most requests do not need.
+    """
+    signals = AlertSignals(
+        customer_code=customer_code,
+        source=source,
+    )
+
+    if alert is None:
+        return signals
+
+    signals.alert_id = alert.id
+    signals.alert_name = alert.alert_name
+    signals.customer_code = alert.customer_code
+    signals.source = alert.source
+    signals.severity = severity_of(alert)
+
+    signals.tags = await _load_alert_tags(alert.id, session)
+
+    context = await _load_alert_context(alert.id, session)
+    if context:
+        signals.document.update(context)
+        signals.document_available = True
+        _signals_from_document(signals, context)
+
+    signals.keywords = [
+        token
+        for token in dict.fromkeys(_tokenize(alert.alert_name or ""))
+        if len(token) >= _MIN_TOKEN_LENGTH and token not in _KEYWORD_STOPWORDS
+    ]
+
+    # De-duplicate while preserving order so the reasons read predictably.
+    signals.mitre_names = list(dict.fromkeys(n.strip() for n in signals.mitre_names if n.strip()))
+    signals.rule_groups = list(dict.fromkeys(g.strip() for g in signals.rule_groups if g.strip()))
+
+    return signals
+
+
+def unresolved_condition_fields(
+    templates: Iterable[CaseTemplate],
+    signals: AlertSignals,
+) -> List[str]:
+    """Which conditional ``match_field``s the stored context cannot settle.
+
+    The stored alert context is a projection of the originating document
+    through the operator's ingest field dictionary, so a template keyed on a
+    field that dictionary drops is unresolvable from the database alone. Those
+    — and only those — justify the indexer round-trip.
+    """
+    return sorted(
+        {t.match_field for t in templates if t.match_field and t.match_value and t.match_field not in signals.document},
+    )
+
+
+async def enrich_with_raw_event(
+    signals: AlertSignals,
+    alert: Alert,
+    session: AsyncSession,
+) -> AlertSignals:
+    """Merge the raw originating Wazuh document into ``signals``, in place.
+
+    Reuses ``case_tasks._fetch_raw_event_for_alert`` rather than reimplementing
+    the asset → (index_name, index_id) lookup, so suggestions read exactly the
+    document auto-apply would evaluate against. That helper swallows its own
+    failures and returns None, which leaves ``document_available`` as whatever
+    the stored context set it to — the "unknown condition" state.
+    """
+    # Lazy import: case_tasks does not import this module today, but both are
+    # service-layer modules in the same package and a module-level edge here is
+    # exactly the shape that trips circular-import resolution later.
+    from app.incidents.services.case_tasks import _fetch_raw_event_for_alert
+
+    raw_event = await _fetch_raw_event_for_alert(alert, session)
+    if not raw_event:
+        return signals
+
+    # Raw document wins on conflict — the stored context is a lossy projection
+    # of it, so where they disagree the raw side is the more complete value.
+    signals.document.update(raw_event)
+    signals.document_available = True
+    _signals_from_document(signals, raw_event)
+
+    signals.mitre_names = list(dict.fromkeys(n.strip() for n in signals.mitre_names if n.strip()))
+    signals.rule_groups = list(dict.fromkeys(g.strip() for g in signals.rule_groups if g.strip()))
+    return signals
+
+
+# ---------------------------------------------------------------------------
+# Template corpus
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TemplateCorpus:
+    """The searchable text of a template, precomputed once per scoring run."""
+
+    text: str
+    tokens: Set[str]
+    mitre_ids: Set[str]
+
+
+def build_template_corpus(template: CaseTemplate) -> TemplateCorpus:
+    """Flatten a template's own words into something matchable.
+
+    Task text is included, not just the template's name and description,
+    because that is where the specifics live — a template named "Endpoint
+    triage" whose tasks talk about ransomware and T1486 should rank on an
+    encryption alert.
+    """
+    parts: List[str] = [template.name or "", template.description or ""]
+    for task in template.tasks or []:
+        parts.extend([task.title or "", task.description or "", task.guidelines or ""])
+
+    text = " ".join(p for p in parts if p).lower()
+    return TemplateCorpus(
+        text=text,
+        tokens=set(_tokenize(text)),
+        mitre_ids=_extract_mitre_ids(text),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Usage history
+# ---------------------------------------------------------------------------
+
+
+async def load_usage_counts(
+    session: AsyncSession,
+    customer_code: Optional[str],
+) -> Dict[int, int]:
+    """How many distinct cases each template has been applied to.
+
+    Counted through ``CaseTask.template_task_id`` rather than the
+    ``template_applied`` timeline event, for two reasons: the join is plain
+    relational SQL that behaves identically on MySQL and the SQLite fallback
+    (``CaseEvent.payload`` is a JSON column and extracting from it is
+    dialect-specific), and it measures templates whose tasks actually landed on
+    a case rather than apply calls that added nothing.
+
+    Scoped to ``customer_code`` when given — "what this customer's analysts
+    reach for" is the useful signal; a deployment-wide count would just rank the
+    biggest tenant's habits first. Templates whose source tasks have since been
+    deleted drop out of the join; that is acceptable for a tiebreaker.
+    """
+    stmt = (
+        select(CaseTemplateTask.template_id, func.count(func.distinct(CaseTask.case_id)))
+        .join(CaseTask, CaseTask.template_task_id == CaseTemplateTask.id)
+        .group_by(CaseTemplateTask.template_id)
+    )
+    if customer_code:
+        stmt = stmt.join(Case, Case.id == CaseTask.case_id).where(Case.customer_code == customer_code)
+
+    try:
+        rows = (await session.execute(stmt)).all()
+    except Exception as e:  # pragma: no cover - defensive; history is optional
+        logger.warning(f"template suggestions: usage-history lookup failed, scoring without it: {e}")
+        return {}
+
+    return {template_id: count for template_id, count in rows if template_id is not None}
+
+
+def _usage_points(count: int) -> int:
+    """Log-scaled usage bonus, clamped to ``WEIGHT_USAGE_HISTORY_MAX``.
+
+    ``log2(1 + count)`` reaches the cap around 8 applications, so a template
+    used twice is meaningfully ahead of one never used, and one used fifty times
+    is not meaningfully ahead of one used ten times.
+    """
+    if count <= 0:
+        return 0
+    return min(WEIGHT_USAGE_HISTORY_MAX, int(round(4 * math.log2(1 + count))))
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _confidence_for(score: int) -> str:
+    if score >= CONFIDENCE_HIGH_THRESHOLD:
+        return "high"
+    if score >= CONFIDENCE_MEDIUM_THRESHOLD:
+        return "medium"
+    return "low"
+
+
+def _evaluate_condition(template: CaseTemplate, signals: AlertSignals) -> Optional[bool]:
+    """Does this template's auto-apply condition hold?
+
+    Returns True/False when the document was readable, and None when it was not
+    — "unknown" is a third outcome the caller must not collapse into False, or
+    a transient indexer outage would hide every conditional template.
+
+    The comparison mirrors ``pick_templates_for_alert`` exactly, including the
+    ``str()`` coercion: Wazuh quotes numeric top-level fields already, but not
+    every source does.
+    """
+    if not template.match_field or not template.match_value:
+        return None
+    if not signals.document_available:
+        return None
+
+    doc_value = signals.document.get(template.match_field)
+    if doc_value is None:
+        return False
+    return str(doc_value) == template.match_value
+
+
+def _score_scope(
+    template: CaseTemplate,
+    signals: AlertSignals,
+    reasons: List[SuggestionReason],
+) -> int:
+    score = 0
+    if template.customer_code and signals.customer_code and template.customer_code == signals.customer_code:
+        score += WEIGHT_CUSTOMER_MATCH
+        reasons.append(
+            SuggestionReason(
+                signal="customer",
+                detail=f"Scoped to customer {template.customer_code}",
+                points=WEIGHT_CUSTOMER_MATCH,
+            ),
+        )
+    if template.source and signals.source and template.source == signals.source:
+        score += WEIGHT_SOURCE_MATCH
+        reasons.append(
+            SuggestionReason(
+                signal="source",
+                detail=f"Scoped to {template.source} alerts",
+                points=WEIGHT_SOURCE_MATCH,
+            ),
+        )
+    return score
+
+
+def _score_tags(
+    corpus: TemplateCorpus,
+    signals: AlertSignals,
+    reasons: List[SuggestionReason],
+) -> int:
+    """Alert tags matched against the template's own words.
+
+    A tag that *is* a MITRE id is routed to the MITRE corpus instead of the text
+    one — analysts do tag alerts ``T1566`` — so it matches a template that
+    mentions the technique even if the literal string sits inside a sentence.
+    """
+    score = 0
+    matched: List[str] = []
+    for tag in signals.tags:
+        mitre_in_tag = _extract_mitre_ids(tag)
+        if mitre_in_tag:
+            if mitre_in_tag & corpus.mitre_ids:
+                matched.append(tag)
+            continue
+        if _contains_phrase(corpus.tokens, corpus.text, tag):
+            matched.append(tag)
+
+    if matched:
+        score = min(CAP_TAG_MATCH, WEIGHT_TAG_MATCH * len(matched))
+        reasons.append(
+            SuggestionReason(
+                signal="tag",
+                detail=f"Matches alert tag(s): {', '.join(matched)}",
+                points=score,
+            ),
+        )
+    return score
+
+
+def _score_mitre(
+    corpus: TemplateCorpus,
+    signals: AlertSignals,
+    reasons: List[SuggestionReason],
+) -> int:
+    exact = sorted(signals.mitre_ids & corpus.mitre_ids)
+
+    # Parent credit only for sub-techniques whose parent is named by the
+    # template and whose exact id is not — otherwise T1059.001 would be counted
+    # twice against a template naming both.
+    parents: List[Tuple[str, str]] = []
+    for technique_id in sorted(signals.mitre_ids):
+        if technique_id in corpus.mitre_ids:
+            continue
+        parent = _mitre_parent(technique_id)
+        if parent and parent in corpus.mitre_ids:
+            parents.append((technique_id, parent))
+
+    raw = WEIGHT_MITRE_MATCH * len(exact) + WEIGHT_MITRE_PARENT_MATCH * len(parents)
+    score = min(CAP_MITRE_MATCH, raw)
+
+    if exact:
+        reasons.append(
+            SuggestionReason(
+                signal="mitre",
+                detail=f"Covers MITRE technique(s): {', '.join(exact)}",
+                points=min(CAP_MITRE_MATCH, WEIGHT_MITRE_MATCH * len(exact)),
+            ),
+        )
+    if parents and score > 0:
+        detail = ", ".join(f"{child} → {parent}" for child, parent in parents)
+        reasons.append(
+            SuggestionReason(
+                signal="mitre_parent",
+                detail=f"Covers the parent technique of: {detail}",
+                points=max(0, score - min(CAP_MITRE_MATCH, WEIGHT_MITRE_MATCH * len(exact))),
+            ),
+        )
+
+    # Technique / tactic display names are matched as plain text; they add no
+    # points of their own (the ids already scored) but they do explain a match
+    # to a reader who does not have the ATT&CK catalogue memorised.
+    if not exact and not parents:
+        named = [name for name in signals.mitre_names if _contains_phrase(corpus.tokens, corpus.text, name)]
+        if named:
+            score = min(CAP_MITRE_MATCH, WEIGHT_MITRE_PARENT_MATCH * len(named))
+            reasons.append(
+                SuggestionReason(
+                    signal="mitre_name",
+                    detail=f"Mentions MITRE technique(s): {', '.join(named)}",
+                    points=score,
+                ),
+            )
+
+    return score
+
+
+def _score_rule_groups(
+    corpus: TemplateCorpus,
+    signals: AlertSignals,
+    reasons: List[SuggestionReason],
+) -> int:
+    matched = [
+        group
+        for group in signals.rule_groups
+        if group.lower() not in _GENERIC_RULE_GROUPS and _contains_phrase(corpus.tokens, corpus.text, group)
+    ]
+    if not matched:
+        return 0
+    score = min(CAP_RULE_GROUP_MATCH, WEIGHT_RULE_GROUP_MATCH * len(matched))
+    reasons.append(
+        SuggestionReason(
+            signal="rule_group",
+            detail=f"Matches rule group(s): {', '.join(matched)}",
+            points=score,
+        ),
+    )
+    return score
+
+
+def _score_keywords(
+    corpus: TemplateCorpus,
+    signals: AlertSignals,
+    reasons: List[SuggestionReason],
+) -> int:
+    matched = [keyword for keyword in signals.keywords if keyword in corpus.tokens]
+    if not matched:
+        return 0
+    score = min(CAP_KEYWORD_MATCH, WEIGHT_KEYWORD_MATCH * len(matched))
+    reasons.append(
+        SuggestionReason(
+            signal="keyword",
+            detail=f"Alert title mentions: {', '.join(matched)}",
+            points=score,
+        ),
+    )
+    return score
+
+
+def score_template(
+    template: CaseTemplate,
+    signals: AlertSignals,
+    usage_counts: Dict[int, int],
+    *,
+    corpus: Optional[TemplateCorpus] = None,
+) -> Tuple[int, List[SuggestionReason], Optional[bool]]:
+    """Score one template. Returns ``(score, reasons, condition_result)``.
+
+    ``condition_result`` is passed back so the caller can drop templates whose
+    auto-apply condition was evaluated and failed — that is a filtering
+    decision, not a scoring one.
+    """
+    corpus = corpus or build_template_corpus(template)
+    reasons: List[SuggestionReason] = []
+    score = 0
+
+    condition_result = _evaluate_condition(template, signals)
+    if condition_result is True:
+        score += WEIGHT_CONDITION_MATCH
+        reasons.append(
+            SuggestionReason(
+                signal="condition",
+                detail=f"Auto-apply condition matches ({template.match_field} = {template.match_value})",
+                points=WEIGHT_CONDITION_MATCH,
+            ),
+        )
+    elif condition_result is None and template.match_field:
+        reasons.append(
+            SuggestionReason(
+                signal="condition_unverified",
+                detail=(f"Auto-apply condition on {template.match_field} could not be checked — " "the originating event was not readable"),
+                points=0,
+            ),
+        )
+
+    score += _score_scope(template, signals, reasons)
+    score += _score_tags(corpus, signals, reasons)
+    score += _score_mitre(corpus, signals, reasons)
+    score += _score_rule_groups(corpus, signals, reasons)
+    score += _score_keywords(corpus, signals, reasons)
+
+    usage = usage_counts.get(template.id, 0)
+    usage_points = _usage_points(usage)
+    if usage_points:
+        score += usage_points
+        scope = f" for {signals.customer_code}" if signals.customer_code else ""
+        reasons.append(
+            SuggestionReason(
+                signal="usage",
+                detail=f"Applied to {usage} case(s){scope}",
+                points=usage_points,
+            ),
+        )
+
+    if template.is_default:
+        score += WEIGHT_IS_DEFAULT
+        reasons.append(
+            SuggestionReason(
+                signal="default",
+                detail="Default template for its scope",
+                points=WEIGHT_IS_DEFAULT,
+            ),
+        )
+
+    return score, reasons, condition_result
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection
+# ---------------------------------------------------------------------------
+
+
+def _in_scope(template: CaseTemplate, signals: AlertSignals) -> bool:
+    """Is this template even applicable?
+
+    Scope is a hard filter, not a penalty: a template pinned to customer B must
+    never be offered on customer A's alert regardless of how well its text
+    matches. Templates left NULL (global / any-source) always pass.
+
+    A ``source`` filter is only applied when we know the alert's source. During
+    manual case creation we do not, so every template stays a candidate and the
+    source dimension simply contributes no points.
+    """
+    if template.customer_code and signals.customer_code and template.customer_code != signals.customer_code:
+        return False
+    if template.customer_code and not signals.customer_code:
+        # Customer-scoped template, no customer context: cannot confirm it
+        # applies. Excluding is the conservative side of the trade.
+        return False
+    if template.source and signals.source and template.source != signals.source:
+        return False
+    return True
+
+
+async def _load_candidate_templates(session: AsyncSession) -> List[CaseTemplate]:
+    stmt = select(CaseTemplate).options(selectinload(CaseTemplate.tasks))
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def suggest_templates(
+    session: AsyncSession,
+    *,
+    alert_id: Optional[int] = None,
+    customer_code: Optional[str] = None,
+    source: Optional[str] = None,
+    limit: int = DEFAULT_SUGGESTION_LIMIT,
+) -> CaseTemplateSuggestionListResponse:
+    """Rank templates for the case an analyst is about to open.
+
+    Two entry contexts, one code path:
+
+    - **From an alert** (``alert_id``) — full topical scoring. ``customer_code``
+      and ``source`` are taken from the alert itself; anything passed by the
+      caller is ignored, because the alert is the authority on its own scope.
+    - **Manual creation** (``customer_code`` and/or ``source``) — scope, usage
+      history and ``is_default`` only. Still useful: it is the same ordering the
+      analyst would get from the tier picker, but explained.
+
+    Never raises for a missing alert or an empty template set — this feeds a
+    panel that renders beside a form, and a failed suggestion lookup must not
+    block case creation. Failures come back as ``success=False`` with an empty
+    list.
+    """
+    try:
+        alert: Optional[Alert] = None
+        if alert_id is not None:
+            alert = (await session.execute(select(Alert).where(Alert.id == alert_id))).scalars().first()
+            if alert is None:
+                return CaseTemplateSuggestionListResponse(
+                    suggestions=[],
+                    success=False,
+                    message=f"Alert id={alert_id} not found",
+                )
+
+        # Signals first, from the database only. Scope filtering and scoring
+        # then both read this one object, so they can never disagree about
+        # which customer or source the case belongs to.
+        signals = await build_alert_signals(
+            session,
+            alert=alert,
+            customer_code=customer_code,
+            source=source,
+        )
+
+        templates = await _load_candidate_templates(session)
+        candidates = [t for t in templates if _in_scope(t, signals)]
+
+        # Only pay for the indexer round-trip when an in-scope conditional
+        # template keys on a field the stored context does not already carry.
+        if alert is not None:
+            unresolved = unresolved_condition_fields(candidates, signals)
+            if unresolved:
+                logger.debug(
+                    f"template suggestions: fetching raw event for alert id={alert.id} to settle " f"condition field(s) {unresolved}",
+                )
+                signals = await enrich_with_raw_event(signals, alert, session)
+
+        usage_counts = await load_usage_counts(session, signals.customer_code)
+
+        suggestions: List[CaseTemplateSuggestion] = []
+        for template in candidates:
+            score, reasons, condition_result = score_template(template, signals, usage_counts)
+
+            # A condition we checked and that came back false is the operator
+            # saying "not this one". Drop it rather than ranking it low —
+            # showing it invites an analyst to override a rule deliberately set.
+            if condition_result is False:
+                continue
+
+            suggestions.append(
+                CaseTemplateSuggestion(
+                    # Reuse the list/CRUD serializer rather than validating the
+                    # ORM row directly: it sorts tasks by order_index, which is
+                    # the order the preview has to show them in.
+                    template=_template_to_response(template),
+                    score=score,
+                    confidence=_confidence_for(score),
+                    reasons=sorted(reasons, key=lambda r: r.points, reverse=True),
+                ),
+            )
+
+        # Ties broken by is_default then name, so repeated calls return a stable
+        # order — a list that reshuffles between renders reads as broken.
+        suggestions.sort(key=lambda s: (-s.score, not s.template.is_default, s.template.name.lower()))
+        top = suggestions[: max(0, limit)] if limit else suggestions
+
+        return CaseTemplateSuggestionListResponse(
+            suggestions=top,
+            total_candidates=len(suggestions),
+            success=True,
+            message=f"Ranked {len(suggestions)} applicable template(s)",
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to build case template suggestions: {e}")
+        return CaseTemplateSuggestionListResponse(
+            suggestions=[],
+            success=False,
+            message=f"Failed to build case template suggestions: {e}",
+        )
+
+
+__all__ = (
+    "AlertSignals",
+    "TemplateCorpus",
+    "build_alert_signals",
+    "build_template_corpus",
+    "enrich_with_raw_event",
+    "load_usage_counts",
+    "score_template",
+    "suggest_templates",
+    "unresolved_condition_fields",
+)

--- a/backend/tests/e2e/case_template_suggestions_e2e.py
+++ b/backend/tests/e2e/case_template_suggestions_e2e.py
@@ -1,0 +1,467 @@
+"""E2E per #935 — NON raccolto da pytest (serve un MySQL vivo); si lancia a mano.
+
+    docker run -d --name copilot-e2e-mysql -p 13306:3306 \
+        -e MYSQL_ROOT_PASSWORD=e2eroot -e MYSQL_DATABASE=copilot \
+        -e MYSQL_USER=copilot -e MYSQL_PASSWORD=e2epass mysql:8.0
+
+    cd backend && export MYSQL_URL=127.0.0.1:13306 MYSQL_USER=copilot \
+        MYSQL_PASSWORD=e2epass MYSQL_ROOT_PASSWORD=e2eroot \
+        JWT_SECRET=e2e-test-secret-not-the-default PYTHONPATH=$PWD
+    .venv/bin/python -c "from app.db.db_setup import apply_migrations; apply_migrations()"
+    .venv/bin/python tests/e2e/case_template_suggestions_e2e.py
+
+Oppure dentro l'immagine di produzione, che verifica in più che il codice
+importi e giri nell'artefatto realmente deployato:
+
+    cd backend && docker build -t copilot-backend:e2e-935 .
+    docker run --rm --add-host=host.docker.internal:host-gateway \
+        -e MYSQL_URL=host.docker.internal:13306 -e MYSQL_USER=copilot \
+        -e MYSQL_PASSWORD=e2epass -e MYSQL_ROOT_PASSWORD=e2eroot \
+        -e JWT_SECRET=e2e-test-secret-not-the-default \
+        -e PYTHONPATH=/opt/copilot/backend \
+        copilot-backend:e2e-935 python tests/e2e/case_template_suggestions_e2e.py
+
+Punta a un'istanza usa-e-getta sulla porta 13306: mai al MySQL della .env.
+
+I unit test di ``tests/test_case_template_suggestions.py`` girano su sessioni
+mockate, quindi non eseguono una sola riga di SQL. Questo script copre proprio
+ciò che quelli non possono:
+
+  1. La query di usage-history — ``COUNT(DISTINCT case_id)`` su un join a tre
+     tavole con GROUP BY — gira davvero su MySQL.
+  2. Il join AlertContext → Asset che estrae MITRE e rule groups legge righe
+     vere, non un dict finto.
+  3. La riga ORM ``CaseTemplate`` (con i task caricati via ``selectinload``)
+     si serializza davvero in ``CaseTemplateResponse`` annidato — è esattamente
+     il punto in cui Pydantic 2 fallisce quando manca ``from_attributes``.
+  4. La rotta ``/suggest`` è raggiungibile e non viene inghiottita dal
+     wildcard ``/{template_id}`` una volta montata sull'app reale.
+  5. Lo scope guard admin/analyst è applicato dal router vero.
+
+Verifica le assunzioni portanti:
+  A) ranking end-to-end su un alert vero (tag + MITRE + scope)
+  B) isolamento tenant: il template di un altro cliente non compare mai
+  C) condizione auto-apply che fallisce -> template escluso
+  D) usage-history calcolata da SQL reale e limitata al cliente
+  E) percorso manuale (customer_code, nessun alert)
+  F) i reason sommano allo score, sui dati veri
+"""
+
+import asyncio
+import datetime
+import os
+
+os.environ.setdefault("MYSQL_URL", "127.0.0.1:13306")
+os.environ.setdefault("MYSQL_USER", "copilot")
+os.environ.setdefault("MYSQL_PASSWORD", "e2epass")
+os.environ.setdefault("MYSQL_ROOT_PASSWORD", "e2eroot")
+os.environ.setdefault("JWT_SECRET", "e2e-test-secret-not-the-default")
+
+import httpx  # noqa: E402
+from fastapi import APIRouter  # noqa: E402
+from fastapi import FastAPI
+from sqlalchemy import delete  # noqa: E402
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+
+from app.auth.models.users import Role  # noqa: E402
+from app.auth.models.users import User
+from app.auth.utils import AuthHandler  # noqa: E402
+from app.db.db_session import async_engine  # noqa: E402
+from app.db.universal_models import Customers  # noqa: E402
+from app.incidents.models import Alert  # noqa: E402
+from app.incidents.models import AlertContext
+from app.incidents.models import AlertTag
+from app.incidents.models import AlertToTag
+from app.incidents.models import Asset
+from app.incidents.models import Case
+from app.incidents.models import CaseTask
+from app.incidents.models import CaseTemplate
+from app.incidents.models import CaseTemplateTask
+
+PASSWORD = "E2ePassw0rd!x"
+CUST_A, CUST_B = "E2E935_A", "E2E935_B"
+ANALYST = "e2e935_analyst"
+
+NOW = datetime.datetime(2026, 1, 1)
+results = []
+
+# Marcatore su ogni riga creata qui, così la pulizia non tocca dati veri se
+# per errore qualcuno punta lo script a un DB popolato.
+TAG_PREFIX = "e2e935_"
+
+
+def check(name, passed, detail=""):
+    results.append((name, passed, detail))
+    print(f"  {'PASS' if passed else 'FAIL'}  {name}" + (f"  [{detail}]" if detail else ""))
+
+
+async def _purge(s):
+    """Pulizia da run precedenti, dai figli verso i padri."""
+    tmpl_ids = list(
+        (await s.execute(select(CaseTemplate.id).where(CaseTemplate.name.like(f"{TAG_PREFIX}%")))).scalars().all(),
+    )
+    case_ids = list((await s.execute(select(Case.id).where(Case.customer_code.in_([CUST_A, CUST_B])))).scalars().all())
+    alert_ids = list((await s.execute(select(Alert.id).where(Alert.customer_code.in_([CUST_A, CUST_B])))).scalars().all())
+
+    if case_ids:
+        await s.execute(delete(CaseTask).where(CaseTask.case_id.in_(case_ids)))
+    if tmpl_ids:
+        await s.execute(delete(CaseTemplateTask).where(CaseTemplateTask.template_id.in_(tmpl_ids)))
+        await s.execute(delete(CaseTemplate).where(CaseTemplate.id.in_(tmpl_ids)))
+    if case_ids:
+        await s.execute(delete(Case).where(Case.id.in_(case_ids)))
+    if alert_ids:
+        await s.execute(delete(AlertToTag).where(AlertToTag.alert_id.in_(alert_ids)))
+        await s.execute(delete(Asset).where(Asset.alert_linked.in_(alert_ids)))
+        await s.execute(delete(Alert).where(Alert.id.in_(alert_ids)))
+    await s.execute(delete(AlertTag).where(AlertTag.tag.like(f"{TAG_PREFIX}%")))
+    await s.commit()
+
+
+async def seed():
+    """Un alert ransomware su CUST_A + cinque template che coprono ogni caso.
+
+    ``expire_on_commit=False``: il seed fa molte commit di fila e poi riusa gli
+    id degli oggetti già inseriti (``AlertToTag(alert_id=alert.id, ...)``). Col
+    default, ogni commit scade gli attributi e il primo accesso successivo
+    tenta un refresh sincrono dentro un contesto async — cioè il
+    ``MissingGreenlet`` descritto in CLAUDE.md.
+    """
+    auth = AuthHandler()
+    async with AsyncSession(async_engine, expire_on_commit=False) as s:
+        for rid, rname in [(1, "admin"), (2, "analyst"), (3, "scheduler"), (4, "customer_user")]:
+            if not (await s.execute(select(Role).where(Role.id == rid))).scalars().first():
+                s.add(Role(id=rid, name=rname, description=rname))
+        await s.commit()
+
+        await _purge(s)
+
+        u = (await s.execute(select(User).where(User.username == ANALYST))).scalars().first()
+        if u:
+            await s.delete(u)
+            await s.commit()
+
+        for code in (CUST_A, CUST_B):
+            c = (await s.execute(select(Customers).where(Customers.customer_code == code))).scalars().first()
+            if not c:
+                s.add(
+                    Customers(
+                        customer_code=code,
+                        customer_name=f"Customer {code}",
+                        contact_first_name="E2E",
+                        contact_last_name="Tester",
+                        phone="000",
+                        address_line1="a",
+                        address_line2="b",
+                        city="c",
+                        state="d",
+                        postal_code="1",
+                        country="IT",
+                        customer_type="MSSP",
+                        logo_file="",
+                    ),
+                )
+        await s.commit()
+
+        s.add(User(username=ANALYST, password=auth.get_password_hash(PASSWORD), email=f"{ANALYST}@e2e.local", role_id=2))
+        await s.commit()
+
+        # --- alert con tag + contesto MITRE ------------------------------
+        alert = Alert(
+            alert_name="Ransomware encryption behaviour on FILESRV01",
+            alert_description="Mass file rename detected",
+            status="OPEN",
+            alert_creation_time=NOW,
+            customer_code=CUST_A,
+            source="wazuh",
+            severity="Critical",
+            assigned_to=None,
+            escalated=False,
+        )
+        s.add(alert)
+        await s.commit()
+        await s.refresh(alert)
+
+        tag = AlertTag(tag=f"{TAG_PREFIX}ransomware")
+        s.add(tag)
+        await s.commit()
+        await s.refresh(tag)
+        s.add(AlertToTag(alert_id=alert.id, tag_id=tag.id))
+
+        # Il contesto è ciò che l'ingest scrive davvero: chiavi piatte, valori
+        # eterogenei (lista per il MITRE, stringa delimitata per i gruppi).
+        ctx = AlertContext(
+            source="wazuh",
+            context={
+                "rule_mitre_id": ["T1486"],
+                "rule_mitre_technique": "Data Encrypted for Impact",
+                # 'ransomware' deve matchare il testo del template, 'syslog' è
+                # nella stoplist dei gruppi generici, 'windows' non compare nel
+                # corpus: i tre casi in una riga sola.
+                "rule_groups": "windows,ransomware,syslog",
+                "data_win_system_eventID": "11",
+                "rule_id": "554",
+            },
+        )
+        s.add(ctx)
+        await s.commit()
+        await s.refresh(ctx)
+
+        s.add(
+            Asset(
+                alert_linked=alert.id,
+                asset_name="FILESRV01",
+                alert_context_id=ctx.id,
+                agent_id="e2e935-1",
+                velociraptor_id="",
+                customer_code=CUST_A,
+                index_name="wazuh-alerts-4.x-e2e",
+                index_id="e2e935doc",
+            ),
+        )
+        await s.commit()
+
+        # --- template ----------------------------------------------------
+        def tmpl(name, **kw):
+            kw.setdefault("customer_code", None)
+            kw.setdefault("source", None)
+            kw.setdefault("is_default", False)
+            kw.setdefault("match_field", None)
+            kw.setdefault("match_value", None)
+            return CaseTemplate(name=name, created_by="e2e", created_at=NOW, updated_at=NOW, **kw)
+
+        # 1. il bersaglio: cliente + source giusti, testo che parla di T1486
+        target = tmpl(
+            f"{TAG_PREFIX}Ransomware containment",
+            description="Contain encrypting hosts",
+            customer_code=CUST_A,
+            source="wazuh",
+        )
+        # 2. altro tenant, testo identico: non deve MAI comparire
+        other_tenant = tmpl(
+            f"{TAG_PREFIX}Ransomware containment (other tenant)",
+            description="Contain encrypting hosts, T1486",
+            customer_code=CUST_B,
+            source="wazuh",
+        )
+        # 3. globale generico, usato spesso in passato -> prova usage-history
+        generic = tmpl(f"{TAG_PREFIX}Generic triage", description="Baseline checks")
+        # 4. condizionale che NON matcha (eventID 11 != 4688) -> va escluso
+        cond_fail = tmpl(
+            f"{TAG_PREFIX}Process creation deep dive",
+            source="wazuh",
+            match_field="data_win_system_eventID",
+            match_value="4688",
+        )
+        # 5. condizionale che matcha -> deve vincere
+        cond_ok = tmpl(
+            f"{TAG_PREFIX}File create deep dive",
+            source="wazuh",
+            match_field="data_win_system_eventID",
+            match_value="11",
+        )
+        for t in (target, other_tenant, generic, cond_fail, cond_ok):
+            s.add(t)
+        await s.commit()
+        for t in (target, other_tenant, generic, cond_fail, cond_ok):
+            await s.refresh(t)
+
+        s.add(CaseTemplateTask(template_id=target.id, title="Isolate the host", order_index=0, mandatory=True))
+        s.add(
+            CaseTemplateTask(
+                template_id=target.id,
+                title="Identify encryption scope",
+                description="Ransomware payload analysis",
+                guidelines="Maps to T1486 Data Encrypted for Impact",
+                order_index=1,
+            ),
+        )
+        # Volutamente fuori ordine: il preview deve riordinarli per order_index.
+        s.add(CaseTemplateTask(template_id=generic.id, title="Second step", order_index=1))
+        s.add(CaseTemplateTask(template_id=generic.id, title="First step", order_index=0))
+        await s.commit()
+
+        # --- usage-history: 3 case su CUST_A usano 'generic' -------------
+        gen_task = (await s.execute(select(CaseTemplateTask).where(CaseTemplateTask.template_id == generic.id).limit(1))).scalars().first()
+        for i in range(3):
+            c = Case(
+                case_name=f"{TAG_PREFIX}case {i}",
+                case_description="x",
+                case_creation_time=NOW,
+                case_status="OPEN",
+                customer_code=CUST_A,
+                escalated=False,
+            )
+            s.add(c)
+            await s.commit()
+            await s.refresh(c)
+            s.add(
+                CaseTask(
+                    case_id=c.id,
+                    template_task_id=gen_task.id,
+                    title="First step",
+                    mandatory=False,
+                    order_index=0,
+                    status="TODO",
+                    created_by="e2e",
+                    created_at=NOW,
+                    updated_at=NOW,
+                ),
+            )
+        await s.commit()
+
+        print(
+            f"seed: alert #{alert.id} su {CUST_A} (tag ransomware, T1486), "
+            f"5 template, 3 case storici sul template 'generic' (#{generic.id})",
+        )
+        return {
+            "alert_id": alert.id,
+            "target": target.id,
+            "other_tenant": other_tenant.id,
+            "generic": generic.id,
+            "cond_fail": cond_fail.id,
+            "cond_ok": cond_ok.id,
+        }
+
+
+def build_app():
+    """Monta il router reale senza gli hook di startup (MinIO/connettori)."""
+    from app.incidents.routes.case_templates import case_templates_router
+
+    api = APIRouter()
+    api.include_router(case_templates_router, prefix="/incidents/case_templates", tags=["incidents-case-templates"])
+    app = FastAPI()
+    app.include_router(api)
+    return app
+
+
+async def main():
+    ids = await seed()
+    app = build_app()
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://e2e", timeout=30) as client:
+        token = await AuthHandler().encode_token(ANALYST)
+        H = {"Authorization": f"Bearer {token}"}
+
+        print("\n=== A) ranking da un alert vero ===")
+        r = await client.get(f"/incidents/case_templates/suggest?alert_id={ids['alert_id']}&limit=10", headers=H)
+        ok = r.status_code == 200 and r.json().get("success") is True
+        check("GET /suggest -> 200 success", ok, f"{r.status_code} {r.text[:160]}")
+        if not ok:
+            return summary()
+
+        body = r.json()
+        got = [s["template"]["id"] for s in body["suggestions"]]
+        by_id = {s["template"]["id"]: s for s in body["suggestions"]}
+
+        check(
+            "la rotta /suggest non è inghiottita da /{template_id}",
+            "suggestions" in body,
+            f"chiavi={sorted(body)}",
+        )
+        # Il condizionale che matcha deve stare in cima ANCHE se un altro
+        # template segna di più: è la partizione che tiene il pannello
+        # d'accordo con pick_templates_for_alert.
+        check(
+            "il condizionale che matcha (eventID=11) è in cima, pur segnando meno",
+            got and got[0] == ids["cond_ok"],
+            f"ordine={got} score={[(s['template']['id'], s['score']) for s in body['suggestions']]}",
+        )
+        check(
+            "condition_matched esposto solo sul template la cui condizione ha sparato",
+            [s["template"]["id"] for s in body["suggestions"] if s["condition_matched"]] == [ids["cond_ok"]],
+            str([(s["template"]["id"], s["condition_matched"]) for s in body["suggestions"]]),
+        )
+        check(
+            "il template mirato (cliente+source+T1486) è suggerito",
+            ids["target"] in got,
+            f"ordine={got}",
+        )
+
+        print("\n=== B) isolamento tenant ===")
+        check(
+            "il template di un ALTRO cliente non compare mai",
+            ids["other_tenant"] not in got,
+            f"ordine={got}",
+        )
+
+        print("\n=== C) condizione auto-apply fallita ===")
+        check(
+            "il condizionale che NON matcha (eventID=4688) è escluso",
+            ids["cond_fail"] not in got,
+            f"ordine={got}",
+        )
+
+        print("\n=== D) usage-history da SQL reale ===")
+        gen = by_id.get(ids["generic"])
+        usage_reasons = [x for x in (gen or {}).get("reasons", []) if x["signal"] == "usage"]
+        check(
+            "COUNT(DISTINCT case_id) conta i 3 case storici",
+            bool(usage_reasons) and "3 case(s)" in usage_reasons[0]["detail"],
+            f"reasons={[x['detail'] for x in (gen or {}).get('reasons', [])]}",
+        )
+
+        print("\n=== E) segnali estratti da righe vere ===")
+        tgt = by_id.get(ids["target"], {})
+        signals = {x["signal"] for x in tgt.get("reasons", [])}
+        check("scope cliente riconosciuto", "customer" in signals, f"segnali={sorted(signals)}")
+        check("scope source riconosciuto", "source" in signals, f"segnali={sorted(signals)}")
+        check(
+            "MITRE T1486 estratto dal contesto e trovato nel testo dei task",
+            "mitre" in signals,
+            f"segnali={sorted(signals)}",
+        )
+        check(
+            "rule group non generico riconosciuto (syslog scartato)",
+            "rule_group" in signals,
+            f"segnali={sorted(signals)}",
+        )
+
+        print("\n=== F) serializzazione ORM -> Pydantic annidato ===")
+        gen_tasks = [t["title"] for t in (gen or {}).get("template", {}).get("tasks", [])]
+        check(
+            "i task arrivano col preview e ordinati per order_index",
+            gen_tasks == ["First step", "Second step"],
+            f"tasks={gen_tasks}",
+        )
+        check(
+            "i reason sommano allo score, su dati veri",
+            all(sum(x["points"] for x in s["reasons"]) == s["score"] for s in body["suggestions"]),
+            str([(s["template"]["id"], s["score"], sum(x["points"] for x in s["reasons"])) for s in body["suggestions"]]),
+        )
+
+        print("\n=== G) percorso manuale (nessun alert) ===")
+        r2 = await client.get(f"/incidents/case_templates/suggest?customer_code={CUST_A}&limit=10", headers=H)
+        ok2 = r2.status_code == 200 and r2.json().get("success") is True
+        check("GET /suggest?customer_code -> 200 success", ok2, f"{r2.status_code} {r2.text[:160]}")
+        if ok2:
+            got2 = [s["template"]["id"] for s in r2.json()["suggestions"]]
+            check("anche qui l'altro tenant è escluso", ids["other_tenant"] not in got2, f"ordine={got2}")
+            check(
+                "i condizionali restano visibili (documento non leggibile = ignoto)",
+                ids["cond_ok"] in got2,
+                f"ordine={got2}",
+            )
+
+        print("\n=== H) scope guard del router reale ===")
+        r3 = await client.get(f"/incidents/case_templates/suggest?customer_code={CUST_A}")
+        check("senza token -> 401/403", r3.status_code in (401, 403), str(r3.status_code))
+
+    # Senza dispose, aiomysql chiude le connessioni nel __del__ a loop già
+    # chiuso e sporca l'output con RuntimeError che non sono fallimenti.
+    await async_engine.dispose()
+    return summary()
+
+
+def summary():
+    failed = [r for r in results if not r[1]]
+    print(f"\n{'=' * 60}\n{len(results) - len(failed)}/{len(results)} PASS")
+    for name, _, detail in failed:
+        print(f"  FAIL: {name}  [{detail}]")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/e2e/seed_suggestion_demo.py
+++ b/backend/tests/e2e/seed_suggestion_demo.py
@@ -1,0 +1,273 @@
+"""Seed di dati dimostrativi per provare a mano i suggerimenti template (#935).
+
+Serve a rendere il test manuale possibile: senza template che parlino di
+ransomware/MITRE e senza un alert taggato, il pannello mostra (correttamente)
+lo stato vuoto e sembra rotto.
+
+Crea, sul DB a cui punta la tua ``.env``:
+  - il cliente DEMO935 (se manca)
+  - un alert Wazuh "ransomware" con tag + contesto MITRE T1486
+  - 4 template che coprono i casi interessanti: mirato, condizionale che spara,
+    condizionale che NON spara, generico con storico d'uso
+  - 2 case storici, per far comparire il segnale "usage"
+
+USO
+    cd backend
+    .venv/bin/python tests/e2e/seed_suggestion_demo.py          # crea
+    .venv/bin/python tests/e2e/seed_suggestion_demo.py --purge  # rimuove tutto
+
+Tutte le righe sono marcate col prefisso ``demo935_`` (e cliente ``DEMO935``),
+quindi ``--purge`` non tocca nient'altro. Lo script è idempotente: rilanciarlo
+ripulisce e ricrea, così non accumula duplicati.
+
+NB: scrive sul database della tua ``.env``. È pensato per un ambiente di
+sviluppo, non per una installazione di produzione.
+"""
+
+import argparse
+import asyncio
+import datetime
+import sys
+
+from sqlalchemy import delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.db_session import async_engine
+from app.db.universal_models import Customers
+from app.incidents.models import Alert
+from app.incidents.models import AlertContext
+from app.incidents.models import AlertTag
+from app.incidents.models import AlertToTag
+from app.incidents.models import Asset
+from app.incidents.models import Case
+from app.incidents.models import CaseTask
+from app.incidents.models import CaseTemplate
+from app.incidents.models import CaseTemplateTask
+
+CUSTOMER = "DEMO935"
+PREFIX = "demo935_"
+NOW = datetime.datetime.utcnow()
+
+
+async def purge(s: AsyncSession) -> None:
+    """Rimuove solo ciò che questo script crea, dai figli verso i padri."""
+    tmpl_ids = list((await s.execute(select(CaseTemplate.id).where(CaseTemplate.name.like(f"{PREFIX}%")))).scalars().all())
+    case_ids = list((await s.execute(select(Case.id).where(Case.customer_code == CUSTOMER))).scalars().all())
+    alert_ids = list((await s.execute(select(Alert.id).where(Alert.customer_code == CUSTOMER))).scalars().all())
+
+    if case_ids:
+        await s.execute(delete(CaseTask).where(CaseTask.case_id.in_(case_ids)))
+    if tmpl_ids:
+        await s.execute(delete(CaseTemplateTask).where(CaseTemplateTask.template_id.in_(tmpl_ids)))
+        await s.execute(delete(CaseTemplate).where(CaseTemplate.id.in_(tmpl_ids)))
+    if case_ids:
+        await s.execute(delete(Case).where(Case.id.in_(case_ids)))
+    if alert_ids:
+        await s.execute(delete(AlertToTag).where(AlertToTag.alert_id.in_(alert_ids)))
+        await s.execute(delete(Asset).where(Asset.alert_linked.in_(alert_ids)))
+        await s.execute(delete(Alert).where(Alert.id.in_(alert_ids)))
+    await s.execute(delete(AlertTag).where(AlertTag.tag.like(f"{PREFIX}%")))
+    await s.commit()
+
+
+async def seed(s: AsyncSession) -> dict:
+    if not (await s.execute(select(Customers).where(Customers.customer_code == CUSTOMER))).scalars().first():
+        s.add(
+            Customers(
+                customer_code=CUSTOMER,
+                customer_name="Demo 935 (suggerimenti template)",
+                contact_first_name="Demo",
+                contact_last_name="935",
+                phone="000",
+                address_line1="a",
+                address_line2="b",
+                city="c",
+                state="d",
+                postal_code="1",
+                country="IT",
+                customer_type="MSSP",
+                logo_file="",
+            ),
+        )
+        await s.commit()
+
+    alert = Alert(
+        alert_name="Ransomware encryption behaviour on FILESRV01",
+        alert_description="Mass file rename with known extension, possible encryption in progress",
+        status="OPEN",
+        alert_creation_time=NOW,
+        customer_code=CUSTOMER,
+        source="wazuh",
+        severity="Critical",
+        escalated=False,
+    )
+    s.add(alert)
+    await s.commit()
+
+    tag = AlertTag(tag=f"{PREFIX}ransomware")
+    s.add(tag)
+    await s.commit()
+    s.add(AlertToTag(alert_id=alert.id, tag_id=tag.id))
+
+    ctx = AlertContext(
+        source="wazuh",
+        context={
+            "rule_mitre_id": ["T1486"],
+            "rule_mitre_technique": "Data Encrypted for Impact",
+            "rule_groups": "windows,ransomware,syslog",
+            "data_win_system_eventID": "11",
+            "rule_id": "554",
+            "rule_level": "12",
+        },
+    )
+    s.add(ctx)
+    await s.commit()
+
+    s.add(
+        Asset(
+            alert_linked=alert.id,
+            asset_name="FILESRV01",
+            alert_context_id=ctx.id,
+            agent_id="demo935-1",
+            velociraptor_id="",
+            customer_code=CUSTOMER,
+            index_name="wazuh-alerts-4.x-demo",
+            index_id="demo935doc",
+        ),
+    )
+    await s.commit()
+
+    def tmpl(name, **kw):
+        kw.setdefault("customer_code", None)
+        kw.setdefault("source", None)
+        kw.setdefault("is_default", False)
+        kw.setdefault("match_field", None)
+        kw.setdefault("match_value", None)
+        return CaseTemplate(name=name, created_by="demo-seed", created_at=NOW, updated_at=NOW, **kw)
+
+    targeted = tmpl(
+        f"{PREFIX}Ransomware containment",
+        description="Contain an encrypting host and preserve evidence",
+        customer_code=CUSTOMER,
+        source="wazuh",
+    )
+    cond_ok = tmpl(
+        f"{PREFIX}Sysmon file-create deep dive",
+        description="Applies only when the Sysmon event is a file creation (eventID 11)",
+        source="wazuh",
+        match_field="data_win_system_eventID",
+        match_value="11",
+    )
+    cond_fail = tmpl(
+        f"{PREFIX}Sysmon process-create deep dive",
+        description="Applies only to process creation (eventID 4688) — should NOT be suggested here",
+        source="wazuh",
+        match_field="data_win_system_eventID",
+        match_value="4688",
+    )
+    generic = tmpl(f"{PREFIX}Generic triage", description="Baseline checks for any alert", is_default=True)
+
+    for t in (targeted, cond_ok, cond_fail, generic):
+        s.add(t)
+    await s.commit()
+
+    s.add(CaseTemplateTask(template_id=targeted.id, title="Isolate the affected host", order_index=0, mandatory=True))
+    s.add(
+        CaseTemplateTask(
+            template_id=targeted.id,
+            title="Identify the encryption scope",
+            description="Ransomware payload and blast-radius analysis",
+            guidelines="Maps to MITRE T1486 (Data Encrypted for Impact). List encrypted shares before restoring.",
+            order_index=1,
+            mandatory=True,
+        ),
+    )
+    s.add(CaseTemplateTask(template_id=targeted.id, title="Notify the customer", order_index=2))
+    s.add(CaseTemplateTask(template_id=cond_ok.id, title="Review the created file and its parent process", order_index=0))
+    s.add(CaseTemplateTask(template_id=cond_fail.id, title="Review the command line", order_index=0))
+    s.add(CaseTemplateTask(template_id=generic.id, title="Confirm the alert is not a false positive", order_index=0))
+    s.add(CaseTemplateTask(template_id=generic.id, title="Document the findings", order_index=1))
+    await s.commit()
+
+    # Storico d'uso: 2 case che hanno già applicato il template generico, così
+    # nel pannello compare il segnale "Applied to 2 case(s) for DEMO935".
+    gen_task = (await s.execute(select(CaseTemplateTask).where(CaseTemplateTask.template_id == generic.id).limit(1))).scalars().first()
+    for i in range(2):
+        c = Case(
+            case_name=f"{PREFIX}historic case {i + 1}",
+            case_description="Seeded to demonstrate the usage-history signal",
+            case_creation_time=NOW,
+            case_status="CLOSED",
+            customer_code=CUSTOMER,
+            escalated=False,
+        )
+        s.add(c)
+        await s.commit()
+        s.add(
+            CaseTask(
+                case_id=c.id,
+                template_task_id=gen_task.id,
+                title=gen_task.title,
+                mandatory=False,
+                order_index=0,
+                status="DONE",
+                created_by="demo-seed",
+                created_at=NOW,
+                updated_at=NOW,
+            ),
+        )
+    await s.commit()
+
+    return {
+        "alert_id": alert.id,
+        "targeted": targeted.id,
+        "cond_ok": cond_ok.id,
+        "cond_fail": cond_fail.id,
+        "generic": generic.id,
+    }
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed/purge demo data for case-template suggestions (#935)")
+    parser.add_argument("--purge", action="store_true", help="rimuove i dati demo ed esce")
+    args = parser.parse_args()
+
+    # expire_on_commit=False: il seed riusa gli id dopo ogni commit e col
+    # default scatterebbe un refresh sincrono in contesto async
+    # (MissingGreenlet, vedi CLAUDE.md).
+    async with AsyncSession(async_engine, expire_on_commit=False) as s:
+        await purge(s)
+        if args.purge:
+            print(f"Dati demo rimossi (cliente {CUSTOMER}, prefisso {PREFIX}).")
+            await async_engine.dispose()
+            return 0
+
+        ids = await seed(s)
+
+    await async_engine.dispose()
+    print(
+        "\n".join(
+            [
+                "",
+                f"Seed completato sul cliente {CUSTOMER}.",
+                "",
+                f"  Alert da aprire in UI: #{ids['alert_id']}  (Incident Management -> Alerts, filtra per customer {CUSTOMER})",
+                "",
+                "  Template creati:",
+                f"    #{ids['cond_ok']:<4} Sysmon file-create deep dive   <- condizione SPARA (eventID 11): deve stare in CIMA",
+                f"    #{ids['targeted']:<4} Ransomware containment         <- punteggio più alto, ma sotto al condizionale",
+                f"    #{ids['generic']:<4} Generic triage                 <- mostra il segnale 'usage' (2 case)",
+                f"    #{ids['cond_fail']:<4} Sysmon process-create deep dive <- condizione NON spara: NON deve comparire",
+                "",
+                "Ora apri l'alert e premi 'Create case'.",
+                "Per rimuovere tutto:  .venv/bin/python tests/e2e/seed_suggestion_demo.py --purge",
+                "",
+            ],
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/tests/test_case_template_suggestions.py
+++ b/backend/tests/test_case_template_suggestions.py
@@ -1,0 +1,590 @@
+"""Smart case-template suggestion ranking (issue #935).
+
+The suggestion endpoint is advisory — it cannot corrupt anything — so what
+these tests protect is not data integrity but *trust*: an analyst who is shown
+a ranked list has to be able to rely on it. Concretely they pin:
+
+- **Scope is a hard filter, never a penalty.** A template pinned to customer B
+  must not surface on customer A's alert no matter how well its text matches.
+  Getting this wrong leaks one tenant's playbook into another's console.
+- **A checked-and-failed auto-apply condition drops the template.** The
+  operator wrote that condition to mean "not this one"; ranking it low instead
+  of removing it invites an analyst to override a deliberate rule. But an
+  *unreadable* document is a third outcome — a transient indexer outage must
+  not silently hide every conditional template.
+- **The reasons sum to the score.** The UI renders reason chips as the
+  explanation for the ranking; if they don't add up, the explanation is a lie.
+- **Ordering is stable.** A list that reshuffles between renders reads as
+  broken even when every score is right.
+
+Unit tests with mocked sessions — no real DB, no indexer.
+
+Run with: cd backend && python -m pytest tests/test_case_template_suggestions.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.incidents.services.template_suggestions as svc  # noqa: E402
+from app.incidents.services.template_suggestions import AlertSignals  # noqa: E402
+
+NOW = datetime(2026, 1, 1, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures-as-builders
+# ---------------------------------------------------------------------------
+
+
+def _task(title, description=None, guidelines=None, order_index=0, task_id=1):
+    return SimpleNamespace(
+        id=task_id,
+        template_id=1,
+        title=title,
+        description=description,
+        guidelines=guidelines,
+        mandatory=False,
+        order_index=order_index,
+    )
+
+
+def _template(
+    template_id=1,
+    name="Generic triage",
+    description=None,
+    customer_code=None,
+    source=None,
+    is_default=False,
+    match_field=None,
+    match_value=None,
+    tasks=None,
+):
+    return SimpleNamespace(
+        id=template_id,
+        name=name,
+        description=description,
+        customer_code=customer_code,
+        source=source,
+        is_default=is_default,
+        match_field=match_field,
+        match_value=match_value,
+        created_by="admin",
+        created_at=NOW,
+        updated_at=NOW,
+        tasks=tasks if tasks is not None else [],
+    )
+
+
+def _signals(**kwargs):
+    kwargs.setdefault("customer_code", "ACME")
+    kwargs.setdefault("source", "wazuh")
+    return AlertSignals(**kwargs)
+
+
+def _score(template, signals=None, usage=None):
+    """Score one template, returning (score, reasons, condition_result)."""
+    return svc.score_template(template, signals or _signals(), usage or {})
+
+
+def _signal_keys(reasons):
+    return {r.signal for r in reasons}
+
+
+# ---------------------------------------------------------------------------
+# Scope filtering — the tenancy-relevant half
+# ---------------------------------------------------------------------------
+
+
+def test_template_for_another_customer_is_out_of_scope():
+    """The leak case. A well-matching template still must not cross tenants."""
+    template = _template(customer_code="OTHERCO", name="Ransomware containment")
+    assert svc._in_scope(template, _signals(customer_code="ACME")) is False
+
+
+def test_global_template_is_in_scope_for_every_customer():
+    assert svc._in_scope(_template(customer_code=None), _signals(customer_code="ACME")) is True
+
+
+def test_customer_scoped_template_excluded_without_customer_context():
+    """Manual creation before a customer is picked: we cannot confirm it applies."""
+    template = _template(customer_code="ACME")
+    assert svc._in_scope(template, AlertSignals(customer_code=None, source=None)) is False
+
+
+def test_source_mismatch_is_out_of_scope():
+    template = _template(source="office365")
+    assert svc._in_scope(template, _signals(source="wazuh")) is False
+
+
+def test_source_scoped_template_stays_in_scope_when_source_unknown():
+    """Manual creation has no alert source; the dimension just scores nothing."""
+    template = _template(source="wazuh")
+    assert svc._in_scope(template, AlertSignals(customer_code="ACME", source=None)) is True
+
+
+def test_scope_matches_award_their_weights():
+    template = _template(customer_code="ACME", source="wazuh")
+    score, reasons, _ = _score(template)
+    assert score == svc.WEIGHT_CUSTOMER_MATCH + svc.WEIGHT_SOURCE_MATCH
+    assert _signal_keys(reasons) == {"customer", "source"}
+
+
+# ---------------------------------------------------------------------------
+# Auto-apply conditions
+# ---------------------------------------------------------------------------
+
+
+def test_satisfied_condition_scores_and_survives():
+    template = _template(match_field="data_win_system_eventID", match_value="1")
+    signals = _signals(document={"data_win_system_eventID": "1"}, document_available=True)
+    score, reasons, condition = _score(template, signals)
+
+    assert condition is True
+    assert score >= svc.WEIGHT_CONDITION_MATCH
+    assert "condition" in _signal_keys(reasons)
+
+
+def test_failed_condition_is_reported_so_the_caller_can_drop_it():
+    template = _template(match_field="data_win_system_eventID", match_value="1")
+    signals = _signals(document={"data_win_system_eventID": "4688"}, document_available=True)
+    _, _, condition = _score(template, signals)
+    assert condition is False
+
+
+def test_absent_field_counts_as_a_failed_condition():
+    """The field the operator keyed on simply isn't on this event."""
+    template = _template(match_field="data_win_system_eventID", match_value="1")
+    signals = _signals(document={"rule_id": "5710"}, document_available=True)
+    _, _, condition = _score(template, signals)
+    assert condition is False
+
+
+def test_unreadable_document_leaves_the_condition_unknown_not_false():
+    """An indexer outage must not silently hide every conditional template."""
+    template = _template(match_field="data_win_system_eventID", match_value="1")
+    signals = _signals(document={}, document_available=False)
+    score, reasons, condition = _score(template, signals)
+
+    assert condition is None
+    assert "condition_unverified" in _signal_keys(reasons)
+    # Unverified earns nothing — it explains, it does not promote. (The template
+    # here is global/any-source, so scope contributes nothing either.)
+    assert score == 0
+
+
+def test_numeric_document_values_are_coerced_like_the_auto_apply_path():
+    """Not every source quotes its numerics the way Wazuh does."""
+    template = _template(match_field="event_id", match_value="4625")
+    signals = _signals(document={"event_id": 4625}, document_available=True)
+    _, _, condition = _score(template, signals)
+    assert condition is True
+
+
+def test_suggest_drops_templates_whose_condition_was_checked_and_failed():
+    templates = [
+        _template(template_id=1, name="Sysmon proc create", match_field="event_id", match_value="1"),
+        _template(template_id=2, name="Generic triage"),
+    ]
+    response = _run_suggest(
+        templates=templates,
+        signals=_signals(document={"event_id": "4688"}, document_available=True),
+    )
+    assert [s.template.id for s in response.suggestions] == [2]
+
+
+def test_suggest_keeps_conditional_templates_when_the_document_is_unreadable():
+    templates = [_template(template_id=1, name="Sysmon proc create", match_field="event_id", match_value="1")]
+    response = _run_suggest(
+        templates=templates,
+        signals=_signals(document={}, document_available=False),
+    )
+    assert [s.template.id for s in response.suggestions] == [1]
+
+
+# ---------------------------------------------------------------------------
+# Topical signals
+# ---------------------------------------------------------------------------
+
+
+def test_alert_tag_matches_template_task_text():
+    """Task text is part of the corpus — that's where the specifics live."""
+    template = _template(
+        name="Endpoint triage",
+        tasks=[_task("Isolate host", description="Suspected ransomware encryption activity")],
+    )
+    score, reasons, _ = _score(template, _signals(tags=["ransomware"]))
+    assert score == svc.WEIGHT_TAG_MATCH
+    assert "tag" in _signal_keys(reasons)
+
+
+def test_tag_separators_are_normalised():
+    """``lateral-movement`` and ``lateral movement`` are the same tag."""
+    template = _template(name="Lateral movement playbook")
+    score, _, _ = _score(template, _signals(tags=["lateral-movement"]))
+    assert score == svc.WEIGHT_TAG_MATCH
+
+
+def test_multi_word_tag_requires_word_order():
+    template = _template(name="Movement lateral of files")
+    score, _, _ = _score(template, _signals(tags=["lateral movement"]))
+    assert score == 0
+
+
+def test_tag_scoring_is_capped():
+    template = _template(name="phishing ransomware exfiltration persistence privilege")
+    tags = ["phishing", "ransomware", "exfiltration", "persistence", "privilege"]
+    score, reasons, _ = _score(template, _signals(tags=tags))
+    assert score == svc.CAP_TAG_MATCH
+    assert next(r for r in reasons if r.signal == "tag").points == svc.CAP_TAG_MATCH
+
+
+def test_a_mitre_id_tag_is_matched_against_the_technique_corpus():
+    """Analysts do tag alerts ``T1566`` — route those to MITRE, not free text."""
+    template = _template(
+        name="Phishing response",
+        tasks=[_task("Review mail", description="Covers T1566 phishing delivery")],
+    )
+    score, reasons, _ = _score(template, _signals(tags=["T1566"]))
+    assert "tag" in _signal_keys(reasons)
+    assert score >= svc.WEIGHT_TAG_MATCH
+
+
+def test_exact_mitre_technique_match():
+    template = _template(name="Script interpreter abuse", description="Handles T1059.001")
+    score, reasons, _ = _score(template, _signals(mitre_ids={"T1059.001"}))
+    assert score == svc.WEIGHT_MITRE_MATCH
+    assert "mitre" in _signal_keys(reasons)
+
+
+def test_parent_technique_earns_partial_credit_only():
+    """T1059 named by the template, T1059.001 on the alert: related, less precise."""
+    template = _template(name="Command interpreter abuse", description="Handles T1059")
+    score, reasons, _ = _score(template, _signals(mitre_ids={"T1059.001"}))
+    assert score == svc.WEIGHT_MITRE_PARENT_MATCH
+    assert "mitre_parent" in _signal_keys(reasons)
+    assert svc.WEIGHT_MITRE_PARENT_MATCH < svc.WEIGHT_MITRE_MATCH
+
+
+def test_parent_credit_is_not_double_counted_with_an_exact_match():
+    template = _template(description="Handles T1059 and T1059.001")
+    score, _, _ = _score(template, _signals(mitre_ids={"T1059.001"}))
+    assert score == svc.WEIGHT_MITRE_MATCH
+
+
+def test_mitre_display_names_match_when_no_id_does():
+    template = _template(name="Command and Scripting Interpreter response")
+    score, reasons, _ = _score(
+        template,
+        _signals(mitre_names=["Command and Scripting Interpreter"]),
+    )
+    assert score == svc.WEIGHT_MITRE_PARENT_MATCH
+    assert "mitre_name" in _signal_keys(reasons)
+
+
+def test_mitre_ids_are_case_insensitive():
+    template = _template(description="covers t1486")
+    score, _, _ = _score(template, _signals(mitre_ids={"T1486"}))
+    assert score == svc.WEIGHT_MITRE_MATCH
+
+
+def test_generic_rule_groups_are_ignored():
+    """Matching on ``syslog`` or ``pci_dss`` would fire on everything."""
+    template = _template(name="Syslog and pci_dss and wazuh review")
+    score, _, _ = _score(template, _signals(rule_groups=["syslog", "pci_dss", "wazuh"]))
+    assert score == 0
+
+
+def test_meaningful_rule_group_scores():
+    template = _template(name="Windows authentication failures")
+    score, reasons, _ = _score(template, _signals(rule_groups=["authentication_failures"]))
+    assert score == svc.WEIGHT_RULE_GROUP_MATCH
+    assert "rule_group" in _signal_keys(reasons)
+
+
+def test_alert_title_stopwords_do_not_score():
+    """ "suspicious", "detected", "rule" appear in half of all alert titles."""
+    template = _template(name="Suspicious activity detected rule")
+    signals = _signals(keywords=[])  # what build_alert_signals would produce
+    score, _, _ = _score(template, signals)
+    assert score == 0
+
+
+def test_title_keyword_match_scores():
+    template = _template(name="Mimikatz credential dumping")
+    score, reasons, _ = _score(template, _signals(keywords=["mimikatz"]))
+    assert score == svc.WEIGHT_KEYWORD_MATCH
+    assert "keyword" in _signal_keys(reasons)
+
+
+# ---------------------------------------------------------------------------
+# Usage history and defaults
+# ---------------------------------------------------------------------------
+
+
+def test_usage_points_are_log_scaled_and_capped():
+    assert svc._usage_points(0) == 0
+    assert svc._usage_points(1) > 0
+    assert svc._usage_points(2) > svc._usage_points(1)
+    assert svc._usage_points(50) == svc.WEIGHT_USAGE_HISTORY_MAX
+    # Diminishing returns is the whole point: without it the most-applied
+    # template becomes self-reinforcing and nothing new ever surfaces.
+    assert (svc._usage_points(6) - svc._usage_points(5)) < (svc._usage_points(2) - svc._usage_points(1))
+
+
+def test_usage_history_never_outranks_scope():
+    """A heavily-used global template must not beat a correctly-scoped one."""
+    heavily_used = _template(template_id=1, name="Everything template")
+    scoped = _template(template_id=2, name="Scoped", customer_code="ACME", source="wazuh")
+
+    used_score, _, _ = _score(heavily_used, usage={1: 500})
+    scoped_score, _, _ = _score(scoped, usage={})
+    assert scoped_score > used_score
+
+
+def test_default_flag_contributes_its_weight():
+    score, reasons, _ = _score(_template(is_default=True))
+    assert score == svc.WEIGHT_IS_DEFAULT
+    assert "default" in _signal_keys(reasons)
+
+
+# ---------------------------------------------------------------------------
+# Explainability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "template,signals",
+    [
+        (
+            _template(customer_code="ACME", source="wazuh", is_default=True, description="T1486 ransomware"),
+            _signals(tags=["ransomware"], mitre_ids={"T1486"}, keywords=["ransomware"]),
+        ),
+        (
+            _template(name="Phishing", tasks=[_task("Check headers", guidelines="T1566.001 delivery")]),
+            _signals(tags=["phishing"], mitre_ids={"T1566.001"}, rule_groups=["email"]),
+        ),
+        (
+            _template(match_field="event_id", match_value="1", name="Sysmon"),
+            _signals(document={"event_id": "1"}, document_available=True, tags=["sysmon"]),
+        ),
+    ],
+)
+def test_reasons_always_sum_to_the_score(template, signals):
+    """The UI shows reasons as *the* explanation. They have to add up."""
+    score, reasons, _ = _score(template, signals, usage={template.id: 4})
+    assert sum(r.points for r in reasons) == score
+
+
+def test_confidence_buckets_track_the_thresholds():
+    assert svc._confidence_for(svc.CONFIDENCE_HIGH_THRESHOLD) == "high"
+    assert svc._confidence_for(svc.CONFIDENCE_HIGH_THRESHOLD - 1) == "medium"
+    assert svc._confidence_for(svc.CONFIDENCE_MEDIUM_THRESHOLD) == "medium"
+    assert svc._confidence_for(svc.CONFIDENCE_MEDIUM_THRESHOLD - 1) == "low"
+
+
+# ---------------------------------------------------------------------------
+# The endpoint service
+# ---------------------------------------------------------------------------
+
+
+def _run_suggest(templates, signals, usage=None, limit=5, alert=None, **kwargs):
+    """Drive suggest_templates with every DB read stubbed out.
+
+    ``build_alert_signals`` is replaced wholesale, so the ``signals`` passed in
+    is the single object both scope filtering and scoring see — which is
+    exactly the invariant the production code now holds.
+    """
+    session = AsyncMock()
+
+    # The only unstubbed session.execute left is the alert lookup.
+    result = SimpleNamespace(scalars=lambda: SimpleNamespace(first=lambda: alert))
+    session.execute = AsyncMock(return_value=result)
+
+    async def _fake_signals(*_args, **_kwargs):
+        return signals
+
+    async def _fake_usage(*_args, **_kwargs):
+        return usage or {}
+
+    with (
+        patch.object(svc, "_load_candidate_templates", AsyncMock(return_value=templates)),
+        patch.object(svc, "build_alert_signals", _fake_signals),
+        patch.object(svc, "load_usage_counts", _fake_usage),
+        patch.object(svc, "enrich_with_raw_event", AsyncMock(return_value=signals)),
+    ):
+        return asyncio.run(
+            svc.suggest_templates(session=session, limit=limit, **kwargs),
+        )
+
+
+def test_suggestions_are_ranked_best_first():
+    templates = [
+        _template(template_id=1, name="Generic triage"),
+        _template(template_id=2, name="Ransomware containment", customer_code="ACME", source="wazuh"),
+        _template(template_id=3, name="Phishing response"),
+    ]
+    response = _run_suggest(templates=templates, signals=_signals(tags=["ransomware"]))
+
+    assert response.success is True
+    assert response.suggestions[0].template.id == 2
+    assert response.total_candidates == 3
+
+
+def test_out_of_scope_templates_never_reach_the_response():
+    templates = [
+        _template(template_id=1, name="Other tenant ransomware", customer_code="OTHERCO"),
+        _template(template_id=2, name="Generic triage"),
+    ]
+    response = _run_suggest(templates=templates, signals=_signals(tags=["ransomware"]))
+    assert [s.template.id for s in response.suggestions] == [2]
+
+
+def test_limit_trims_the_list_but_total_candidates_reports_the_truth():
+    templates = [_template(template_id=i, name=f"Template {i}") for i in range(1, 8)]
+    response = _run_suggest(templates=templates, signals=_signals(), limit=3)
+    assert len(response.suggestions) == 3
+    assert response.total_candidates == 7
+
+
+def test_ordering_is_stable_across_identical_scores():
+    """Ties break on is_default then name, so renders don't reshuffle."""
+    templates = [
+        _template(template_id=1, name="Zebra"),
+        _template(template_id=2, name="Alpha"),
+        _template(template_id=3, name="Middle", is_default=False),
+    ]
+    first = _run_suggest(templates=templates, signals=_signals())
+    second = _run_suggest(templates=list(reversed(templates)), signals=_signals())
+    assert [s.template.id for s in first.suggestions] == [s.template.id for s in second.suggestions]
+    assert [s.template.name for s in first.suggestions] == ["Alpha", "Middle", "Zebra"]
+
+
+def test_default_wins_a_tie_against_a_non_default():
+    templates = [
+        _template(template_id=1, name="Alpha"),
+        _template(template_id=2, name="Zebra", is_default=True),
+    ]
+    response = _run_suggest(templates=templates, signals=_signals())
+    assert response.suggestions[0].template.id == 2
+
+
+def test_suggestion_carries_the_full_task_list_for_the_preview():
+    """One round-trip: the preview must not need a second call per suggestion."""
+    templates = [
+        _template(
+            template_id=1,
+            tasks=[
+                _task("Second", order_index=1, task_id=20),
+                _task("First", order_index=0, task_id=10),
+            ],
+        ),
+    ]
+    response = _run_suggest(templates=templates, signals=_signals())
+    titles = [t.title for t in response.suggestions[0].template.tasks]
+    assert titles == ["First", "Second"]
+
+
+def test_missing_alert_reports_failure_without_raising():
+    response = _run_suggest(templates=[], signals=_signals(), alert=None, alert_id=999)
+    assert response.success is False
+    assert "not found" in response.message
+
+
+def test_a_lookup_failure_degrades_instead_of_blocking_case_creation():
+    """This feeds a panel beside a form. It must never take the form down."""
+    session = AsyncMock()
+    with patch.object(svc, "_load_candidate_templates", AsyncMock(side_effect=RuntimeError("db down"))):
+        response = asyncio.run(svc.suggest_templates(session=session))
+
+    assert response.success is False
+    assert response.suggestions == []
+
+
+def test_manual_creation_path_still_ranks_on_scope_and_defaults():
+    """No alert: topical signals are empty, scope and default still order things."""
+    templates = [
+        _template(template_id=1, name="Global fallback", is_default=True),
+        _template(template_id=2, name="ACME playbook", customer_code="ACME"),
+    ]
+    response = _run_suggest(
+        templates=templates,
+        signals=AlertSignals(customer_code="ACME", source=None),
+        customer_code="ACME",
+    )
+    assert response.suggestions[0].template.id == 2
+
+
+# ---------------------------------------------------------------------------
+# Corpus + context extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_includes_name_description_and_all_task_text():
+    template = _template(
+        name="Alpha",
+        description="Beta",
+        tasks=[_task("Gamma", description="Delta", guidelines="Epsilon T1005")],
+    )
+    corpus = svc.build_template_corpus(template)
+    for token in ("alpha", "beta", "gamma", "delta", "epsilon"):
+        assert token in corpus.tokens
+    assert corpus.mitre_ids == {"T1005"}
+
+
+def test_context_values_are_flattened_regardless_of_shape():
+    """Ingest writes these blobs straight through; shape varies by deployment."""
+    signals = AlertSignals()
+    svc._signals_from_document(signals, {"rule_groups": "windows,sysmon", "rule_mitre_id": ["T1059", "T1055"]})
+    assert set(signals.rule_groups) == {"windows", "sysmon"}
+    assert signals.mitre_ids == {"T1059", "T1055"}
+
+
+def test_mitre_ids_are_found_even_when_only_inline_in_a_description():
+    signals = AlertSignals()
+    svc._signals_from_document(signals, {"rule_description": "Mimikatz detected (T1003.001)"})
+    assert signals.mitre_ids == {"T1003.001"}
+
+
+def test_no_indexer_call_when_the_stored_context_settles_every_condition():
+    """The round-trip is the expensive part; the DB usually already has the field."""
+    templates = [_template(match_field="event_id", match_value="1")]
+    signals = _signals(document={"event_id": "1"}, document_available=True)
+    assert svc.unresolved_condition_fields(templates, signals) == []
+
+
+def test_indexer_call_is_gated_on_fields_the_ingest_dictionary_dropped():
+    templates = [
+        _template(template_id=1, match_field="data_win_eventdata_image", match_value="x"),
+        _template(template_id=2, match_field="event_id", match_value="1"),
+        _template(template_id=3),  # unconditional — never justifies a fetch
+    ]
+    signals = _signals(document={"event_id": "1"}, document_available=True)
+    assert svc.unresolved_condition_fields(templates, signals) == ["data_win_eventdata_image"]
+
+
+def test_half_set_match_pairs_never_trigger_a_fetch():
+    """A match_field with no match_value is inert; it must not cost a round-trip."""
+    templates = [_template(match_field="event_id", match_value=None)]
+    assert svc.unresolved_condition_fields(templates, _signals(document={})) == []
+
+
+def test_alert_context_merge_prefers_the_lowest_asset_id():
+    """Divergent contexts across assets: first row wins, matching auto-apply."""
+    session = AsyncMock()
+    result = AsyncMock()
+    result.scalars = lambda: SimpleNamespace(
+        all=lambda: [{"rule_id": "100", "shared": "a"}, {"rule_id": "200", "extra": "b"}],
+    )
+    session.execute = AsyncMock(return_value=result)
+
+    merged = asyncio.run(svc._load_alert_context(1, session))
+    assert merged["rule_id"] == "100"
+    assert merged["extra"] == "b"

--- a/backend/tests/test_case_template_suggestions.py
+++ b/backend/tests/test_case_template_suggestions.py
@@ -476,6 +476,41 @@ def test_default_wins_a_tie_against_a_non_default():
     assert response.suggestions[0].template.id == 2
 
 
+def test_a_firing_condition_outranks_a_higher_scoring_template():
+    """The partition, not a weight — this is what keeps the panel agreeing with
+    ``pick_templates_for_alert``, where field-match templates win outright and
+    the scope-tier picker only runs when none of them fire.
+
+    Regression: expressing this as a 40-point weight let a template scoring
+    customer (25) + source (20) beat a firing condition, so the panel
+    recommended something different from what auto-apply would have applied.
+    Caught by the e2e, not by the mocked tests.
+    """
+    templates = [
+        _template(template_id=1, name="Well scoped", customer_code="ACME", source="wazuh"),
+        _template(template_id=2, name="Conditional", match_field="event_id", match_value="1"),
+    ]
+    signals = _signals(document={"event_id": "1"}, document_available=True, tags=["ransomware"])
+    response = _run_suggest(templates=templates, signals=signals)
+
+    top, second = response.suggestions[0], response.suggestions[1]
+    assert top.template.id == 2
+    assert top.condition_matched is True
+    # The point of the partition: it wins despite scoring less.
+    assert top.score < second.score
+    assert second.condition_matched is False
+
+
+def test_condition_matched_is_false_when_the_document_is_unreadable():
+    """Unverified is not matched — it must not jump the queue."""
+    templates = [_template(template_id=1, match_field="event_id", match_value="1")]
+    response = _run_suggest(
+        templates=templates,
+        signals=_signals(document={}, document_available=False),
+    )
+    assert response.suggestions[0].condition_matched is False
+
+
 def test_suggestion_carries_the_full_task_list_for_the_preview():
     """One round-trip: the preview must not need a second call per suggestion."""
     templates = [

--- a/frontend/src/api/endpoints/incidentManagement/case-templates.ts
+++ b/frontend/src/api/endpoints/incidentManagement/case-templates.ts
@@ -9,6 +9,7 @@ import type {
 	CaseTemplateLibraryEntry,
 	CaseTemplateLibraryListResponse,
 	CaseTemplateLibraryRefreshResponse,
+	CaseTemplateSuggestionListResponse,
 	CaseTemplateTask,
 	CaseTemplateTaskCreatePayload,
 	CaseTemplateTaskUpdatePayload,
@@ -31,6 +32,22 @@ export interface CaseTimelineQuery {
 	offset?: number
 }
 
+/**
+ * Context for ranking templates (issue #935).
+ *
+ * `alertId` and the `customerCode`/`source` pair are alternatives, not
+ * companions: when an alert id is supplied the backend reads scope from the
+ * alert itself and ignores anything passed alongside it.
+ */
+export interface CaseTemplateSuggestQuery {
+	/** Creating a case from an alert — enables full contextual scoring. */
+	alertId?: number
+	/** Manual creation — scores on scope, usage history and default status. */
+	customerCode?: string | null
+	source?: string | null
+	limit?: number
+}
+
 export default {
 	listTemplates(filters: CaseTemplateListFilters = {}) {
 		const params: Record<string, string | boolean> = {}
@@ -41,6 +58,25 @@ export default {
 		return HttpClient.get<FlaskBaseResponse & { templates: CaseTemplate[] }>(`/incidents/case_templates`, {
 			params
 		})
+	},
+	/**
+	 * Rank templates against the context of the case about to be created.
+	 *
+	 * Returns each suggestion with its full template (tasks included) so the
+	 * "tasks that will be added" preview costs no extra round-trip, plus the
+	 * reasons behind its rank so the ordering is auditable rather than opaque.
+	 */
+	suggestTemplates(query: CaseTemplateSuggestQuery = {}) {
+		const params: Record<string, string | number> = {}
+		if (query.alertId !== undefined) params.alert_id = query.alertId
+		if (query.customerCode) params.customer_code = query.customerCode
+		if (query.source) params.source = query.source
+		if (query.limit !== undefined) params.limit = query.limit
+
+		return HttpClient.get<FlaskBaseResponse & CaseTemplateSuggestionListResponse>(
+			`/incidents/case_templates/suggest`,
+			{ params }
+		)
 	},
 	getTemplate(templateId: number) {
 		return HttpClient.get<FlaskBaseResponse & { template: CaseTemplate | null }>(

--- a/frontend/src/components/incidentManagement/alerts/AlertCreateCaseButton.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertCreateCaseButton.vue
@@ -1,19 +1,75 @@
 <template>
-	<n-button secondary type="primary" :loading="creating" @click="createCase()">
+	<n-button secondary type="primary" :loading="creating" @click="openDialog()">
 		<template #icon>
 			<Icon :name="DangerIcon" />
 		</template>
 		Create case
 	</n-button>
+
+	<n-modal
+		v-model:show="showDialog"
+		display-directive="show"
+		preset="card"
+		title="Create case from alert"
+		:style="{ maxWidth: 'min(760px, 90vw)', minHeight: 'min(420px, 90vh)', maxHeight: '85vh' }"
+		content-class="flex flex-col overflow-hidden px-2! py-0!"
+		segmented
+	>
+		<n-scrollbar class="flex grow flex-col" content-class="grow" trigger="none">
+			<div class="flex flex-col gap-4 px-5 py-5">
+				<p class="text-secondary text-sm">
+					Ranked against this alert's tags, MITRE techniques, rule groups and source. Pick one to apply its
+					tasks on creation, or skip and let CoPilot auto-select as before.
+				</p>
+
+				<CaseTemplateSuggestions
+					:alert-id="alert.id"
+					:selected-template-id="selectedTemplate?.id ?? null"
+					@select="selectedTemplate = $event"
+				>
+					<template #browseAll>
+						<n-button text size="tiny" @click="browseAllTemplates()">
+							<template #icon>
+								<Icon :name="BrowseIcon" :size="14" />
+							</template>
+							Browse all templates
+						</n-button>
+					</template>
+				</CaseTemplateSuggestions>
+			</div>
+		</n-scrollbar>
+
+		<template #footer>
+			<div class="flex flex-wrap items-center justify-between gap-3">
+				<!--
+					Omitting template_id is NOT "no template" — the backend then
+					runs its own auto-apply selection. Labelled accordingly so
+					the analyst isn't surprised by tasks appearing on a case they
+					thought they'd created bare.
+				-->
+				<n-button quaternary :disabled="creating" @click="createCase(null)">Skip — auto-select</n-button>
+
+				<n-button type="primary" :loading="creating" :disabled="!selectedTemplate" @click="createCase()">
+					<template #icon>
+						<Icon :name="DangerIcon" />
+					</template>
+					Create with {{ selectedTemplate ? `"${truncatedName}"` : "template" }}
+				</n-button>
+			</div>
+		</template>
+	</n-modal>
 </template>
 
 <script setup lang="ts">
 import type { ApiError } from "@/types/common"
 import type { Alert } from "@/types/incidentManagement/alerts"
-import { NButton, useMessage } from "naive-ui"
-import { ref, toRefs } from "vue"
+import type { CaseTemplate } from "@/types/incidentManagement/case-templates"
+import { NButton, NModal, NScrollbar, useMessage } from "naive-ui"
+import { computed, ref, toRefs } from "vue"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
+import CaseTemplateSuggestions from "@/components/incidentManagement/caseTemplates/CaseTemplateSuggestions.vue"
+import { useNavigation } from "@/composables/useNavigation"
 import { getApiErrorMessage } from "@/utils"
 
 const props = defineProps<{ alert: Alert }>()
@@ -24,19 +80,50 @@ const emit = defineEmits<{
 const { alert } = toRefs(props)
 
 const DangerIcon = "majesticons:exclamation-line"
+const BrowseIcon = "carbon:list"
 
 const message = useMessage()
+const { routeIncidentManagementCaseTemplates } = useNavigation()
 const creating = ref(false)
+const showDialog = ref(false)
+const selectedTemplate = ref<CaseTemplate | null>(null)
+
+const truncatedName = computed(() => {
+	const name = selectedTemplate.value?.name ?? ""
+	return name.length > 28 ? `${name.slice(0, 27)}…` : name
+})
+
+function openDialog() {
+	selectedTemplate.value = null
+	showDialog.value = true
+}
+
+function browseAllTemplates() {
+	// Full-page navigation, so close the modal first — leaving it mounted over
+	// the templates list is the classic "back button does nothing" bug.
+	showDialog.value = false
+	routeIncidentManagementCaseTemplates().navigate()
+}
 
 function updateAlert(updatedAlert: Alert) {
 	emit("updated", updatedAlert)
 }
 
-function createCase() {
+/**
+ * `template` explicitly null means "skip" — send no template_id and let the
+ * backend's own auto-apply selection run, which is exactly what this button
+ * did before suggestions existed. Passing undefined falls back to whatever the
+ * analyst selected in the panel.
+ */
+function createCase(template: CaseTemplate | null | undefined = undefined) {
+	const chosen = template === undefined ? selectedTemplate.value : template
 	creating.value = true
 
+	const params: Record<string, number> = {}
+	if (chosen) params.template_id = chosen.id
+
 	Api.incidentManagement.cases
-		.createCaseFromAlert(alert.value.id)
+		.createCaseFromAlert(alert.value.id, params)
 		.then(res => {
 			if (res.data.success) {
 				updateAlert({
@@ -54,6 +141,7 @@ function createCase() {
 						}
 					]
 				})
+				showDialog.value = false
 				message.success(res.data?.message || "Case created successfully")
 			} else {
 				message.warning(res.data?.message || "An error occurred. Please try again later.")

--- a/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestionCard.vue
+++ b/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestionCard.vue
@@ -1,0 +1,202 @@
+<template>
+	<CardEntity size="small" hoverable :highlighted="selected" card-entity-class="h-full" main-box-class="grow">
+		<template #headerMain>
+			<div class="flex items-center gap-2">
+				<div class="text-default text-base leading-snug font-semibold text-balance">
+					{{ suggestion.template.name }}
+				</div>
+				<n-tag v-if="suggestion.template.is_default" size="tiny" :bordered="false">default</n-tag>
+			</div>
+		</template>
+
+		<template #headerExtra>
+			<Badge type="splitted" size="small" :color="confidenceColor" bright>
+				<template #label>Match</template>
+				<template #value>{{ confidenceLabel }}</template>
+			</Badge>
+		</template>
+
+		<template #default>
+			<div class="flex flex-col gap-3">
+				<p v-if="suggestion.template.description" class="text-secondary line-clamp-2 text-sm">
+					{{ suggestion.template.description }}
+				</p>
+
+				<!--
+					The reasons ARE the ranking's explanation — a list an analyst
+					cannot audit is a list they will not trust. Rendered in the
+					order the backend sent them (highest-scoring signal first).
+				-->
+				<div v-if="suggestion.reasons.length" class="flex flex-wrap items-center gap-1.5">
+					<n-tag
+						v-for="reason of suggestion.reasons"
+						:key="`${reason.signal}-${reason.detail}`"
+						size="small"
+						:bordered="false"
+						:type="reasonTagType(reason)"
+						:title="reason.points ? `${reason.detail} (+${reason.points})` : reason.detail"
+					>
+						<template #icon>
+							<Icon :name="reasonIcon(reason.signal)" :size="13" />
+						</template>
+						{{ reason.detail }}
+					</n-tag>
+				</div>
+
+				<!--
+					Task preview. The full task list already arrived with the
+					suggestion, so expanding costs no request — which is why this
+					is a plain toggle and not a lazy fetch.
+				-->
+				<div v-if="suggestion.template.tasks.length" class="flex flex-col gap-2">
+					<n-button text size="tiny" class="self-start" @click="expanded = !expanded">
+						<template #icon>
+							<Icon :name="expanded ? CollapseIcon : ExpandIcon" :size="14" />
+						</template>
+						{{ expanded ? "Hide" : "Preview" }} {{ suggestion.template.tasks.length }} task{{
+							suggestion.template.tasks.length === 1 ? "" : "s"
+						}}
+					</n-button>
+
+					<n-collapse-transition :show="expanded">
+						<ol class="text-secondary flex flex-col gap-1 pl-4 text-sm">
+							<li v-for="task of suggestion.template.tasks" :key="task.id" class="list-decimal">
+								<span>{{ task.title }}</span>
+								<n-tag v-if="task.mandatory" size="tiny" :bordered="false" type="warning" class="ml-2">
+									mandatory
+								</n-tag>
+							</li>
+						</ol>
+					</n-collapse-transition>
+				</div>
+				<p v-else class="text-tertiary text-sm italic">This template has no tasks yet.</p>
+			</div>
+		</template>
+
+		<template #footerMain>
+			<div class="flex h-full flex-wrap items-center gap-2">
+				<Badge type="splitted" size="small">
+					<template #iconLeft>
+						<Icon :name="TasksIcon" :size="13" />
+					</template>
+					<template #label>Tasks</template>
+					<template #value>{{ suggestion.template.tasks.length }}</template>
+				</Badge>
+				<Badge v-if="mandatoryCount > 0" color="warning" type="splitted" bright size="small">
+					<template #label>Mandatory</template>
+					<template #value>{{ mandatoryCount }}</template>
+				</Badge>
+				<Badge v-if="scopeLabel" type="splitted" size="small">
+					<template #label>Scope</template>
+					<template #value>{{ scopeLabel }}</template>
+				</Badge>
+			</div>
+		</template>
+
+		<template #footerExtra>
+			<div class="flex flex-wrap items-center justify-end gap-2">
+				<n-button
+					size="tiny"
+					:type="selected ? 'success' : 'primary'"
+					:secondary="!selected"
+					:loading="applying"
+					@click="emit('select', suggestion)"
+				>
+					<template #icon>
+						<Icon :name="selected ? SelectedIcon : ApplyIcon" />
+					</template>
+					{{ selected ? "Selected" : applyLabel || "Use this template" }}
+				</n-button>
+			</div>
+		</template>
+	</CardEntity>
+</template>
+
+<script setup lang="ts">
+import type {
+	CaseTemplateSuggestion,
+	SuggestionReason,
+	SuggestionSignal
+} from "@/types/incidentManagement/case-templates"
+import { NButton, NCollapseTransition, NTag } from "naive-ui"
+import { computed, ref } from "vue"
+import Badge from "@/components/common/Badge.vue"
+import CardEntity from "@/components/common/cards/CardEntity.vue"
+import Icon from "@/components/common/Icon.vue"
+
+const { suggestion, selected, applying, applyLabel } = defineProps<{
+	suggestion: CaseTemplateSuggestion
+	selected?: boolean
+	applying?: boolean
+	/** Overrides the CTA text — "Use this template" when creating, "Apply" when the case exists. */
+	applyLabel?: string
+}>()
+
+const emit = defineEmits<{
+	(e: "select", value: CaseTemplateSuggestion): void
+}>()
+
+const TasksIcon = "carbon:task"
+const ApplyIcon = "carbon:play-filled-alt"
+const SelectedIcon = "carbon:checkmark-filled"
+const ExpandIcon = "carbon:chevron-down"
+const CollapseIcon = "carbon:chevron-up"
+
+// Only `carbon:`, `mdi:` and `logos:` collections are bundled — anything else
+// renders as an empty box with no console error.
+const SIGNAL_ICONS: Record<SuggestionSignal, string> = {
+	condition: "carbon:filter",
+	condition_unverified: "carbon:warning-alt",
+	customer: "carbon:enterprise",
+	source: "carbon:data-base",
+	tag: "carbon:tag",
+	mitre: "carbon:security",
+	mitre_parent: "carbon:security",
+	mitre_name: "carbon:security",
+	rule_group: "carbon:rule",
+	keyword: "carbon:search",
+	usage: "carbon:chart-line",
+	default: "carbon:star"
+}
+
+const expanded = ref(false)
+
+const mandatoryCount = computed(() => suggestion.template.tasks.filter(t => t.mandatory).length)
+
+const confidenceColor = computed(() => {
+	if (suggestion.confidence === "high") return "success"
+	if (suggestion.confidence === "medium") return "primary"
+	return undefined
+})
+
+const confidenceLabel = computed(() => {
+	if (suggestion.confidence === "high") return "Strong"
+	if (suggestion.confidence === "medium") return "Likely"
+	return "Possible"
+})
+
+/**
+ * "Global / any source" is worth stating explicitly — an analyst comparing two
+ * suggestions needs to see that one is pinned to their customer and the other
+ * is the catch-all.
+ */
+const scopeLabel = computed(() => {
+	const parts = [suggestion.template.customer_code, suggestion.template.source].filter(Boolean)
+	return parts.length ? parts.join(" — ") : "global"
+})
+
+function reasonIcon(signal: SuggestionSignal): string {
+	return SIGNAL_ICONS[signal] ?? "carbon:information"
+}
+
+/**
+ * `condition_unverified` is the one reason that is a caveat rather than a
+ * credit — it scores nothing and warns that the originating event could not be
+ * read, so it must not look like the others.
+ */
+function reasonTagType(reason: SuggestionReason): "warning" | "success" | "default" {
+	if (reason.signal === "condition_unverified") return "warning"
+	if (reason.signal === "condition") return "success"
+	return "default"
+}
+</script>

--- a/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestionCard.vue
+++ b/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestionCard.vue
@@ -10,10 +10,25 @@
 		</template>
 
 		<template #headerExtra>
-			<Badge type="splitted" size="small" :color="confidenceColor" bright>
-				<template #label>Match</template>
-				<template #value>{{ confidenceLabel }}</template>
-			</Badge>
+			<div class="flex items-center gap-2">
+				<!--
+					Why this card is at the top. A fired auto-apply condition
+					sorts ahead of everything regardless of score, so the reason
+					for the ordering has to be visible at a glance — otherwise a
+					lower-scoring card sitting first looks like a bug.
+				-->
+				<Badge v-if="suggestion.condition_matched" color="success" type="splitted" bright size="small">
+					<template #iconLeft>
+						<Icon :name="SIGNAL_ICONS.condition" :size="13" />
+					</template>
+					<template #label>Auto-apply</template>
+					<template #value>fires</template>
+				</Badge>
+				<Badge type="splitted" size="small" :color="confidenceColor" bright>
+					<template #label>Match</template>
+					<template #value>{{ confidenceLabel }}</template>
+				</Badge>
+			</div>
 		</template>
 
 		<template #default>

--- a/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestions.vue
+++ b/frontend/src/components/incidentManagement/caseTemplates/CaseTemplateSuggestions.vue
@@ -1,0 +1,185 @@
+<template>
+	<div class="case-template-suggestions flex flex-col gap-3">
+		<div class="flex flex-wrap items-center justify-between gap-2">
+			<div class="flex items-center gap-2">
+				<Icon :name="SuggestIcon" :size="16" />
+				<span class="text-default text-sm font-semibold">Suggested templates</span>
+				<n-tag v-if="totalCandidates > suggestions.length" size="tiny" :bordered="false">
+					top {{ suggestions.length }} of {{ totalCandidates }}
+				</n-tag>
+			</div>
+
+			<div class="flex items-center gap-2">
+				<n-button v-if="selectedId !== null" text size="tiny" @click="clearSelection()">
+					<template #icon>
+						<Icon :name="ClearIcon" :size="14" />
+					</template>
+					Clear selection
+				</n-button>
+				<slot name="browseAll" />
+			</div>
+		</div>
+
+		<n-spin :show="loading" content-class="flex flex-col gap-3">
+			<template v-if="suggestions.length">
+				<div class="flex flex-col gap-3">
+					<CaseTemplateSuggestionCard
+						v-for="suggestion of suggestions"
+						:key="suggestion.template.id"
+						:suggestion
+						:apply-label
+						:selected="selectedId === suggestion.template.id"
+						:applying="applyingId === suggestion.template.id"
+						@select="toggleSelection(suggestion)"
+					/>
+				</div>
+			</template>
+
+			<!--
+				Two distinct empty states. "Nothing ranked" is normal on a fresh
+				deployment with no templates yet; a failed lookup is not, and
+				saying so lets the analyst know the full template list is still
+				trustworthy even though the ranking isn't there. Worded without
+				reference to creating a case — this panel is also used when
+				applying a template to one that already exists.
+			-->
+			<n-alert v-else-if="failed && !loading" type="warning" :bordered="false" size="small">
+				Couldn't rank templates for this context. Choose one manually instead — nothing else is affected.
+			</n-alert>
+			<n-empty v-else-if="!loading" description="No templates match this context yet" class="justify-center py-6">
+				<template #extra>
+					<span class="text-tertiary text-xs">
+						Suggestions improve as templates gain tasks mentioning the techniques and tags they cover.
+					</span>
+				</template>
+			</n-empty>
+		</n-spin>
+	</div>
+</template>
+
+<script setup lang="ts">
+import type { CaseTemplateSuggestQuery } from "@/api/endpoints/incidentManagement/case-templates"
+import type { ApiError } from "@/types/common"
+import type { CaseTemplate, CaseTemplateSuggestion } from "@/types/incidentManagement/case-templates"
+import { NAlert, NButton, NEmpty, NSpin, NTag } from "naive-ui"
+import { ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import CaseTemplateSuggestionCard from "./CaseTemplateSuggestionCard.vue"
+
+const { alertId, customerCode, source, limit, selectedTemplateId, applyingId, applyLabel } = defineProps<{
+	/** Creating from an alert — enables full contextual scoring. */
+	alertId?: number | null
+	/** Manual creation. Ignored by the backend when alertId is set. */
+	customerCode?: string | null
+	source?: string | null
+	limit?: number
+	/** Reflects the parent's current choice so the panel and any template dropdown agree. */
+	selectedTemplateId?: number | null
+	applyingId?: number | null
+	applyLabel?: string
+}>()
+
+const emit = defineEmits<{
+	/** null when the analyst clears their choice. */
+	(e: "select", value: CaseTemplate | null): void
+	(e: "loaded", value: CaseTemplateSuggestion[]): void
+}>()
+
+const SuggestIcon = "carbon:idea"
+const ClearIcon = "carbon:close"
+
+const suggestions = ref<CaseTemplateSuggestion[]>([])
+const totalCandidates = ref(0)
+const loading = ref(false)
+const failed = ref(false)
+const selectedId = ref<number | null>(selectedTemplateId ?? null)
+
+// Sequence guard: customer_code changes fire this repeatedly while the analyst
+// tabs through the form, and axios gives no ordering guarantee. Without it a
+// slow early response can overwrite a fast later one and the panel ends up
+// showing suggestions for the previous customer.
+let requestToken = 0
+
+function toggleSelection(suggestion: CaseTemplateSuggestion) {
+	if (selectedId.value === suggestion.template.id) {
+		clearSelection()
+		return
+	}
+	selectedId.value = suggestion.template.id
+	emit("select", suggestion.template)
+}
+
+function clearSelection() {
+	selectedId.value = null
+	emit("select", null)
+}
+
+function load() {
+	// Nothing to score against: no alert and no customer. Show the empty state
+	// rather than firing a request that can only come back empty.
+	if (!alertId && !customerCode && !source) {
+		suggestions.value = []
+		totalCandidates.value = 0
+		failed.value = false
+		return
+	}
+
+	const token = ++requestToken
+	loading.value = true
+	failed.value = false
+
+	const query: CaseTemplateSuggestQuery = { limit: limit ?? 5 }
+	if (alertId) {
+		query.alertId = alertId
+	} else {
+		query.customerCode = customerCode ?? null
+		query.source = source ?? null
+	}
+
+	Api.incidentManagement.caseTemplates
+		.suggestTemplates(query)
+		.then(res => {
+			if (token !== requestToken) return
+			if (res.data.success) {
+				suggestions.value = res.data.suggestions || []
+				totalCandidates.value = res.data.total_candidates || 0
+				emit("loaded", suggestions.value)
+			} else {
+				failed.value = true
+				suggestions.value = []
+				totalCandidates.value = 0
+			}
+		})
+		.catch((err: ApiError) => {
+			if (token !== requestToken) return
+			// Deliberately not a toast. This panel sits beside a form the
+			// analyst can still submit; an error popup would imply the whole
+			// action failed when only the ranking did.
+			console.warn("Failed to load case template suggestions:", err)
+			failed.value = true
+			suggestions.value = []
+			totalCandidates.value = 0
+		})
+		.finally(() => {
+			if (token === requestToken) loading.value = false
+		})
+}
+
+// Keep in step with a selection made outside the panel (e.g. the template
+// dropdown on the create-case form).
+watch(
+	() => selectedTemplateId,
+	value => {
+		selectedId.value = value ?? null
+	}
+)
+
+watch(
+	() => [alertId, customerCode, source, limit],
+	() => load(),
+	{ immediate: true }
+)
+
+defineExpose({ load })
+</script>

--- a/frontend/src/components/incidentManagement/cases/CaseCreationForm.vue
+++ b/frontend/src/components/incidentManagement/cases/CaseCreationForm.vue
@@ -52,6 +52,24 @@
 						/>
 					</n-form-item>
 				</div>
+				<!--
+					Suggestions sit above the picker, not inside it: the ranked
+					cards are the fast path, and the full dropdown below stays
+					the unchanged "browse all templates" fallback. Both write the
+					same selectedTemplateId, so choosing in one updates the other.
+
+					Only rendered once a customer is chosen — with no customer
+					there is nothing to rank against and an empty panel above an
+					empty form is just noise.
+				-->
+				<div v-if="form.customer_code">
+					<CaseTemplateSuggestions
+						:customer-code="form.customer_code"
+						:selected-template-id
+						@select="onSuggestionSelected"
+					/>
+				</div>
+
 				<div>
 					<n-form-item label="Template (optional)" path="template_id">
 						<n-select
@@ -100,6 +118,7 @@ import _trim from "lodash/trim"
 import { NButton, NForm, NFormItem, NInput, NSelect, NSpin, useMessage } from "naive-ui"
 import { computed, h, inject, onBeforeMount, ref, watch } from "vue"
 import Api from "@/api"
+import CaseTemplateSuggestions from "@/components/incidentManagement/caseTemplates/CaseTemplateSuggestions.vue"
 import { useGlobalCustomerFilter } from "@/composables/useGlobalCustomerFilter"
 import { getApiErrorMessage } from "@/utils"
 
@@ -224,6 +243,16 @@ function reset(force?: boolean) {
 
 function resetForm() {
 	form.value = getForm()
+}
+
+/**
+ * Picking a suggested card and picking from the dropdown are the same action —
+ * both just set the template applied on creation. Clearing the card selection
+ * clears the dropdown too, so the two controls can never disagree about what
+ * will be applied.
+ */
+function onSuggestionSelected(template: CaseTemplate | null) {
+	selectedTemplateId.value = template?.id ?? null
 }
 
 function renderOption(option: {

--- a/frontend/src/components/incidentManagement/cases/CaseTasks/CaseTasksToolbar.vue
+++ b/frontend/src/components/incidentManagement/cases/CaseTasks/CaseTasksToolbar.vue
@@ -55,7 +55,12 @@
 			title="Apply template"
 			:style="{ maxWidth: 'min(600px, 90vw)', overflow: 'hidden' }"
 		>
-			<CaseTasksToolbarApplyTemplateForm :case-id :customer-code @success="handleApplyTemplateSuccess" />
+			<CaseTasksToolbarApplyTemplateForm
+				:case-id
+				:customer-code
+				:linked-alerts="linkedAlerts || []"
+				@success="handleApplyTemplateSuccess"
+			/>
 		</n-modal>
 	</div>
 </template>

--- a/frontend/src/components/incidentManagement/cases/CaseTasks/CaseTasksToolbarApplyTemplateForm.vue
+++ b/frontend/src/components/incidentManagement/cases/CaseTasks/CaseTasksToolbarApplyTemplateForm.vue
@@ -1,5 +1,30 @@
 <template>
 	<n-form label-placement="top">
+		<!--
+			Ranked against the case's primary (first-linked) alert when it has
+			one, falling back to customer scope otherwise. "Primary = first
+			alert" is the existing convention in this codebase — see the
+			primary_* keys built in incidents/services/incident_case.py.
+
+			The alert is used for ranking only. Applying still creates case-wide
+			tasks exactly as before; nothing here changes what gets stamped.
+
+			Capped at 3 and scroll-bounded: this lives in a 600px modal that
+			already has a picker and a CTA below it, so an unbounded card list
+			would push the Apply button off-screen.
+		-->
+		<div class="mb-4 max-h-80 overflow-y-auto">
+			<CaseTemplateSuggestions
+				:alert-id="primaryAlertId"
+				:customer-code
+				:selected-template-id
+				:applying-id="applySubmitting ? selectedTemplateId : null"
+				:limit="3"
+				apply-label="Apply this template"
+				@select="selectedTemplateId = $event?.id ?? null"
+			/>
+		</div>
+
 		<n-form-item label="Template">
 			<n-select
 				v-model:value="selectedTemplateId"
@@ -31,15 +56,19 @@
 
 <script setup lang="ts">
 import type { ApiError } from "@/types/common"
+import type { Alert } from "@/types/incidentManagement/alerts"
 import type { CaseTemplate } from "@/types/incidentManagement/case-templates"
 import { NButton, NForm, NFormItem, NSelect, useMessage } from "naive-ui"
 import { computed, h, onBeforeMount, ref } from "vue"
 import Api from "@/api"
+import CaseTemplateSuggestions from "@/components/incidentManagement/caseTemplates/CaseTemplateSuggestions.vue"
 import { getApiErrorMessage } from "@/utils"
 
 const props = defineProps<{
 	caseId: number
 	customerCode?: string | null
+	/** Alerts on this case. Only the first is used, and only to rank suggestions. */
+	linkedAlerts?: Alert[]
 }>()
 
 const emit = defineEmits<{
@@ -52,6 +81,8 @@ const applySubmitting = ref(false)
 const loadingTemplates = ref(false)
 const availableTemplates = ref<CaseTemplate[]>([])
 const selectedTemplateId = ref<number | null>(null)
+
+const primaryAlertId = computed(() => props.linkedAlerts?.[0]?.id ?? null)
 
 const templateOptions = computed(() =>
 	availableTemplates.value.map(t => ({

--- a/frontend/src/types/incidentManagement/case-templates.ts
+++ b/frontend/src/types/incidentManagement/case-templates.ts
@@ -191,3 +191,58 @@ export interface CaseTemplateLibraryRefreshResponse {
 	invalid_paths: string[]
 	last_refresh: string | null
 }
+
+// ---------------------------------------------------------------------------
+// Smart template suggestions (issue #935)
+//
+// Mirrors SuggestionReason / CaseTemplateSuggestion /
+// CaseTemplateSuggestionListResponse in
+// backend/app/incidents/schema/case_templates.py.
+//
+// Suggestions are a ranking *over* the templates that already exist — nothing
+// is persisted, so there is no "suggestion" entity to create, update or delete.
+// ---------------------------------------------------------------------------
+
+/**
+ * Machine-readable signal keys. Kept as a union rather than `string` so the
+ * icon/colour lookup in CaseTemplateSuggestionCard.vue fails at compile time
+ * when the backend grows a new signal, instead of silently rendering unstyled.
+ */
+export type SuggestionSignal =
+	| "condition"
+	| "condition_unverified"
+	| "customer"
+	| "source"
+	| "tag"
+	| "mitre"
+	| "mitre_parent"
+	| "mitre_name"
+	| "rule_group"
+	| "keyword"
+	| "usage"
+	| "default"
+
+export type SuggestionConfidence = "high" | "medium" | "low"
+
+/** One explainable contribution to a template's score. Rendered as a chip. */
+export interface SuggestionReason {
+	signal: SuggestionSignal
+	detail: string
+	/** Points contributed after capping. Reasons always sum to the score. */
+	points: number
+}
+
+export interface CaseTemplateSuggestion {
+	/** Full template, tasks included — the preview needs no extra request. */
+	template: CaseTemplate
+	score: number
+	confidence: SuggestionConfidence
+	/** Highest-scoring signal first. */
+	reasons: SuggestionReason[]
+}
+
+export interface CaseTemplateSuggestionListResponse {
+	suggestions: CaseTemplateSuggestion[]
+	/** Applicable templates before `limit` was applied. */
+	total_candidates: number
+}

--- a/frontend/src/types/incidentManagement/case-templates.ts
+++ b/frontend/src/types/incidentManagement/case-templates.ts
@@ -237,6 +237,13 @@ export interface CaseTemplateSuggestion {
 	template: CaseTemplate
 	score: number
 	confidence: SuggestionConfidence
+	/**
+	 * This template's auto-apply condition fired for this alert. Such templates
+	 * are returned ahead of every other suggestion regardless of score — the
+	 * same partition the backend's auto-apply uses. Do not re-sort the list by
+	 * score alone, or the panel will disagree with what applying would do.
+	 */
+	condition_matched: boolean
 	/** Highest-scoring signal first. */
 	reasons: SuggestionReason[]
 }


### PR DESCRIPTION
Closes #935.

Ranks the case templates an analyst can already see against the context of the case they are about to open, so the common path becomes "accept the top suggestion" rather than "browse the whole library".

## No schema

No table, no column, no Alembic migration. Every signal is derived from data that already exists:

| Signal | Source |
|---|---|
| customer / source scope | `CaseTemplate.customer_code` / `.source` |
| auto-apply condition | `match_field` / `match_value`, evaluated exactly as `pick_templates_for_alert` does |
| alert tags | `incident_management_alert_to_tag` → `_alerttag.tag` |
| MITRE technique ids, rule groups | `incident_management_alertcontext.context`, falling back to the raw Wazuh document |
| alert title keywords | `Alert.alert_name` |
| usage history | `CaseTask.template_task_id` → `CaseTemplateTask` → `Case.customer_code` |

The template side of each text comparison is a corpus built from the template's own name, description and task text (title + description + guidelines). That is what makes this work on day one: existing templates carry no tags or MITRE columns anyone would have to backfill, but a template called "Ransomware — host containment" whose tasks mention T1486 already says everything the scorer needs. Explicit metadata columns would be a strictly better signal later; they are not a precondition.

## Backend

- **`services/template_suggestions.py`** — additive, explainable scorer. Every point earned comes with a `SuggestionReason` naming the signal and the evidence, and the reasons always sum to the score. Weights live in one block of module constants.
- **`GET /incidents/case_templates/suggest`** — takes `alert_id` (full contextual scoring) or `customer_code`/`source` (manual-creation path). Declared **above** `/{template_id}`, since a wildcard registered first would swallow it and 422 on `"suggest"`.

Three behaviours worth reviewing closely:

- **Scope is a hard filter, never a penalty.** A template pinned to customer B can never surface on customer A's alert regardless of how well its text matches.
- **A checked-and-failed auto-apply condition drops the template** — the operator wrote that condition to mean "not this one", and ranking it low instead invites an analyst to override a deliberate rule. An *unreadable* document is a third state, not `False`, so a transient indexer outage does not silently hide every conditional template (it renders a "could not be checked" caveat chip instead).
- **The indexer round-trip is gated** on in-scope conditional templates keyed on a field the stored alert context does not already carry. Most requests stay database-only.

The service never raises: a lookup failure returns `success=false` with an empty list, so a broken ranking can never block case creation.

## Frontend

`CaseTemplateSuggestions.vue` + `CaseTemplateSuggestionCard.vue` — ranked cards with reason chips and a task preview that costs no extra request (the full task list arrives with each suggestion). Sequence-guarded against out-of-order responses, which axios does not order and which fire repeatedly as the analyst changes the customer field.

Wired into three surfaces. **Each keeps its existing manual picker untouched as the "browse all templates" fallback:**

1. **Create case from alert** — now opens a modal. `Skip — auto-select` preserves the previous one-click behaviour, labelled honestly: omitting `template_id` is *not* "no template", it runs the backend's own auto-apply selection.
2. **Manual case-creation form** — panel above the existing dropdown; both write the same `selectedTemplateId` so they cannot disagree.
3. **Apply template to an existing case** — ranked against the case's primary (first-linked) alert, matching the `primary_*` convention in `incidents/services/incident_case.py`. The alert is used for **ranking only**; applying still creates case-wide tasks exactly as before.

## Verification

- 570 backend tests pass (50 new, in `tests/test_case_template_suggestions.py` — mocked sessions, no DB or indexer)
- `pnpm lint-type-format` clean
- `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5GJ7mv96tGcADcs4dx3vm