### PR TITLE
Filter CoPilot Searches by detections/ folder instead of platform

### DIFF
--- a/backend/app/integrations/copilot_searches/routes/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/routes/copilot_searches.py
@@ -84,6 +84,10 @@ from app.integrations.copilot_searches.schema.copilot_searches import (
     ProvisionGraylogAlertResponse,
 )
 from app.integrations.copilot_searches.schema.copilot_searches import RefreshResponse
+from app.integrations.copilot_searches.schema.copilot_searches import (
+    RuleCategoriesResponse,
+)
+from app.integrations.copilot_searches.schema.copilot_searches import RuleCategory
 from app.integrations.copilot_searches.schema.copilot_searches import RuleDetailResponse
 from app.integrations.copilot_searches.schema.copilot_searches import RuleListResponse
 from app.integrations.copilot_searches.schema.copilot_searches import RulesByIdsRequest
@@ -96,6 +100,9 @@ from app.integrations.copilot_searches.services.copilot_searches import (
 )
 from app.integrations.copilot_searches.services.copilot_searches import (
     generate_graylog_query,
+)
+from app.integrations.copilot_searches.services.copilot_searches import (
+    get_categories_list,
 )
 from app.integrations.copilot_searches.services.copilot_searches import get_rule_by_id
 from app.integrations.copilot_searches.services.copilot_searches import get_rule_by_name
@@ -194,6 +201,10 @@ async def list_rules(
         PlatformFilter.ALL,
         description="Filter by platform (linux, windows, powershell, all)",
     ),
