### PR TITLE
fix: skip TLS verification on Shuffle calls in notification routes

### DIFF
--- a/backend/app/notifications/services/dispatchers.py
+++ b/backend/app/notifications/services/dispatchers.py
@@ -48,6 +48,17 @@ ShuffleDispatchResult = Tuple[str, Optional[str], int, Optional[str]]
 # stall the dispatch loop indefinitely.
 _SHUFFLE_TIMEOUT_S = 30.0
 
+# Shuffle is very often self-hosted behind a self-signed certificate or an
+# internal CA the backend container has no trust store for (GitHub issue
+# #1087). The legacy Shuffle connector
+# (`app/connectors/shuffle/utils/universal.py`) has always called with
+# `verify=False`; the Notification Routes dispatchers must match it, or the
+# same deployment that verifies fine on the connector page dies with
+# `CERTIFICATE_VERIFY_FAILED` on org/app lookup and dispatch. Shuffle carries
+# an API key on every call, so the TLS layer is transport privacy here, not
+# the authentication boundary.
+_SHUFFLE_VERIFY_SSL = False
+
 # Webhook delivery is fire-and-record like Shuffle. 15s is plenty for a
 # healthy automation endpoint (most respond in well under a
 # second); a slow target shouldn't stall the whole dispatch loop.
@@ -333,7 +344,7 @@ async def dispatch_shuffle(
     logger.info(f"Dispatching payload to Shuffle body: {body}")
     started = time.monotonic()
     try:
-        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True) as client:
+        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True, verify=_SHUFFLE_VERIFY_SSL) as client:
             response = await client.post(url, headers=_shuffle_headers(api_key, org_id), json=body)
         latency_ms = int((time.monotonic() - started) * 1000)
 
@@ -388,7 +399,7 @@ async def list_shuffle_apps(
     """
     url = f"{base_url.rstrip('/')}/api/v1/apps"
     try:
-        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True) as client:
+        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True, verify=_SHUFFLE_VERIFY_SSL) as client:
             response = await client.get(url, headers=_shuffle_headers(api_key, org_id))
         if response.status_code in (401, 403):
             return (False, [], f"Shuffle authentication failed ({response.status_code})")
@@ -448,7 +459,7 @@ async def list_shuffle_orgs(
         "Accept": "application/json",
     }
     try:
-        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True) as client:
+        async with httpx.AsyncClient(timeout=_SHUFFLE_TIMEOUT_S, http2=True, verify=_SHUFFLE_VERIFY_SSL) as client:
             response = await client.get(url, headers=headers)
         if response.status_code in (401, 403):
             return (False, [], f"Shuffle authentication failed ({response.status_code})")


### PR DESCRIPTION
Fixes #1087.

## Problem

Self-hosted Shuffle behind an internal CA: the Shuffle connector shows **Verified** and legacy Notification Workflows dispatch fine, but the new Notification Routes system fails with

```
ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain
```

on the integration probe and the route form's app dropdown.

## Cause

Two code paths, two HTTP stacks, two TLS defaults against the same Shuffle host:

- legacy — `app/connectors/shuffle/utils/universal.py`, `requests` with `verify=False` on every call
- new — `app/notifications/services/dispatchers.py`, `httpx.AsyncClient` with httpx's default `verify=True`

## Fix

All Shuffle HTTP in the new system funnels through three clients in `dispatchers.py`, so one constant covers every affected surface:

- `dispatch_shuffle` — actual delivery, which would have failed the same way once a route was saved
- `list_shuffle_apps` — app dropdown, and also what `verify_shuffle_org` (the probe) calls
- `list_shuffle_orgs` — org dropdown

Webhook, Teams and Resend clients are untouched and keep verifying — those target public CAs.

## Security note

This disables TLS verification on the CoPilot→Shuffle hop. Deliberate, and consistent with what the deployment already does: the legacy connector has `verify=False` on all five of its calls, as do the Talon connector, Bitdefender provisioning and `integrations/utils/alerts.py`. Leaving Routes strict while the connector is lax bought no real security — same host, same API key — only the bug.

A follow-up could mirror `_influxdb_verify_ssl()`: a `SHUFFLE_VERIFY_SSL` env var (default `False` so this stays fixed) plus an optional `SHUFFLE_CA_BUNDLE` path, letting operators mount their internal CA and get genuine verification.

## Testing

Not run — no local Python env with pytest available. Change is a single kwarg on three client constructions; syntax parses and no line exceeds black's 140.