### PR TITLE
fix: accept Velociraptor multi-org client ids

### DIFF
--- a/backend/app/connectors/velociraptor/utils/universal.py
+++ b/backend/app/connectors/velociraptor/utils/universal.py
@@ -209,9 +209,24 @@ class UniversalService:
                 )
             else:
                 logger.error(f"Failed to execute query: {e}")
+                details = e.details() or ""
+                # A root administrator is NOT implicitly an administrator in child orgs, so an
+                # org-scoped query fails with "Permission denied: ... requires permission
+                # ANY_QUERY" while org enumeration (which runs at root) succeeds. That reads as a
+                # CoPilot fault unless we say what the operator has to grant (GitHub issue #1015).
+                if "permission denied" in details.lower():
+                    raise HTTPException(
+                        status_code=403,
+                        detail=(
+                            f"Velociraptor denied the query for org '{org_id}': {details}. "
+                            "The Velociraptor API user CoPilot authenticates as needs a role in "
+                            "each org, not just root. Grant it on the Velociraptor server with: "
+                            f"SELECT user_grant(user='<copilot api user>', roles='administrator', orgs=['{org_id}']) FROM scope()"
+                        ),
+                    )
                 raise HTTPException(
                     status_code=500,
-                    detail=f"Failed to execute query: {e.details()}",
+                    detail=f"Failed to execute query: {details}",
                 )
         except Exception as e:
             logger.error(f"Failed to execute query: {e}")

--- a/backend/app/connectors/velociraptor/utils/validation.py
+++ b/backend/app/connectors/velociraptor/utils/validation.py
@@ -21,7 +21,17 @@ from fastapi import HTTPException
 # Velociraptor client IDs are "C." followed by hex (e.g. C.475df76785008b04). The literal
 # "server" addresses the Velociraptor server itself and is used by built-in server
 # artifacts (e.g. Server.Utils.DeleteClient).
-_CLIENT_ID_PATTERN = re.compile(r"^(server|C\.[0-9A-Fa-f]+)$")
+#
+# In a multi-org deployment Velociraptor reports a client's id *within an org* with the org
+# appended -- "C.<hex>-<ORGID>" -- and that suffixed form is the one the server matches on:
+# flows(client_id='C.aaaaaaaaaaaaaaaa') returns nothing where
+# flows(client_id='C.aaaaaaaaaaaaaaaa-OXXXXXXX') returns the flow. `sync_agents_velociraptor`
+# stores exactly what clients() reports, so agents outside the root org carry the suffixed id
+# and the un-suffixed pattern rejected CoPilot's own stored value (GitHub issue #1015).
+# The optional suffix uses the same character class as _ORG_ID_PATTERN below, so this widens
+# an accepted *format* without admitting any of the quote/backtick/brace/backslash/whitespace
+# characters the validator exists to reject (GHSA-5542-j2fc-gqjm).
+_CLIENT_ID_PATTERN = re.compile(r"^(server|C\.[0-9A-Fa-f]+(-[A-Za-z0-9._-]+)?)$")
 
 # Org IDs are "root" (the default org) or generated ids like "O1234ABCD".
 _ORG_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
@@ -42,7 +52,7 @@ _VQL_BREAKOUT_CHARS = ("'", '"', "`", "\\", "\n", "\r")
 
 
 def validate_client_id(value: str) -> str:
-    """Validate a Velociraptor client/agent id ("C.<hex>" or "server")."""
+    """Validate a Velociraptor client/agent id ("C.<hex>", "C.<hex>-<ORGID>", or "server")."""
     if not isinstance(value, str) or not _CLIENT_ID_PATTERN.fullmatch(value):
         raise HTTPException(status_code=400, detail="Invalid Velociraptor client id")
     return value