+    category: Optional[str] = Query(
+        None,
+        description="Filter by detections/ folder, e.g. eid_01_process_creation. See GET /categories.",
+    ),
     status: Optional[RuleStatus] = Query(
         None,
         description="Filter by rule status",
@@ -222,6 +233,7 @@ async def list_rules(
 
     Supports filtering by:
     - **platform**: linux, windows, powershell, cve or all
+    - **category**: detections/ folder from the CoPilot-Search-Queries repo
     - **status**: production, experimental, deprecated
     - **severity**: low, medium, high, critical
     - **mitre_id**: MITRE ATT&CK technique ID
@@ -230,6 +242,7 @@ async def list_rules(
     """
     result = await get_rules_list(
         platform=platform,
+        category=category,
         status=status,
         severity=severity,
         mitre_id=mitre_id,
@@ -387,6 +400,27 @@ async def get_rule_stats():
 
 
 @copilot_searches_router.get(
+    "/categories",
+    response_model=RuleCategoriesResponse,
+    description="List the detection categories (detections/ folders) available in the rules repo",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+)
+async def list_rule_categories():
+    """
+    List the detection categories that back the Data Source filter.
+
+    These mirror the folders under `detections/` in CoPilot-Search-Queries
+    verbatim — the list is derived from the loaded rules, so a folder added
+    upstream appears here after the next cache refresh with no code change.
+    Each entry carries a display `label`, a presentation `group` and the `count`
+    of cached rules in that folder.
+    """
+    categories = await get_categories_list()
+
+    return RuleCategoriesResponse(categories=[RuleCategory(**c) for c in categories])
+
+
+@copilot_searches_router.get(
     "/id/{rule_id}",
     response_model=RuleDetailResponse,
     description="Get full details of a specific rule by its ID",
@@ -467,6 +501,10 @@ async def get_mitre_coverage(
         PlatformFilter.ALL,
         description="Restrict coverage to rules matching this platform",
     ),
+    category: Optional[str] = Query(
+        None,
+        description="Restrict coverage to rules in this detections/ folder. See GET /categories.",
+    ),
     severity: Optional[RuleSeverity] = Query(None, description="Restrict coverage to rules of this severity"),
     status: Optional[RuleStatus] = Query(None, description="Restrict coverage to rules of this status"),
     has_graylog: Optional[bool] = Query(
@@ -489,6 +527,7 @@ async def get_mitre_coverage(
     try:
         result = await get_coverage(
             platform=platform,
+            category=category,
             severity=severity,
             status=status,
             has_graylog=has_graylog,
@@ -530,6 +569,7 @@ async def refresh_mitre_matrix():
 async def get_rules_by_mitre(
     technique_id: str,
     platform: PlatformFilter = Query(PlatformFilter.ALL),
+    category: Optional[str] = Query(None),
 ):
     """
     Get all rules that detect a specific MITRE ATT&CK technique.
@@ -541,6 +581,7 @@ async def get_rules_by_mitre(
     """
     result = await get_rules_list(
         platform=platform,
+        category=category,
         mitre_id=technique_id,
     )
 

--- a/backend/app/integrations/copilot_searches/schema/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/schema/copilot_searches.py
@@ -10,7 +10,13 @@ from pydantic import model_validator
 
 
 class PlatformFilter(str, Enum):
-    """Supported platform filters."""
+    """Supported platform filters.
+
+    Kept for the OS badge on a rule and the /linux, /windows, /powershell
+    convenience routes. The user-facing rule filter is `category` — the
+    detections/<folder> the rule lives in — which is not an enum on purpose:
+    folders are added to CoPilot-Search-Queries without a CoPilot release.
+    """
 
     ALL = "all"
     LINUX = "linux"
@@ -132,6 +138,8 @@ class RuleSummary(BaseModel):
     severity: str
     risk_score: int
     platform: str
+    category: str = ""
+    category_label: str = ""
     mitre_attack_id: list[str] = []
     analytic_story: list[str] = []
     cve: list[str] = []
@@ -172,9 +180,27 @@ class RuleListResponse(BaseModel):
     total: int
     filtered: int
     platform: str
+    category: Optional[str] = None
     rules: list[RuleSummary]
     success: bool = True
     message: str = "Rules fetched successfully"
+
+
+class RuleCategory(BaseModel):
+    """One detections/ folder from the CoPilot-Search-Queries repo."""
+
+    value: str = Field(..., description="Folder name as it appears under detections/ (e.g. eid_01_process_creation)")
+    label: str = Field(..., description="Display label (e.g. 'EID 01 Process Creation')")
+    group: str = Field(..., description="Presentation bucket: Sysmon, Windows Event Logs, PowerShell, Linux, …")
+    count: int = Field(..., description="Number of cached rules in this folder")
+
+
+class RuleCategoriesResponse(BaseModel):
+    """Response model for the detection category listing."""
+
+    categories: list[RuleCategory]
+    success: bool = True
+    message: str = "Categories fetched successfully"
 
 
 class RuleStatsResponse(BaseModel):
@@ -182,6 +208,7 @@ class RuleStatsResponse(BaseModel):
 
     total_rules: int
     by_platform: dict[str, int]
+    by_category: dict[str, int] = {}
     by_status: dict[str, int]
     by_severity: dict[str, int]
     by_mitre_tactic: dict[str, int]

--- a/backend/app/integrations/copilot_searches/services/copilot_searches.py
+++ b/backend/app/integrations/copilot_searches/services/copilot_searches.py
@@ -91,6 +91,104 @@ CACHE_TTL_MINUTES = 30
 
 
 # =============================================================================
+# Detection categories
+# =============================================================================
+#
+# The CoPilot-Search-Queries repo is laid out as detections/<source_folder>/<rule>.yaml
+# — the folder IS the log source a detection reads (see
+# https://github.com/socfortress/CoPilot-Search-Queries/tree/main/detections).
+# `_category` is that folder verbatim, which makes it the one filter dimension
+# that can never drift from the repo: new folder upstream = new filter option on
+# the next cache refresh, no code change. Contrast `_platform` below, which is a
+# best-effort OS guess kept only for the rule badge and the /linux, /windows,
+# /powershell convenience routes.
+
+DETECTIONS_ROOT = "detections"
+UNCATEGORIZED = "uncategorized"
+
+# Folders whose auto-humanized label would read badly. Everything else goes
+# through _humanize_category (underscores -> spaces, title case, EID uppercase).
+CATEGORY_LABEL_OVERRIDES = {
+    "entra_id": "Entra ID",
+    "sharepoint_onedrive": "SharePoint / OneDrive",
+    "eid_12_13_14_registry_events": "EID 12/13/14 Registry Events",
+    "eid_17_18_pipe_events": "EID 17/18 Pipe Events",
+    "eid_19_20_21_wmi_events": "EID 19/20/21 WMI Events",
+    "eid_23_26_file_delete": "EID 23/26 File Delete",
+    "eid_27_28_29_file_block": "EID 27/28/29 File Block",
+    "eid_22_dns_query": "EID 22 DNS Query",
+    "eid_15_file_create_stream_hash": "EID 15 File Create Stream Hash",
+    "eid_16_sysmon_config_changed": "EID 16 Sysmon Config Changed",
+    "web": "Web",
+}
+
+# Grouping is presentation only — it buckets the ~33 folders so the dropdown
+# stays scannable. Membership is by folder name; anything unrecognised (a folder
+# added upstream after this list was written) lands in "Other" and still works.
+GROUP_SYSMON = "Sysmon"
+GROUP_WINDOWS_LOGS = "Windows Event Logs"
+GROUP_POWERSHELL = "PowerShell"
+GROUP_LINUX = "Linux"
+GROUP_M365 = "Microsoft 365"
+GROUP_OTHER = "Other"
+
+CATEGORY_GROUP_ORDER = [
+    GROUP_SYSMON,
+    GROUP_WINDOWS_LOGS,
+    GROUP_POWERSHELL,
+    GROUP_LINUX,
+    GROUP_M365,
+    GROUP_OTHER,
+]
+
+POWERSHELL_CATEGORIES = {"eid_4103_module_logging", "eid_4104_script_block_logging"}
+WINDOWS_LOG_CATEGORIES = {
+    "application_eventlog",
+    "security_eventlog",
+    "system_eventlog",
+    "defender_operational",
+    "task_scheduler_operational",
+}
+LINUX_CATEGORIES = {"auditd", "syslog", "tetragon"}
+M365_CATEGORIES = {"entra_id", "exchange", "sharepoint_onedrive"}
+
+
+def _humanize_category(folder: str) -> str:
+    """Turn a folder name into a display label ('eid_01_process_creation' -> 'EID 01 Process Creation')."""
+    words = folder.replace("-", "_").split("_")
+    return " ".join("EID" if w.lower() == "eid" else w.capitalize() if w.islower() or w.isupper() else w for w in words if w)
+
+
+def category_label(folder: str) -> str:
+    """Display label for a detections/ folder."""
+    return CATEGORY_LABEL_OVERRIDES.get(folder.lower(), _humanize_category(folder))
+
+
+def category_group(folder: str) -> str:
+    """Presentation bucket for a detections/ folder."""
+    key = folder.lower()
+    if key in POWERSHELL_CATEGORIES:
+        return GROUP_POWERSHELL
+    if key.startswith("eid_"):
+        return GROUP_SYSMON
+    if key in WINDOWS_LOG_CATEGORIES:
+        return GROUP_WINDOWS_LOGS
+    if key in LINUX_CATEGORIES:
+        return GROUP_LINUX
+    if key in M365_CATEGORIES:
+        return GROUP_M365
+    return GROUP_OTHER
+
+
+def category_from_path(file_path: str) -> str:
+    """Extract the detections/<folder>/ segment from a rule's repo path."""
+    parts = file_path.strip("/").split("/")
+    if len(parts) >= 3 and parts[0] == DETECTIONS_ROOT:
+        return parts[1]
+    return UNCATEGORIZED
+
+
+# =============================================================================
 # Rules Cache
 # =============================================================================
 
@@ -235,6 +333,7 @@ class RulesCache:
             # Add metadata
             rule_data["_file_path"] = file_path
             rule_data["_raw_yaml"] = raw_yaml
+            rule_data["_category"] = category_from_path(file_path)
             rule_data["_platform"] = self._detect_platform(file_path, rule_data)
             rule_data["_has_graylog"] = "graylog" in rule_data and bool(rule_data.get("graylog", {}).get("query"))
 
@@ -333,9 +432,40 @@ class RulesCache:
 
         return None
 
+    def get_categories(self) -> list[dict]:
+        """
+        List the detections/ folders present in the cache, with counts.
+
+        Drives the Data Source filter — derived from the loaded rules rather than
+        a hardcoded enum, so a folder added upstream shows up after a refresh.
+        """
+        counts: dict[str, int] = {}
+        for rule in self._rules.values():
+            folder = rule.get("_category") or UNCATEGORIZED
+            counts[folder] = counts.get(folder, 0) + 1
+
+        categories = [
+            {
+                "value": folder,
+                "label": category_label(folder),
+                "group": category_group(folder),
+                "count": count,
+            }
+            for folder, count in counts.items()
+        ]
+        categories.sort(
+            key=lambda c: (
+                CATEGORY_GROUP_ORDER.index(c["group"]),
+                -c["count"],
+                c["label"].lower(),
+            ),
+        )
+        return categories
+
     def filter_rules(
         self,
         platform: PlatformFilter = PlatformFilter.ALL,
+        category: Optional[str] = None,
         status: Optional[RuleStatus] = None,
         severity: Optional[RuleSeverity] = None,
         mitre_id: Optional[str] = None,
@@ -344,12 +474,20 @@ class RulesCache:
     ) -> list[dict]:
         """Filter rules based on criteria."""
         results = []
+        category_key = category.lower() if category else None
 
         for rule in self._rules.values():
             # Platform filter
             if platform != PlatformFilter.ALL:
                 rule_platform = rule.get("_platform", "unknown")
                 if rule_platform != platform.value:
+                    continue
+
+            # Category (detections/ folder) filter — matched case-insensitively
+            # because the repo mixes cases (Entra_id, Exchange vs auditd).
+            if category_key is not None:
+                rule_category = (rule.get("_category") or UNCATEGORIZED).lower()
+                if rule_category != category_key:
                     continue
 
             # Status filter
@@ -393,6 +531,7 @@ class RulesCache:
         stats = {
             "total_rules": len(self._rules),
             "by_platform": {},
+            "by_category": {},
             "by_status": {},
             "by_severity": {},
             "by_mitre_tactic": {},
@@ -403,6 +542,10 @@ class RulesCache:
             # By platform
             platform = rule.get("_platform", "unknown")
             stats["by_platform"][platform] = stats["by_platform"].get(platform, 0) + 1
+
+            # By category (detections/ folder)
+            category = rule.get("_category") or UNCATEGORIZED
+            stats["by_category"][category] = stats["by_category"].get(category, 0) + 1
 
             # By status
             status = rule.get("status", "unknown")
@@ -451,6 +594,8 @@ def rule_to_summary(rule: dict) -> RuleSummary:
         severity=response.get("severity", "medium"),
         risk_score=response.get("risk_score", 0),
         platform=rule.get("_platform", "unknown"),
+        category=rule.get("_category") or UNCATEGORIZED,
+        category_label=category_label(rule.get("_category") or UNCATEGORIZED),
         mitre_attack_id=tags.get("mitre_attack_id", []),
         analytic_story=tags.get("analytic_story", []),
         cve=tags.get("cve", []),
@@ -671,8 +816,20 @@ rules_cache = RulesCache()
 # =============================================================================
 
 
+async def get_categories_list() -> list[dict]:
+    """
+    List the available detection categories (detections/ folders) with counts.
+
+    Returns:
+        List of {value, label, group, count} dicts, group-ordered.
+    """
+    await rules_cache.ensure_loaded()
+    return rules_cache.get_categories()
+
+
 async def get_rules_list(
     platform: PlatformFilter = PlatformFilter.ALL,
+    category: Optional[str] = None,
     status: Optional[RuleStatus] = None,
     severity: Optional[RuleSeverity] = None,
     mitre_id: Optional[str] = None,
@@ -686,6 +843,7 @@ async def get_rules_list(
 
     Args:
         platform: Filter by platform (linux, windows, powershell, all)
+        category: Filter by detections/ folder (e.g. eid_01_process_creation)
         status: Filter by rule status
         severity: Filter by severity level
         mitre_id: Filter by MITRE ATT&CK technique ID
@@ -695,13 +853,26 @@ async def get_rules_list(
         limit: Maximum rules to return
 
     Returns:
-        Dictionary with total, filtered count, platform, and rules list
+        Dictionary with total, filtered count, platform, category, and rules list
+
+    Raises:
+        ValueError: If category is not a folder present in the cache (surfaced as
+            HTTP 400) — a typo returning an empty list looks identical to a folder
+            with no rules, which is a miserable thing to debug from the UI.
     """
     await rules_cache.ensure_loaded()
+
+    if category is not None:
+        known = {c["value"].lower() for c in rules_cache.get_categories()}
+        if category.lower() not in known:
+            raise ValueError(
+                f"Unknown category '{category}'. See GET /copilot_searches/categories for the available folders.",
+            )
 
     # Filter rules
     filtered_rules = rules_cache.filter_rules(
         platform=platform,
+        category=category,
         status=status,
         severity=severity,
         mitre_id=mitre_id,
@@ -723,6 +894,7 @@ async def get_rules_list(
         "total": rules_cache.rules_count,
         "filtered": total_filtered,
         "platform": platform.value,
+        "category": category,
         "rules": summaries,
     }
 
@@ -800,6 +972,7 @@ async def get_rules_stats() -> dict:
     return {
         "total_rules": stats["total_rules"],
         "by_platform": stats["by_platform"],
+        "by_category": stats["by_category"],
         "by_status": stats["by_status"],
         "by_severity": stats["by_severity"],
         "by_mitre_tactic": stats["by_mitre_tactic"],

--- a/backend/app/integrations/copilot_searches/services/mitre_coverage.py
+++ b/backend/app/integrations/copilot_searches/services/mitre_coverage.py
@@ -158,6 +158,7 @@ mitre_matrix = MitreMatrix()
 def _rule_matches_filters(
     rule: dict,
     platform: Optional[PlatformFilter],
+    category: Optional[str],
     severity: Optional[RuleSeverity],
     status: Optional[RuleStatus],
     has_graylog: Optional[bool],
@@ -165,6 +166,10 @@ def _rule_matches_filters(
 ) -> bool:
     if platform is not None and platform != PlatformFilter.ALL:
         if rule.get("_platform", "unknown") != platform.value:
+            return False
+    if category:
+        # Case-insensitive: the repo mixes folder casing (Entra_id vs auditd).
+        if (rule.get("_category") or "").lower() != category.lower():
             return False
     if severity is not None:
         if rule.get("response", {}).get("severity", "").lower() != severity.value:
@@ -186,6 +191,7 @@ def _rule_matches_filters(
 
 async def get_coverage(
     platform: Optional[PlatformFilter] = None,
+    category: Optional[str] = None,
     severity: Optional[RuleSeverity] = None,
     status: Optional[RuleStatus] = None,
     has_graylog: Optional[bool] = None,
@@ -193,8 +199,9 @@ async def get_coverage(
 ) -> dict:
     """Build the MITRE coverage map by cross-referencing rules against the matrix.
 
-    Optional filters narrow the rules considered (platform/severity/status/has_graylog/search)
-    so the matrix can show "Windows-only coverage", etc.
+    Optional filters narrow the rules considered
+    (platform/category/severity/status/has_graylog/search) so the matrix can show
+    "Sysmon process-creation coverage only", etc.
 
     Returns a payload shaped for the frontend matrix view: ordered tactic columns,
     techniques grouped under each tactic, per-technique rule counts + IDs with
@@ -212,7 +219,7 @@ async def get_coverage(
         rule_id = rule.get("id", "")
         if not rule_id:
             continue
-        if not _rule_matches_filters(rule, platform, severity, status, has_graylog, search):
+        if not _rule_matches_filters(rule, platform, category, severity, status, has_graylog, search):
             continue
 
         # Cap data_sources at 3 to keep payload small; full list is in /id/{rule_id}.

--- a/backend/app/schedulers/scheduler.py
+++ b/backend/app/schedulers/scheduler.py
@@ -317,10 +317,14 @@ def get_function_by_name(function_name: str):
         "invoke_palace_lesson_sweeper": invoke_palace_lesson_sweeper,
         # Add other function mappings here
     }
-    return function_map.get(
-        function_name,
-        lambda: ValueError(f"Function {function_name} not found"),
-    )
+    # Raise rather than returning a placeholder lambda: APScheduler's SQLAlchemy jobstore
+    # pickles every job's callable at `start()`, and a lambda has no importable reference,
+    # so a stale/unknown job_id in scheduled_job_metadata would kill app startup with
+    # "This Job cannot be serialized...". Raising lets schedule_enabled_jobs skip the job.
+    try:
+        return function_map[function_name]
+    except KeyError:
+        raise ValueError(f"Function {function_name} not found")
 
 
 async def add_scheduler_jobs(create_scheduler_request: CreateSchedulerRequest):

--- a/frontend/src/api/endpoints/copilot-searches.ts
+++ b/frontend/src/api/endpoints/copilot-searches.ts
@@ -11,6 +11,7 @@ import type {
 	ProvisionGraylogAlertRequest,
 	ProvisionGraylogAlertResponse,
 	RefreshResponse,
+	RuleCategoriesResponse,
 	RuleDetailResponse,
 	RuleListQuery,
 	RuleListResponse,
@@ -30,6 +31,7 @@ export default {
 		return HttpClient.get<FlaskBaseResponse & RuleListResponse>(`/copilot_searches`, {
 			params: {
 				platform: query.platform,
+				category: query.category,
 				status: query.status,
 				severity: query.severity,
 				mitre_id: query.mitre_id,
@@ -115,6 +117,16 @@ export default {
 	},
 
 	/**
+	 * List the detection categories (detections/ folders in the rules repo) that
+	 * back the Data Source filter, with per-folder rule counts.
+	 */
+	getCategories(signal?: AbortSignal) {
+		return HttpClient.get<FlaskBaseResponse & RuleCategoriesResponse>(`/copilot_searches/categories`, {
+			signal
+		})
+	},
+
+	/**
 	 * Get statistics about loaded detection rules
 	 */
 	getStats(signal?: AbortSignal) {
@@ -150,7 +162,8 @@ export default {
 	getRulesByMitre(query: RulesByMitreQuery, signal?: AbortSignal) {
 		return HttpClient.get<FlaskBaseResponse & RuleListResponse>(`/copilot_searches/mitre/${query.techniqueId}`, {
 			params: {
-				platform: query.platform
+				platform: query.platform,
+				category: query.category
 			},
 			signal
 		})
@@ -227,6 +240,7 @@ export default {
 		return HttpClient.get<FlaskBaseResponse & MitreCoverageResponse>(`/copilot_searches/mitre/coverage`, {
 			params: {
 				platform: query.platform,
+				category: query.category,
 				severity: query.severity,
 				status: query.status,
 				has_graylog: query.has_graylog,

--- a/frontend/src/components/copilotSearches/GridView/GridView.vue
+++ b/frontend/src/components/copilotSearches/GridView/GridView.vue
@@ -4,7 +4,7 @@
 			<GridViewToolbar
 				v-model:search-query="searchQuery"
 				v-model:show-filters="showFilters"
-				v-model:selected-platform="selectedPlatform"
+				v-model:selected-category="selectedCategory"
 				v-model:selected-severity="selectedSeverity"
 				v-model:selected-status="selectedStatus"
 				v-model:has-graylog-filter="hasGraylogFilter"
@@ -68,7 +68,6 @@
 import type { ApiError } from "@/types/common"
 import type {
 	BulkProvisionGraylogAlertResponse,
-	PlatformFilter,
 	RuleListQuery,
 	RuleSeverity,
 	RuleStatus,
@@ -96,7 +95,7 @@ const pagination = ref({
 	filtered: 0
 })
 
-const selectedPlatform = ref<PlatformFilter | null>(null)
+const selectedCategory = ref<string | null>(null)
 const selectedSeverity = ref<RuleSeverity | null>(null)
 const selectedStatus = ref<RuleStatus | null>(null)
 const searchQuery = ref<string | null>(null)
@@ -106,7 +105,7 @@ const showFilters = ref(false)
 let abortController: AbortController | null = null
 
 function resetFilters() {
-	selectedPlatform.value = null
+	selectedCategory.value = null
 	selectedSeverity.value = null
 	selectedStatus.value = null
 	hasGraylogFilter.value = false
@@ -136,7 +135,7 @@ function getList() {
 	const query: RuleListQuery = {
 		skip: (pagination.value.current - 1) * pagination.value.size,
 		limit: pagination.value.size,
-		platform: selectedPlatform.value || undefined,
+		category: selectedCategory.value || undefined,
 		severity: selectedSeverity.value || undefined,
 		status: selectedStatus.value || undefined,
 		search: searchQuery.value || undefined,
@@ -184,7 +183,7 @@ async function handleRefresh() {
 }
 
 watchDebounced(
-	[selectedPlatform, selectedSeverity, selectedStatus, searchQuery, hasGraylogFilter, () => pagination.value.current],
+	[selectedCategory, selectedSeverity, selectedStatus, searchQuery, hasGraylogFilter, () => pagination.value.current],
 	getList,
 	{
 		deep: true,

--- a/frontend/src/components/copilotSearches/GridView/GridViewToolbar.vue
+++ b/frontend/src/components/copilotSearches/GridView/GridViewToolbar.vue
@@ -44,12 +44,15 @@
 				<div class="divide-border flex w-50 flex-col gap-0 divide-y">
 					<div class="flex flex-col gap-2.5 px-3 pt-1 pb-3">
 						<n-select
-							v-model:value="selectedPlatform"
-							:options="platformOptions"
+							v-model:value="selectedCategory"
+							:options="categoryOptions"
+							:render-label="renderCategoryLabel"
+							:loading="categoriesLoading"
 							size="small"
-							placeholder="Platform"
+							placeholder="Data Source"
 							class="w-full"
 							clearable
+							filterable
 							:consistent-menu-width="false"
 						/>
 
@@ -115,12 +118,13 @@
 </template>
 
 <script setup lang="ts">
-import type { PlatformFilter, RuleSeverity, RuleStatus } from "@/types/copilot-searches"
+import type { RuleSeverity, RuleStatus } from "@/types/copilot-searches"
 import { NBadge, NButton, NCheckbox, NInput, NPopover, NSelect } from "naive-ui"
-import { computed } from "vue"
+import { computed, onBeforeMount, watch } from "vue"
 import Icon from "@/components/common/Icon.vue"
+import { useDetectionCategories } from "@/composables/useDetectionCategories"
 
-defineProps<{
+const { refreshing } = defineProps<{
 	pagination: { total: number; filtered: number }
 	selectMode: boolean
 	hideSelectionSwitch: boolean
@@ -135,13 +139,21 @@ const emit = defineEmits<{
 
 const searchQuery = defineModel<string | null>("searchQuery", { default: null })
 const showFilters = defineModel<boolean>("showFilters", { default: false })
-const selectedPlatform = defineModel<PlatformFilter | null>("selectedPlatform", { default: null })
+const selectedCategory = defineModel<string | null>("selectedCategory", { default: null })
 const selectedSeverity = defineModel<RuleSeverity | null>("selectedSeverity", { default: null })
 const selectedStatus = defineModel<RuleStatus | null>("selectedStatus", { default: null })
 const hasGraylogFilter = defineModel<boolean>("hasGraylogFilter", { default: false })
 
+const {
+	options: categoryOptions,
+	loading: categoriesLoading,
+	renderLabel: renderCategoryLabel,
+	load: loadCategories,
+	reload: reloadCategories
+} = useDetectionCategories()
+
 const hasActiveFilters = computed(
-	() => !!selectedPlatform.value || !!selectedSeverity.value || !!selectedStatus.value || hasGraylogFilter.value
+	() => !!selectedCategory.value || !!selectedSeverity.value || !!selectedStatus.value || hasGraylogFilter.value
 )
 
 const InfoIcon = "carbon:information"
@@ -149,16 +161,6 @@ const FilterIcon = "carbon:filter-edit"
 const SearchIcon = "carbon:search"
 const RefreshIcon = "carbon:renew"
 const SelectIcon = "carbon:checkbox-checked"
-
-const platformOptions = [
-	{ label: "Linux", value: "linux" },
-	{ label: "Windows", value: "windows" },
-	{ label: "PowerShell", value: "powershell" },
-	{ label: "CVE", value: "cve" },
-	{ label: "Cloud", value: "cloud" },
-	{ label: "Office 365", value: "office365" },
-	{ label: "Web", value: "web" }
-]
 
 const severityOptions = [
 	{ label: "Low", value: "low" },
@@ -172,4 +174,18 @@ const statusOptions = [
 	{ label: "Experimental", value: "experimental" },
 	{ label: "Deprecated", value: "deprecated" }
 ]
+
+onBeforeMount(() => {
+	loadCategories()
+})
+
+// A manual cache refresh can pull in new detections/ folders. Re-fetch once the
+// parent's refresh settles, not when the button is pressed — the backend cache
+// is still reloading at that point and would hand back the old folder list.
+watch(
+	() => refreshing,
+	(isRefreshing, wasRefreshing) => {
+		if (wasRefreshing && !isRefreshing) reloadCategories()
+	}
+)
 </script>

--- a/frontend/src/components/copilotSearches/MatrixView/MatrixView.vue
+++ b/frontend/src/components/copilotSearches/MatrixView/MatrixView.vue
@@ -3,7 +3,7 @@
 		<MatrixViewToolbar
 			v-model:search-query="searchQuery"
 			v-model:show-filters="showFilters"
-			v-model:selected-platform="selectedPlatform"
+			v-model:selected-category="selectedCategory"
 			v-model:selected-severity="selectedSeverity"
 			v-model:selected-status="selectedStatus"
 			v-model:has-graylog-filter="hasGraylogFilter"
@@ -70,7 +70,6 @@ import type {
 	MitreSubTechnique,
 	MitreTactic,
 	MitreTechnique,
-	PlatformFilter,
 	RuleSeverity,
 	RuleStatus
 } from "@/types/copilot-searches"
@@ -101,7 +100,7 @@ const onlyCovered = useLocalStorage("copilot-searches/matrix/only-covered", fals
 const searchQuery = ref("")
 const expanded = useLocalStorage<Record<string, boolean>>("copilot-searches/matrix/expanded", {})
 
-const selectedPlatform = ref<PlatformFilter | null>(null)
+const selectedCategory = ref<string | null>(null)
 const selectedSeverity = ref<RuleSeverity | null>(null)
 const selectedStatus = ref<RuleStatus | null>(null)
 const hasGraylogFilter = ref(false)
@@ -172,7 +171,7 @@ const filteredTactics = computed<MitreTactic[]>(() => {
 })
 
 function clearAllFilters() {
-	selectedPlatform.value = null
+	selectedCategory.value = null
 	selectedSeverity.value = null
 	selectedStatus.value = null
 	hasGraylogFilter.value = false
@@ -223,7 +222,7 @@ function exportCoverageCsv() {
 }
 
 function resetFilters() {
-	selectedPlatform.value = null
+	selectedCategory.value = null
 	selectedSeverity.value = null
 	selectedStatus.value = null
 	hasGraylogFilter.value = false
@@ -267,8 +266,8 @@ function syncRouteFromSelection() {
 
 function syncFiltersToUrl() {
 	const next: Record<string, string> = { ...(route.query as Record<string, string>) }
-	if (selectedPlatform.value) next.platform = selectedPlatform.value
-	else delete next.platform
+	if (selectedCategory.value) next.category = selectedCategory.value
+	else delete next.category
 	if (selectedSeverity.value) next.severity = selectedSeverity.value
 	else delete next.severity
 	if (selectedStatus.value) next.status = selectedStatus.value
@@ -280,16 +279,16 @@ function syncFiltersToUrl() {
 
 function applyFiltersFromUrl() {
 	const q = route.query
-	const platform = q.platform as string | undefined
+	const category = q.category as string | undefined
 	const severity = q.severity as string | undefined
 	const status = q.status as string | undefined
 
-	const validPlatforms: PlatformFilter[] = ["all", "linux", "windows", "powershell", "cve"]
 	const validSeverities: RuleSeverity[] = ["low", "medium", "high", "critical"]
 	const validStatuses: RuleStatus[] = ["production", "experimental", "deprecated"]
 
-	selectedPlatform.value =
-		platform && (validPlatforms as string[]).includes(platform) ? (platform as PlatformFilter) : null
+	// Categories come from the rules repo, so there is no static list to validate
+	// against here — an unknown folder simply yields empty coverage.
+	selectedCategory.value = category || null
 	selectedSeverity.value =
 		severity && (validSeverities as string[]).includes(severity) ? (severity as RuleSeverity) : null
 	selectedStatus.value = status && (validStatuses as string[]).includes(status) ? (status as RuleStatus) : null
@@ -321,7 +320,7 @@ function applyDeepLinkFromRoute() {
 async function load(opts: { preserveDeepLink?: boolean } = {}) {
 	loading.value = true
 	const query: MitreCoverageQuery = {
-		platform: selectedPlatform.value || undefined,
+		category: selectedCategory.value || undefined,
 		severity: selectedSeverity.value || undefined,
 		status: selectedStatus.value || undefined,
 		has_graylog: hasGraylogFilter.value || undefined
@@ -355,7 +354,7 @@ async function handleRefresh() {
 }
 
 watchDebounced(
-	[selectedPlatform, selectedSeverity, selectedStatus, hasGraylogFilter],
+	[selectedCategory, selectedSeverity, selectedStatus, hasGraylogFilter],
 	() => {
 		if (!ready.value) return
 		syncFiltersToUrl()

--- a/frontend/src/components/copilotSearches/MatrixView/MatrixViewToolbar.vue
+++ b/frontend/src/components/copilotSearches/MatrixView/MatrixViewToolbar.vue
@@ -58,12 +58,15 @@
 				<div class="divide-border flex w-50 flex-col gap-0 divide-y">
 					<div class="flex flex-col gap-2.5 px-3 pt-1 pb-3">
 						<n-select
-							v-model:value="selectedPlatform"
-							:options="platformOptions"
+							v-model:value="selectedCategory"
+							:options="categoryOptions"
+							:render-label="renderCategoryLabel"
+							:loading="categoriesLoading"
 							size="small"
-							placeholder="Platform"
+							placeholder="Data Source"
 							class="w-full"
 							clearable
+							filterable
 							:consistent-menu-width="false"
 						/>
 						<n-select
@@ -129,10 +132,11 @@
 </template>
 
 <script setup lang="ts">
-import type { MitreCoverageResponse, PlatformFilter, RuleSeverity, RuleStatus } from "@/types/copilot-searches"
+import type { MitreCoverageResponse, RuleSeverity, RuleStatus } from "@/types/copilot-searches"
 import { NBadge, NButton, NCheckbox, NInput, NPopover, NSelect, NTooltip } from "naive-ui"
-import { computed } from "vue"
+import { computed, onBeforeMount } from "vue"
 import Icon from "@/components/common/Icon.vue"
+import { useDetectionCategories } from "@/composables/useDetectionCategories"
 
 defineProps<{
 	coverage: MitreCoverageResponse | null
@@ -147,14 +151,21 @@ const emit = defineEmits<{
 
 const searchQuery = defineModel<string>("searchQuery", { default: "" })
 const showFilters = defineModel<boolean>("showFilters", { default: false })
-const selectedPlatform = defineModel<PlatformFilter | null>("selectedPlatform", { default: null })
+const selectedCategory = defineModel<string | null>("selectedCategory", { default: null })
 const selectedSeverity = defineModel<RuleSeverity | null>("selectedSeverity", { default: null })
 const selectedStatus = defineModel<RuleStatus | null>("selectedStatus", { default: null })
 const hasGraylogFilter = defineModel<boolean>("hasGraylogFilter", { default: false })
 const onlyCovered = defineModel<boolean>("onlyCovered", { default: false })
 
+const {
+	options: categoryOptions,
+	loading: categoriesLoading,
+	renderLabel: renderCategoryLabel,
+	load: loadCategories
+} = useDetectionCategories()
+
 const anyFiltersActive = computed(
-	() => !!selectedPlatform.value || !!selectedSeverity.value || !!selectedStatus.value || hasGraylogFilter.value
+	() => !!selectedCategory.value || !!selectedSeverity.value || !!selectedStatus.value || hasGraylogFilter.value
 )
 
 const InfoIcon = "carbon:information"
@@ -162,16 +173,6 @@ const SearchIcon = "carbon:search"
 const FilterIcon = "carbon:filter-edit"
 const ExportIcon = "carbon:download"
 const RefreshIcon = "carbon:renew"
-
-const platformOptions = [
-	{ label: "Linux", value: "linux" },
-	{ label: "Windows", value: "windows" },
-	{ label: "PowerShell", value: "powershell" },
-	{ label: "CVE", value: "cve" },
-	{ label: "Cloud", value: "cloud" },
-	{ label: "Office 365", value: "office365" },
-	{ label: "Web", value: "web" }
-]
 
 const severityOptions = [
 	{ label: "Low", value: "low" },
@@ -185,4 +186,8 @@ const statusOptions = [
 	{ label: "Experimental", value: "experimental" },
 	{ label: "Deprecated", value: "deprecated" }
 ]
+
+onBeforeMount(() => {
+	loadCategories()
+})
 </script>

--- a/frontend/src/components/copilotSearches/RuleCard.vue
+++ b/frontend/src/components/copilotSearches/RuleCard.vue
@@ -60,6 +60,14 @@
 							<template #value>{{ platformInfo.label }}</template>
 						</Badge>
 
+						<Badge v-if="rule.category_label" type="splitted" size="small">
+							<template #iconLeft>
+								<Icon :name="SourceIcon" :size="11" />
+							</template>
+							<template #label>source</template>
+							<template #value>{{ rule.category_label }}</template>
+						</Badge>
+
 						<Badge v-for="mitre of visibleMitreIds" :key="mitre" size="small" color="primary">
 							<template #value>{{ mitre }}</template>
 						</Badge>
@@ -184,6 +192,7 @@ const message = useMessage()
 
 const PlayIcon = "carbon:play"
 const ProvisionIcon = "carbon:add-alt"
+const SourceIcon = "carbon:document"
 
 const visibleMitreIds = computed(() => rule.mitre_attack_id?.slice(0, 2) ?? [])
 const hiddenMitreCount = computed(() => Math.max((rule.mitre_attack_id?.length ?? 0) - 2, 0))

--- a/frontend/src/composables/useDetectionCategories.ts
+++ b/frontend/src/composables/useDetectionCategories.ts
@@ -1,0 +1,99 @@
+import type { SelectOption } from "naive-ui"
+import type { RuleCategory } from "@/types/copilot-searches"
+import { computed, h, ref } from "vue"
+import Api from "@/api"
+
+/**
+ * Detection categories — the `detections/<folder>` layout of the
+ * CoPilot-Search-Queries repo, exposed as filter options.
+ *
+ * State is module-level on purpose: the list is derived from the backend rules
+ * cache and only moves when the repo does, so the Grid and Matrix toolbars share
+ * a single fetch instead of one each. Concurrent callers await the same promise.
+ */
+const categories = ref<RuleCategory[]>([])
+const loading = ref(false)
+let inflight: Promise<void> | null = null
+
+function fetchCategories(): Promise<void> {
+	if (inflight) return inflight
+
+	loading.value = true
+	inflight = Api.copilotSearches
+		.getCategories()
+		.then(res => {
+			if (res.data.success) {
+				categories.value = res.data.categories || []
+			}
+		})
+		.catch(() => {
+			// Silent — the filter simply has no options. Everything else on the
+			// page keeps working, which beats an error toast on mount.
+		})
+		.finally(() => {
+			loading.value = false
+			inflight = null
+		})
+
+	return inflight
+}
+
+export function useDetectionCategories() {
+	/**
+	 * Naive UI select options, bucketed by the backend-provided `group`
+	 * (Sysmon, Windows Event Logs, PowerShell, Linux, Microsoft 365, Other).
+	 * Backend order is preserved — it already sorts group-first, count-desc.
+	 */
+	const options = computed<SelectOption[]>(() => {
+		const groups: { label: string; children: SelectOption[] }[] = []
+
+		for (const category of categories.value) {
+			let group = groups.find(g => g.label === category.group)
+			if (!group) {
+				group = { label: category.group, children: [] }
+				groups.push(group)
+			}
+			group.children.push({
+				label: category.label,
+				value: category.value,
+				count: category.count
+			})
+		}
+
+		return groups.map(group => ({
+			type: "group",
+			key: group.label,
+			label: group.label,
+			children: group.children
+		}))
+	})
+
+	/** Renders the rule count alongside each option label. */
+	function renderLabel(option: SelectOption) {
+		if (option.type === "group") return String(option.label ?? "")
+
+		return h("div", { class: "flex items-center justify-between gap-4" }, [
+			h("span", String(option.label ?? "")),
+			h("span", { class: "text-tertiary text-xs" }, String(option.count ?? ""))
+		])
+	}
+
+	function load() {
+		if (categories.value.length) return Promise.resolve()
+		return fetchCategories()
+	}
+
+	/** Force a re-fetch — used after the rules cache is manually refreshed. */
+	function reload() {
+		return fetchCategories()
+	}
+
+	return {
+		categories,
+		loading,
+		options,
+		renderLabel,
+		load,
+		reload
+	}
+}

--- a/frontend/src/types/copilot-searches.ts
+++ b/frontend/src/types/copilot-searches.ts
@@ -27,6 +27,10 @@ export interface RuleSummary {
 	severity: string
 	risk_score: number
 	platform: string
+	/** detections/<folder> the rule lives in, verbatim from the rules repo */
+	category: string
+	/** Display label for `category`, e.g. "EID 01 Process Creation" */
+	category_label: string
 	mitre_attack_id: string[]
 	analytic_story: string[]
 	cve: string[]
@@ -89,7 +93,20 @@ export interface RuleListResponse {
 	total: number
 	filtered: number
 	platform: string
+	category: string | null
 	rules: RuleSummary[]
+}
+
+/** One detections/ folder from the CoPilot-Search-Queries repo */
+export interface RuleCategory {
+	value: string
+	label: string
+	group: string
+	count: number
+}
+
+export interface RuleCategoriesResponse {
+	categories: RuleCategory[]
 }
 
 export interface RuleDetailResponse {
@@ -99,6 +116,7 @@ export interface RuleDetailResponse {
 export interface RuleStatsResponse {
 	total_rules: number
 	by_platform: Record<string, number>
+	by_category: Record<string, number>
 	by_status: Record<string, number>
 	by_severity: Record<string, number>
 	by_mitre_tactic: Record<string, number>
@@ -206,6 +224,7 @@ export interface GraylogProvisioningStatusResponse {
 
 export interface RuleListQuery {
 	platform?: PlatformFilter
+	category?: string
 	status?: RuleStatus
 	severity?: RuleSeverity
 	mitre_id?: string
@@ -264,10 +283,12 @@ export interface MitreRuleIndexEntry {
 export interface RulesByMitreQuery {
 	techniqueId: string
 	platform?: PlatformFilter
+	category?: string
 }
 
 export interface MitreCoverageQuery {
 	platform?: PlatformFilter
+	category?: string
 	severity?: RuleSeverity
 	status?: RuleStatus
 	has_graylog?: boolean


### PR DESCRIPTION
Closes #1081.

## What

The **Platform** filter (`linux` / `windows` / `powershell` / `cve` / `cloud` / `office365` / `web`) was a hand-maintained heuristic in CoPilot — `_detect_platform` guessed at an OS from the file path, then the tags, then the rule name. It drifted from the corpus it was filtering. This replaces it with the structure [CoPilot-Search-Queries](https://github.com/socfortress/CoPilot-Search-Queries/tree/main/detections) already has: the `detections/<folder>` a rule lives in, which *is* the log source it reads.

## Backend

- `_category` is the folder verbatim, captured when the YAML is fetched. A folder added upstream becomes a filter option on the next cache refresh with **no code change** — which is why `category` is deliberately not an enum.
- `category_label` / `category_group` map folders to display labels and six presentation buckets (Sysmon, Windows Event Logs, PowerShell, Linux, Microsoft 365, Other). An unrecognised folder lands in Other and still filters correctly.
- New `GET /copilot_searches/categories` → `{value, label, group, count}[]`, derived from the loaded rules.
- `category` query param added to the list route, `/mitre/coverage` and `/mitre/{technique_id}`. Matching is case-insensitive — the repo mixes `Entra_id` with `auditd`.
- An unknown `category` is a **400**, not an empty list: silently returning nothing is indistinguishable from a folder with no rules, and miserable to debug from the UI.
- `RuleSummary` carries `category` + `category_label`; stats gain `by_category`.
- `PlatformFilter` is **untouched** — it still backs the rule's OS badge and the `/linux`, `/windows`, `/powershell` convenience routes. No endpoint changes shape for existing callers.

## Frontend

- `useDetectionCategories` — module-level fetch shared by the Grid and Matrix toolbars (one request, not two), building grouped `n-select` options with per-folder counts rendered on the right.
- Both toolbars swap Platform for a filterable **Data Source** select.
- MatrixView's URL sync moves `?platform=` → `?category=`, and no longer validates against a static list since the folder set is dynamic.
- Rule cards gained a `source` badge showing the folder label.
- `AlertAssetSearches` keeps its Linux/Windows toggle — that one is about the alert's asset OS, not the log source.

## Verification

Ran against the live repo through the service layer:

```
categories: 33   total rules: 3050   sum(by_category) = 3050
Sysmon(17) · Windows Event Logs(5) · PowerShell(2) · Linux(3) · Microsoft 365(3) · Other(3)
filter eid_22_dns_query -> 25
filter ENTRA_ID        -> 4      (case-insensitive)
filter nope            -> 400 "Unknown category 'nope'. See GET /copilot_searches/categories"
```

Route registration checked against the built OpenAPI: `/categories` is declared ahead of the `{rule_id}` / `{technique_id}` wildcards, and `category` is present on all three GETs. `pnpm type-check` + eslint clean, `pre-commit` clean.

## Also in this branch

One unrelated commit: `get_function_by_name` in the scheduler returned `lambda: ValueError(...)` for an unknown `job_id`. APScheduler pickles every pending job's callable into the SQLAlchemy jobstore at `start()`, and a closure lambda has no importable reference — so a single stale row in `scheduled_job_metadata` took down app startup with `This Job cannot be serialized…`. The fallback also *returned* rather than *raised*, so the `except ValueError` guard in `schedule_enabled_jobs` never fired. It now raises, and the unknown job is logged and skipped.