--- a/backend/tests/test_velociraptor_client_id_validation.py
+++ b/backend/tests/test_velociraptor_client_id_validation.py
@@ -1,0 +1,96 @@
+"""Tests for Velociraptor client id validation across multi-org deployments (issue #1015).
+
+In a multi-org Velociraptor deployment, `clients()` reports a client's id *within an org*
+as "C.<hex>-<ORGID>", and that suffixed form is the one the server matches on. CoPilot's
+agent sync stores exactly what `clients()` reports, so every agent outside the root org
+carried an id that CoPilot's own validator rejected with 400 on any endpoint that
+validates one (`GET /api/flows/{host}` being the visible one).
+
+The widened pattern must accept the suffix without weakening the VQL-injection defence it
+was added for (GHSA-5542-j2fc-gqjm): no quote, backtick, brace, backslash, whitespace or
+newline may reach an interpolated VQL string.
+
+Pure-function unit tests — no DB or Velociraptor server.
+
+Run with: cd backend && python -m pytest tests/test_velociraptor_client_id_validation.py
+"""
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.connectors.velociraptor.utils.validation import (  # noqa: E402
+    validate_client_id,
+)
+
+
+@pytest.mark.parametrize(
+    "client_id",
+    [
+        "C.475df76785008b04",  # root-org client, the pre-#1015 shape
+        "C.AAAAAAAAAAAAAAAA",  # uppercase hex
+        "server",  # the Velociraptor server itself (Server.Utils.DeleteClient)
+    ],
+)
+def test_accepts_single_org_ids(client_id):
+    assert validate_client_id(client_id) == client_id
+
+
+@pytest.mark.parametrize(
+    "client_id",
+    [
+        "C.aaaaaaaaaaaaaaaa-OXXXXXXX",  # the shape from the issue report
+        "C.475df76785008b04-O1234ABCD",  # generated org id
+        "C.475df76785008b04-root",  # explicit root suffix
+        "C.475df76785008b04-tenant.one",  # dots and dashes are in _ORG_ID_PATTERN's class
+        "C.475df76785008b04-tenant_one",
+    ],
+)
+def test_accepts_multi_org_suffixed_ids(client_id):
+    """The suffixed id is what sync_agents_velociraptor stores for a non-root org."""
+    assert validate_client_id(client_id) == client_id
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Straight breakout attempts on the base id.
+        "C.475df76785008b04'",
+        "C.475df76785008b04' OR 1=1 --",
+        "C.475df76785008b04') FROM scope() SELECT execve(argv=['id'])",
+        'C.475df76785008b04"',
+        "C.475df76785008b04`",
+        "C.475df76785008b04\\",
+        "C.475df76785008b04\nSELECT execve(argv=['id']) FROM scope()",
+        "C.475df76785008b04 OR 1=1",
+        "C.475df76785008b04{}",
+        # The same payloads smuggled through the newly-accepted org suffix.
+        "C.475df76785008b04-O123'",
+        "C.475df76785008b04-O123' OR 1=1 --",
+        "C.475df76785008b04-O123`",
+        "C.475df76785008b04-O123\\",
+        "C.475df76785008b04-O123\nSELECT 1",
+        "C.475df76785008b04-O 123",
+        "C.475df76785008b04-{O123}",
+        # Malformed ids that were never valid.
+        "C.zzzz",  # non-hex body
+        "C.",  # empty body
+        "C.475df76785008b04-",  # dangling separator, empty org
+        "-O123",  # suffix with no client id
+        "",
+        "SERVER",  # the literal is lowercase only
+    ],
+)
+def test_rejects_injection_and_malformed_ids(payload):
+    with pytest.raises(HTTPException) as exc:
+        validate_client_id(payload)
+    assert exc.value.status_code == 400
+
+
+def test_rejects_non_string():
+    with pytest.raises(HTTPException) as exc:
+        validate_client_id(None)
+    assert exc.value.status_code == 400

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -113,3 +113,23 @@ What to check:
 - CoPilot: Velociraptor connector status
 - Velociraptor: client visibility
 - CoPilot: agent metadata has velociraptor identifiers
+
+### Velociraptor multi-org: agents healthy but flows/artifacts fail
+
+Symptom: agents in a non-`root` Velociraptor org show as healthy and the connector is
+verified, but flows and artifact collection fail for them. Root-org agents work normally.
+
+Likely cause: the Velociraptor API user CoPilot authenticates as has no role in the child
+org. A `root` administrator is **not** implicitly an administrator in child orgs. Org
+enumeration runs at root and succeeds, so the gap only shows on org-scoped queries.
+
+What to check:
+- CoPilot returns `403` with `Velociraptor denied the query for org '<ORGID>'` — that is
+  Velociraptor refusing, not CoPilot failing
+- On the Velociraptor server, grant the API user a role **per org**:
+
+```
+SELECT user_grant(user='<copilot api user>', roles='administrator', orgs=['<ORGID>']) FROM scope()
+```
+
+Repeat for every tenant org. Then re-run the agent sync.


### PR DESCRIPTION
Fixes #1015. Thanks @chiefghost47 for the diagnosis — the root cause and the suggested pattern were both correct, and this takes the second half of the report along with it.

## Problem

In a multi-org Velociraptor deployment every agent outside the `root` org fails with `400 Invalid Velociraptor client id` on endpoints that validate one — `GET /api/flows/{host}` being the visible one.

`clients()` reports a client's id *within an org* as `C.<hex>-<ORGID>`, and that suffixed form is the one the server matches on:

```
flows(client_id='C.aaaaaaaaaaaaaaaa')          -> 0 rows
flows(client_id='C.aaaaaaaaaaaaaaaa-OXXXXXXX') -> 1 row
```

`sync_agents_velociraptor` stores exactly what `clients()` reports (`agents.velociraptor_id`), so CoPilot persisted a value its own validator refused. The agent list and health indicator don't validate a client id, which is why those agents read as healthy while flows and artifacts were dead — the mismatch that made it look like a Velociraptor problem.

## Fix

```diff
-_CLIENT_ID_PATTERN = re.compile(r"^(server|C\.[0-9A-Fa-f]+)$")
+_CLIENT_ID_PATTERN = re.compile(r"^(server|C\.[0-9A-Fa-f]+(-[A-Za-z0-9._-]+)?)$")
```

The suffix uses the same character class as `_ORG_ID_PATTERN`. No quote, backtick, brace, backslash, whitespace or newline is admitted, so the injection defence from GHSA-5542-j2fc-gqjm is untouched — this widens an accepted *format*, not the escape rejection.

## Second half: the permission error behind it

Once the id is accepted, the query still fails unless the API user CoPilot authenticates as holds a role **in each org** — a `root` administrator is not implicitly an administrator in child orgs. Org enumeration runs at root and succeeds, so the gap only surfaced on org-scoped queries, as a generic 500 that read like a CoPilot fault.

`execute_query` now maps a gRPC permission denial to **403** naming the org and the exact grant:

```
Velociraptor denied the query for org 'OXXXXXXX': Permission denied: User admin requires permission ANY_QUERY to run queries.
The Velociraptor API user CoPilot authenticates as needs a role in each org, not just root.
Grant it on the Velociraptor server with:
SELECT user_grant(user='<copilot api user>', roles='administrator', orgs=['OXXXXXXX']) FROM scope()
```

`docs/reference/troubleshooting.mdx` gains a matching "Velociraptor multi-org: agents healthy but flows/artifacts fail" section.

## Testing

New `backend/tests/test_velociraptor_client_id_validation.py` — 31 cases, all passing:

- the suffixed ids sync actually stores are accepted (`C.<hex>-OXXXXXXX`, generated org ids, `-root`, dotted/underscored tenant names)
- root-org ids and the `server` literal still accepted
- injection payloads still rejected — quote, double quote, backtick, backslash, newline, space, brace, `execve()` subquery
- **the same payloads smuggled through the newly accepted suffix** are rejected
- malformed ids rejected: non-hex body, empty body, dangling `C.<hex>-`, bare `-O123`

Verified the multi-org cases fail against the pre-fix pattern, so the tests pin the actual bug.

Run: `cd backend && python -m pytest tests/test_velociraptor_client_id_validation.py`. `pre-commit run --files ...` clean on all four files.