### PR TITLE
feat: false positive classification on alerts (phase 1)

### DIFF
--- a/backend/alembic/versions/b151c7ebbb95_false_positive_alerts.py
+++ b/backend/alembic/versions/b151c7ebbb95_false_positive_alerts.py
@@ -1,0 +1,105 @@
+"""false positive alerts
+
+Revision ID: b151c7ebbb95
+Revises: b4c7e2a91f38
+Create Date: 2026-08-20 19:48:12.209870
+
+Alerts had no structured way to record that they were judged a false positive. Tags were
+the workaround, but they are free-form and ACL-gated, so the monthly "how many false
+positives, and from which detections" question could not be answered reliably.
+
+See issue #1085.
+
+"""
+from typing import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b151c7ebbb95"
+down_revision: Union[str, None] = "b4c7e2a91f38"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # `verdict` is nullable with NO default and NO backfill, and that is the load-bearing
+    # decision in this migration.
+    #
+    # NULL means "nobody has judged this alert yet", which is a different fact from
+    # "judged, and not a false positive". A NOT NULL boolean defaulting to False -- the
+    # obvious shape for a feature described as a false-positive flag -- would fold every
+    # never-triaged alert into the true-positive side. The KPI a monthly service review
+    # needs is "of the alerts we actually reviewed, X% were false positives", and that
+    # ratio is only computable while unreviewed alerts remain distinguishable.
+    #
+    # Existing rows therefore stay NULL: they were never triaged under this scheme, and
+    # inventing a verdict for them would put fabricated data into the first report anyone
+    # runs. Backfilling from an existing "FP"-style tag was considered and rejected for
+    # the same reason -- tag spelling is exactly what is not trustworthy here.
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("verdict", sa.String(length=20), nullable=True),
+    )
+
+    # Why it was judged a false positive. Only meaningful alongside verdict =
+    # FALSE_POSITIVE; the application enforces that pairing, since a CHECK constraint here
+    # would be unenforced on MySQL 5.7 and silently ignored rather than failing loudly.
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("verdict_reason", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("verdict_note", sa.String(length=1024), nullable=True),
+    )
+
+    # Who judged it and when. `verdict_by` is a username snapshot with no foreign key,
+    # matching `assigned_to` on this table: the record of who made the call has to survive
+    # that user being deleted. These carry the CURRENT verdict only -- the change history,
+    # including a verdict later reversed, lives in `audit_log` under alert.verdict_set /
+    # alert.verdict_clear.
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("verdict_by", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "incident_management_alert",
+        sa.Column("verdict_at", sa.DateTime(), nullable=True),
+    )
+
+    # Filtering by verdict is the point of storing it -- including the untriaged slice,
+    # which is an IS NULL scan an analyst runs against a whole review backlog.
+    op.create_index("ix_incident_management_alert_verdict", "incident_management_alert", ["verdict"])
+
+    # Every reporting query is per-tenant ("false positive rate for customer X last
+    # month"), so the composite carries those rather than making them scan the
+    # single-column index and filter. customer_code first: it is the more selective leg
+    # and the one always present, while verdict may be absent from a query that only
+    # counts a customer's alerts.
+    op.create_index(
+        "ix_incident_management_alert_customer_verdict",
+        "incident_management_alert",
+        ["customer_code", "verdict"],
+    )
+
+
+def downgrade() -> None:
+    """Lossy: an analyst's triage judgement is not re-derivable from anything else.
+
+    The audit_log rows written by alert.verdict_set / alert.verdict_clear survive this
+    downgrade and hold the same information, so a re-upgrade could be reconstructed from
+    them if it ever mattered. That reconstruction is deliberately not automated here --
+    replaying it belongs in a one-off script written by whoever needs it, not in a
+    downgrade path that would run silently.
+    """
+    op.drop_index("ix_incident_management_alert_customer_verdict", table_name="incident_management_alert")
+    op.drop_index("ix_incident_management_alert_verdict", table_name="incident_management_alert")
+    op.drop_column("incident_management_alert", "verdict_at")
+    op.drop_column("incident_management_alert", "verdict_by")
+    op.drop_column("incident_management_alert", "verdict_note")
+    op.drop_column("incident_management_alert", "verdict_reason")
+    op.drop_column("incident_management_alert", "verdict")

--- a/backend/app/audit/models/audit.py
+++ b/backend/app/audit/models/audit.py
@@ -61,6 +61,10 @@ class AuditAction(str, Enum):
     # Cases
     CASE_CREATE = "case.create"
 
+    # Alert triage
+    ALERT_VERDICT_SET = "alert.verdict_set"
+    ALERT_VERDICT_CLEAR = "alert.verdict_clear"
+
     # File data store
     DATASTORE_FILE_CREATE = "datastore.file_create"
     DATASTORE_FILE_DELETE = "datastore.file_delete"

--- a/backend/app/incidents/models.py
+++ b/backend/app/incidents/models.py
@@ -58,6 +58,38 @@ class Alert(SQLModel, table=True):
     assigned_to: Optional[str] = Field(max_length=50, nullable=True)
     escalated: bool = Field(default=False, nullable=False)
 
+    # Analyst triage verdict: TRUE_POSITIVE | FALSE_POSITIVE (see AlertVerdict).
+    #
+    # Deliberately TRI-STATE, not a `false_positive` boolean. NULL means "nobody has
+    # judged this yet" -- which is a different fact from "judged, and not a false
+    # positive". A NOT NULL boolean defaulting to False would fold every never-triaged
+    # alert into the true-positive side and make the headline KPI a lie: the number a
+    # monthly service review needs is "of the alerts we actually reviewed, X% were false
+    # positives", and that ratio is only computable if unreviewed alerts are excludable.
+    #
+    # Orthogonal to `status` on purpose. A CLOSED alert can be either verdict, and status
+    # already drives the OPEN/IN_PROGRESS/CLOSED counters -- folding a verdict into it
+    # would break those and throw the true/false axis away (GitHub issue #1085).
+    #
+    # Indexed because filtering and aggregating on it is the point of storing it.
+    verdict: Optional[str] = Field(default=None, max_length=20, nullable=True, index=True)
+
+    # Why it was judged a false positive (see FalsePositiveReason). Only meaningful when
+    # verdict is FALSE_POSITIVE. A closed vocabulary rather than free text is the whole
+    # reason this feature exists instead of a tag -- consistent values are what make
+    # "most common false positive categories" answerable.
+    verdict_reason: Optional[str] = Field(default=None, max_length=50, nullable=True)
+
+    # Free-text detail, for the OTHER reason or any judgement worth a sentence.
+    verdict_note: Optional[str] = Field(default=None, max_length=1024, nullable=True)
+
+    # Who judged it and when. Username is a denormalized snapshot with no FK, matching
+    # `assigned_to` above: the record of who called it must survive that user's deletion.
+    # These carry the *current* verdict only -- the full change history (including a
+    # verdict being reversed) goes to the audit log as ALERT_VERDICT_SET/CLEAR.
+    verdict_by: Optional[str] = Field(default=None, max_length=50, nullable=True)
+    verdict_at: Optional[datetime] = Field(default=None, nullable=True)
+
     comments: List["Comment"] = Relationship(back_populates="alert")
     assets: List["Asset"] = Relationship(back_populates="alert")
     cases: List["CaseAlertLink"] = Relationship(back_populates="alert")

--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -103,6 +103,7 @@ from app.incidents.schema.db_operations import SocfortressRecommendsWazuhIoCFiel
 from app.incidents.schema.db_operations import SocfortressRecommendsWazuhResponse
 from app.incidents.schema.db_operations import SocfortressRecommendsWazuhTimeFieldName
 from app.incidents.schema.db_operations import UpdateAlertStatus
+from app.incidents.schema.db_operations import UpdateAlertVerdict
 from app.incidents.schema.db_operations import UpdateCaseStatus
 from app.incidents.schema.incident_alert import CreatedAlertPayload
 from app.incidents.schema.incident_alert import CreatedCaseNotificationPayload
@@ -234,6 +235,7 @@ from app.incidents.services.db_operations import report_template_exists
 from app.incidents.services.db_operations import update_alert_assigned_to
 from app.incidents.services.db_operations import update_alert_escalated
 from app.incidents.services.db_operations import update_alert_status
+from app.incidents.services.db_operations import update_alert_verdict
 from app.incidents.services.db_operations import update_case_assigned_to
 from app.incidents.services.db_operations import update_case_customer_code
 from app.incidents.services.db_operations import update_case_escalated
@@ -573,6 +575,62 @@ async def update_alert_status_endpoint(
     # caller who is not entitled to it (GHSA-wjpw-xrg8-vmf9).
     await _ensure_alert_access(alert_status.alert_id, current_user, db)
     return AlertResponse(alert=await update_alert_status(alert_status, db), success=True, message="Alert status updated successfully")
+
+
+@incidents_db_operations_router.put(
+    "/alert/verdict",
+    response_model=AlertResponse,
+    description="Set, change or clear an alert's triage verdict (true positive / false positive)",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def update_alert_verdict_endpoint(
+    alert_verdict: UpdateAlertVerdict,
+    request: Request,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Record an analyst's triage verdict on an alert (GitHub issue #1085).
+
+    Scoped to admin/analyst, deliberately narrower than the sibling `/alert/status` route
+    which also admits `customer_user`. The verdict feeds SOC quality metrics and detection
+    tuning, so the set of people who can move those numbers is kept to the SOC. Widening
+    it later is a one-word change; narrowing it after release would break callers.
+    """
+    # Enforce per-object ownership: resolve the alert's customer and reject a
+    # caller who is not entitled to it (GHSA-wjpw-xrg8-vmf9).
+    await _ensure_alert_access(alert_verdict.alert_id, current_user, db)
+
+    verdict_value = alert_verdict.verdict.value if alert_verdict.verdict else None
+    reason_value = alert_verdict.verdict_reason.value if alert_verdict.verdict_reason else None
+
+    updated_alert, previous = await update_alert_verdict(
+        alert_id=alert_verdict.alert_id,
+        verdict=verdict_value,
+        verdict_reason=reason_value,
+        verdict_note=alert_verdict.verdict_note,
+        actor=current_user.username,
+        db=db,
+    )
+
+    # The columns carry the current verdict only; the audit log carries the history, so a
+    # verdict that was set and later reversed stays answerable after the fact.
+    await record_audit_event(
+        action=AuditAction.ALERT_VERDICT_CLEAR if verdict_value is None else AuditAction.ALERT_VERDICT_SET,
+        actor_user_id=current_user.id,
+        actor_username=current_user.username,
+        customer_code=updated_alert.customer_code,
+        entity_type="alert",
+        entity_id=updated_alert.id,
+        old_value=previous,
+        new_value={
+            "verdict": verdict_value,
+            "verdict_reason": reason_value,
+            "verdict_note": alert_verdict.verdict_note,
+        },
+        request=request,
+    )
+
+    return AlertResponse(alert=updated_alert, success=True, message="Alert verdict updated successfully")
 
 
 @incidents_db_operations_router.put(
@@ -1792,6 +1850,11 @@ async def list_alerts_multiple_filters_endpoint(
     status: Optional[str] = Query(None),
     tags: Optional[List[str]] = Query(None),
     ioc_value: Optional[str] = Query(None),
+    verdict: Optional[str] = Query(
+        None,
+        description="TRUE_POSITIVE, FALSE_POSITIVE, or UNTRIAGED for alerts with no verdict recorded yet",
+    ),
+    verdict_reason: Optional[str] = Query(None, description="False-positive reason; only meaningful alongside verdict=FALSE_POSITIVE"),
     page: int = Query(1, ge=1),
     page_size: int = Query(25, ge=1),
     order: str = Query("desc", pattern="^(asc|desc)$"),
@@ -1833,6 +1896,8 @@ async def list_alerts_multiple_filters_endpoint(
         status=status,
         tags=tags,
         ioc_value=ioc_value,
+        verdict=verdict,
+        verdict_reason=verdict_reason,
         db=db,
         page=page,
         page_size=page_size,
@@ -1857,6 +1922,8 @@ async def list_alerts_multiple_filters_endpoint(
         status=status,
         tags=tags,
         ioc_value=ioc_value,
+        verdict=verdict,
+        verdict_reason=verdict_reason,
         db=db,
     )
 

--- a/backend/app/incidents/schema/db_operations.py
+++ b/backend/app/incidents/schema/db_operations.py
@@ -7,6 +7,7 @@ from typing import Optional
 from fastapi import HTTPException
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 
@@ -120,6 +121,61 @@ class AlertStatus(str, Enum):
 class UpdateAlertStatus(BaseModel):
     alert_id: int
     status: AlertStatus
+
+
+class AlertVerdict(str, Enum):
+    """Analyst triage verdict. The absence of a verdict (NULL on the alert) is a third,
+    meaningful state -- "not yet triaged" -- and is represented by omitting the value
+    rather than by a member here."""
+
+    TRUE_POSITIVE = "TRUE_POSITIVE"
+    FALSE_POSITIVE = "FALSE_POSITIVE"
+
+
+class FalsePositiveReason(str, Enum):
+    """Why an alert was judged a false positive.
+
+    A closed vocabulary on purpose: free-form tags were the pre-existing workaround and
+    the reason reporting on false positives was unreliable (GitHub issue #1085). Adding a
+    member is a code change, which is what keeps the aggregate counts comparable across
+    analysts and across months.
+    """
+
+    EXPECTED_ACTIVITY = "EXPECTED_ACTIVITY"
+    KNOWN_APPLICATION = "KNOWN_APPLICATION"
+    AUTHORIZED_USER = "AUTHORIZED_USER"
+    RULE_TOO_SENSITIVE = "RULE_TOO_SENSITIVE"
+    OTHER = "OTHER"
+
+
+# Filter-only sentinel for "no verdict recorded yet". Not an AlertVerdict member and never
+# stored -- untriaged is NULL on the column. It exists so a single `verdict` query param can
+# express all three states an analyst wants to slice by.
+VERDICT_FILTER_UNTRIAGED = "UNTRIAGED"
+
+
+class UpdateAlertVerdict(BaseModel):
+    """Set, change or clear an alert's triage verdict.
+
+    `verdict=None` clears it back to untriaged, which is why the field is Optional rather
+    than defaulted -- an analyst who mis-clicked needs a way back to "nobody has judged
+    this", and that is not the same as marking it a true positive.
+    """
+
+    alert_id: int
+    verdict: Optional[AlertVerdict] = None
+    verdict_reason: Optional[FalsePositiveReason] = None
+    verdict_note: Optional[str] = Field(default=None, max_length=1024)
+
+    @model_validator(mode="after")
+    def check_reason_matches_verdict(self):
+        # A reason only means anything alongside FALSE_POSITIVE. Silently dropping a
+        # mismatched one would leave the caller believing it was recorded.
+        if self.verdict_reason is not None and self.verdict != AlertVerdict.FALSE_POSITIVE:
+            raise ValueError("verdict_reason is only valid when verdict is FALSE_POSITIVE")
+        if self.verdict == AlertVerdict.FALSE_POSITIVE and self.verdict_reason is None:
+            raise ValueError("verdict_reason is required when verdict is FALSE_POSITIVE")
+        return self
 
 
 class UpdateCaseStatus(BaseModel):
@@ -444,13 +500,18 @@ class AlertOut(BaseModel):
     source: str
     assigned_to: Optional[str] = None
     escalated: bool = False
+    verdict: Optional[str] = None
+    verdict_reason: Optional[str] = None
+    verdict_note: Optional[str] = None
+    verdict_by: Optional[str] = None
+    verdict_at: Optional[str] = None
     comments: List[CommentBase] = []
     assets: List[AssetBase] = []
     tags: List[AlertTagBase] = []
     linked_cases: List[LinkedCaseCreate] = []
     iocs: List[IoCBase] = []
 
-    @field_validator("alert_creation_time", "time_closed", mode="before")
+    @field_validator("alert_creation_time", "time_closed", "verdict_at", mode="before")
     @classmethod
     def format_datetime(cls, v):
         if isinstance(v, datetime):
@@ -595,6 +656,11 @@ class AlertFilterOptionsResponse(BaseModel):
     assets: List[str]
     tags: List[str]
     statuses: List[str] = [s.value for s in AlertStatus]
+    # Verdict vocabulary is served alongside the data-derived options so the UI never
+    # hard-codes it. UNTRIAGED is included because it is a selectable filter state even
+    # though it is never a stored value.
+    verdicts: List[str] = [v.value for v in AlertVerdict] + [VERDICT_FILTER_UNTRIAGED]
+    false_positive_reasons: List[str] = [r.value for r in FalsePositiveReason]
     success: bool
     message: str
 

--- a/backend/app/incidents/services/db_operations.py
+++ b/backend/app/incidents/services/db_operations.py
@@ -54,6 +54,7 @@ from app.incidents.models import IoCFieldName
 from app.incidents.models import Notification
 from app.incidents.models import ThresholdAlertMetadata
 from app.incidents.models import TimestampFieldName
+from app.incidents.schema.db_operations import VERDICT_FILTER_UNTRIAGED
 from app.incidents.schema.db_operations import AlertContextCreate
 from app.incidents.schema.db_operations import AlertCreate
 from app.incidents.schema.db_operations import AlertIoCCreate
@@ -85,6 +86,48 @@ from app.integrations.alert_creation_settings.models.alert_creation_settings imp
     AlertCreationSettings,
 )
 from app.middleware.customer_access import customer_access_handler
+
+
+def build_alert_out(
+    alert: Alert,
+    *,
+    comments: Optional[List[CommentBase]] = None,
+    assets: Optional[List[AssetBase]] = None,
+    tags: Optional[List[AlertTagBase]] = None,
+    iocs: Optional[List[IoCBase]] = None,
+    linked_cases: Optional[List[LinkedCaseCreate]] = None,
+) -> AlertOut:
+    """Single construction point for an ``AlertOut`` from an ``Alert`` row.
+
+    Twenty call sites in this module used to spell out the same ten scalar fields by hand
+    and differ only in which relationship lists they had loaded. That made adding a field
+    to the alert response a twenty-site edit, and the fastest way to ship a field that is
+    silently missing from four of the listing endpoints. Every caller now goes through
+    here; the relationship lists stay per-caller because not all of them eager-load all
+    five, and omitting one must keep meaning "empty" exactly as it did before.
+    """
+    return AlertOut(
+        id=alert.id,
+        alert_creation_time=alert.alert_creation_time,
+        time_closed=alert.time_closed,
+        alert_name=alert.alert_name,
+        alert_description=alert.alert_description,
+        status=alert.status,
+        customer_code=alert.customer_code,
+        source=alert.source,
+        assigned_to=alert.assigned_to,
+        escalated=alert.escalated,
+        verdict=alert.verdict,
+        verdict_reason=alert.verdict_reason,
+        verdict_note=alert.verdict_note,
+        verdict_by=alert.verdict_by,
+        verdict_at=alert.verdict_at,
+        comments=comments or [],
+        assets=assets or [],
+        tags=tags or [],
+        iocs=iocs or [],
+        linked_cases=linked_cases or [],
+    )
 
 
 async def customer_code_valid(customer_code: str, db: AsyncSession) -> bool:
@@ -439,6 +482,8 @@ async def alerts_total_multiple_filters(
     status: Optional[str] = None,
     tags: Optional[List[str]] = None,
     ioc_value: Optional[str] = None,
+    verdict: Optional[str] = None,
+    verdict_reason: Optional[str] = None,
 ) -> int:
     """Count alerts matching the filter set.
 
@@ -465,6 +510,13 @@ async def alerts_total_multiple_filters(
         filters.append(AlertTag.tag.in_(tags))
     if ioc_value:
         filters.append(IoC.value == ioc_value)
+    if verdict:
+        # UNTRIAGED is a filter-only sentinel, not a stored value: the untriaged state is
+        # NULL on the column, and "no verdict yet" is exactly the slice an analyst working
+        # a review queue wants (GitHub issue #1085).
+        filters.append(Alert.verdict.is_(None) if verdict == VERDICT_FILTER_UNTRIAGED else Alert.verdict == verdict)
+    if verdict_reason:
+        filters.append(Alert.verdict_reason == verdict_reason)
 
     # Build the query with dynamic filters
     query = (
@@ -1072,6 +1124,49 @@ async def update_alert_assigned_to(alert_id: int, assigned_to: str, db: AsyncSes
     return alert
 
 
+async def update_alert_verdict(
+    alert_id: int,
+    verdict: Optional[str],
+    verdict_reason: Optional[str],
+    verdict_note: Optional[str],
+    actor: Optional[str],
+    db: AsyncSession,
+) -> Tuple[Alert, dict]:
+    """Set, change or clear an alert's triage verdict (GitHub issue #1085).
+
+    Returns the alert plus the previous verdict snapshot, so the caller can write the
+    audit record without re-reading the row. Clearing (``verdict=None``) wipes the reason,
+    note and attribution together -- leaving a stale "marked false positive by X" behind
+    an absent verdict is worse than no attribution at all.
+    """
+    result = await db.execute(select(Alert).where(Alert.id == alert_id))
+    alert = result.scalars().first()
+    if not alert:
+        raise HTTPException(status_code=404, detail="Alert not found")
+
+    previous = {
+        "verdict": alert.verdict,
+        "verdict_reason": alert.verdict_reason,
+        "verdict_note": alert.verdict_note,
+        "verdict_by": alert.verdict_by,
+    }
+
+    alert.verdict = verdict
+    if verdict is None:
+        alert.verdict_reason = None
+        alert.verdict_note = None
+        alert.verdict_by = None
+        alert.verdict_at = None
+    else:
+        alert.verdict_reason = verdict_reason
+        alert.verdict_note = verdict_note
+        alert.verdict_by = actor
+        alert.verdict_at = datetime.utcnow()
+
+    await db.commit()
+    return alert, previous
+
+
 async def update_alert_escalated(alert_id: int, escalated: bool, db: AsyncSession) -> Alert:
     result = await db.execute(select(Alert).where(Alert.id == alert_id))
     alert = result.scalars().first()
@@ -1360,23 +1455,7 @@ async def get_alert_by_id(alert_id: int, db: AsyncSession, user: Optional[User] 
     iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
     linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
 
-    alert_out = AlertOut(
-        id=alert.id,
-        alert_creation_time=alert.alert_creation_time,
-        time_closed=alert.time_closed,
-        alert_name=alert.alert_name,
-        alert_description=alert.alert_description,
-        status=alert.status,
-        customer_code=alert.customer_code,
-        source=alert.source,
-        assigned_to=alert.assigned_to,
-        escalated=alert.escalated,
-        comments=comments,
-        assets=assets,
-        tags=tags,
-        iocs=iocs,
-        linked_cases=linked_cases,
-    )
+    alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
 
     return alert_out
 
@@ -1407,23 +1486,7 @@ async def list_alerts(db: AsyncSession, page: int = 1, page_size: int = 25, orde
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
         linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            iocs=iocs,
-            linked_cases=linked_cases,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -1709,23 +1772,7 @@ async def get_case_by_id(case_id: int, db: AsyncSession) -> CaseOut:
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            linked_cases=linked_cases,
-            iocs=iocs,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
         alerts_out.append(alert_out)
 
     # Extract case comments
@@ -1769,23 +1816,7 @@ async def list_cases(db: AsyncSession) -> List[CaseOut]:
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
             linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
             iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-                linked_cases=linked_cases,
-                iocs=iocs,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
             alerts_out.append(alert_out)
 
         # Extract case comments
@@ -1838,23 +1869,7 @@ async def list_cases_by_status(status: str, db: AsyncSession, page: int = 1, pag
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
             linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
             iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-                linked_cases=linked_cases,
-                iocs=iocs,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
             alerts_out.append(alert_out)
 
         # Extract case comments
@@ -1888,23 +1903,7 @@ def _case_to_out(case: Case) -> CaseOut:
         linked_cases = [LinkedCaseCreate(**link.case.__dict__) for link in alert.cases]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
         alerts_out.append(
-            AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-                linked_cases=linked_cases,
-                iocs=iocs,
-            ),
+            build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases),
         )
 
     case_comments = [CaseCommentBase(**comment.__dict__) for comment in case.comments]
@@ -1973,21 +1972,7 @@ async def list_cases_by_assigned_to(assigned_to: str, db: AsyncSession) -> List[
             comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
             assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
             alerts_out.append(alert_out)
 
         # Handle case comments
@@ -2042,21 +2027,7 @@ async def list_cases_by_asset_name(asset_name: str, db: AsyncSession) -> List[Ca
             comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
             assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
             alerts_out.append(alert_out)
 
         # Handle case comments
@@ -2108,21 +2079,7 @@ async def list_cases_by_customer_code(customer_code: str, db: AsyncSession) -> L
             comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
             assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
             alerts_out.append(alert_out)
 
         # Handle case comments
@@ -2191,22 +2148,7 @@ async def list_alerts_by_ioc(ioc_value: str, db: AsyncSession, page: int = 1, pa
         assets: List[AssetBase] = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags: List[AlertTagBase] = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         iocs: List[IoCBase] = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            iocs=iocs,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2238,22 +2180,7 @@ async def list_alerts_by_tag(tag: str, db: AsyncSession, page: int = 1, page_siz
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            iocs=iocs,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2284,22 +2211,7 @@ async def list_alert_by_status(status: str, db: AsyncSession, page: int = 1, pag
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            iocs=iocs,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2334,21 +2246,7 @@ async def list_alerts_by_asset_name(
         comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2382,21 +2280,7 @@ async def list_alert_by_assigned_to(
         comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2430,21 +2314,7 @@ async def list_alerts_by_title(
         comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2478,21 +2348,7 @@ async def list_alerts_by_customer_code(
         comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2526,21 +2382,7 @@ async def list_alerts_by_source(
         comments = [CommentBase(**comment.__dict__) for comment in alert.comments]
         assets = [AssetBase(**asset.__dict__) for asset in alert.assets]
         tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags)
         alerts_out.append(alert_out)
     return alerts_out
 
@@ -2556,6 +2398,8 @@ async def list_alerts_multiple_filters(
     status: Optional[str] = None,
     tags: Optional[List[str]] = None,
     ioc_value: Optional[str] = None,
+    verdict: Optional[str] = None,
+    verdict_reason: Optional[str] = None,
     page: int = 1,
     page_size: int = 25,
     order: str = "desc",
@@ -2594,6 +2438,13 @@ async def list_alerts_multiple_filters(
         filters.append(AlertTag.tag.in_(tags))
     if ioc_value:
         filters.append(IoC.value == ioc_value)
+    if verdict:
+        # UNTRIAGED is a filter-only sentinel, not a stored value: the untriaged state is
+        # NULL on the column, and "no verdict yet" is exactly the slice an analyst working
+        # a review queue wants (GitHub issue #1085).
+        filters.append(Alert.verdict.is_(None) if verdict == VERDICT_FILTER_UNTRIAGED else Alert.verdict == verdict)
+    if verdict_reason:
+        filters.append(Alert.verdict_reason == verdict_reason)
 
     # Apply tag-based RBAC filtering if user is provided
     if user:
@@ -2660,23 +2511,7 @@ async def list_alerts_multiple_filters(
         tags_out = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
         linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags_out,
-            iocs=iocs,
-            linked_cases=linked_cases,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags_out, iocs=iocs, linked_cases=linked_cases)
         alerts_out.append(alert_out)
 
     return alerts_out
@@ -2765,23 +2600,7 @@ async def list_alerts_for_user(
         iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
         linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
 
-        alert_out = AlertOut(
-            id=alert.id,
-            alert_creation_time=alert.alert_creation_time,
-            time_closed=alert.time_closed,
-            alert_name=alert.alert_name,
-            alert_description=alert.alert_description,
-            status=alert.status,
-            customer_code=alert.customer_code,
-            source=alert.source,
-            assigned_to=alert.assigned_to,
-            escalated=alert.escalated,
-            comments=comments,
-            assets=assets,
-            tags=tags,
-            iocs=iocs,
-            linked_cases=linked_cases,
-        )
+        alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
         alerts_out.append(alert_out)
 
     return alerts_out
@@ -2883,23 +2702,7 @@ async def list_cases_for_user(
             tags = [AlertTagBase(**alert_to_tag.tag.__dict__) for alert_to_tag in alert.tags]
             linked_cases = [LinkedCaseCreate(**case_alert_link.case.__dict__) for case_alert_link in alert.cases]
             iocs = [IoCBase(**alert_to_ioc.ioc.__dict__) for alert_to_ioc in alert.iocs]
-            alert_out = AlertOut(
-                id=alert.id,
-                alert_creation_time=alert.alert_creation_time,
-                time_closed=alert.time_closed,
-                alert_name=alert.alert_name,
-                alert_description=alert.alert_description,
-                status=alert.status,
-                customer_code=alert.customer_code,
-                source=alert.source,
-                assigned_to=alert.assigned_to,
-                escalated=alert.escalated,
-                comments=comments,
-                assets=assets,
-                tags=tags,
-                linked_cases=linked_cases,
-                iocs=iocs,
-            )
+            alert_out = build_alert_out(alert, comments=comments, assets=assets, tags=tags, iocs=iocs, linked_cases=linked_cases)
             alerts_out.append(alert_out)
 
         # Handle case comments

--- a/backend/tests/test_alert_verdict.py
+++ b/backend/tests/test_alert_verdict.py
@@ -1,0 +1,164 @@
+"""Tests for the alert triage verdict — false positive classification (issue #1085).
+
+Two pieces of real logic are covered here, both pure enough to test without a database:
+
+1. `UpdateAlertVerdict` validation. A false-positive reason is mandatory when marking an
+   alert a false positive and meaningless otherwise. Free-form classification via tags was
+   the pre-existing workaround and the reason false-positive reporting was unreliable, so
+   the request model has to refuse the shapes that would reintroduce it.
+2. `build_alert_out`. Twenty call sites used to spell out the alert projection by hand;
+   they now share this one helper, so a field silently missing from it would be missing
+   from every listing endpoint at once.
+
+Run with: cd backend && python -m pytest tests/test_alert_verdict.py
+"""
+
+import os
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.incidents.models import Alert  # noqa: E402
+from app.incidents.schema.db_operations import VERDICT_FILTER_UNTRIAGED  # noqa: E402
+from app.incidents.schema.db_operations import AlertVerdict  # noqa: E402
+from app.incidents.schema.db_operations import FalsePositiveReason  # noqa: E402
+from app.incidents.schema.db_operations import UpdateAlertVerdict  # noqa: E402
+from app.incidents.services.db_operations import build_alert_out  # noqa: E402
+
+
+def _alert(**overrides) -> Alert:
+    defaults = dict(
+        id=1,
+        alert_name="Suspicious PowerShell",
+        alert_description="encoded command",
+        status="OPEN",
+        customer_code="ACME",
+        source="wazuh",
+        assigned_to="analyst1",
+        escalated=False,
+        alert_creation_time=datetime(2026, 8, 20, 12, 0, 0),
+    )
+    defaults.update(overrides)
+    return Alert(**defaults)
+
+
+# --- UpdateAlertVerdict validation -------------------------------------------------
+
+
+def test_false_positive_requires_a_reason():
+    """Without this, an analyst could mark FP with no category and the monthly
+    "most common false positive categories" report would have a silent null bucket."""
+    with pytest.raises(ValidationError):
+        UpdateAlertVerdict(alert_id=1, verdict=AlertVerdict.FALSE_POSITIVE)
+
+
+def test_false_positive_with_reason_is_accepted():
+    payload = UpdateAlertVerdict(
+        alert_id=1,
+        verdict=AlertVerdict.FALSE_POSITIVE,
+        verdict_reason=FalsePositiveReason.RULE_TOO_SENSITIVE,
+        verdict_note="fires on every backup job",
+    )
+    assert payload.verdict is AlertVerdict.FALSE_POSITIVE
+    assert payload.verdict_reason is FalsePositiveReason.RULE_TOO_SENSITIVE
+
+
+def test_true_positive_rejects_a_false_positive_reason():
+    """Silently dropping the mismatched reason would leave the caller believing it was
+    recorded."""
+    with pytest.raises(ValidationError):
+        UpdateAlertVerdict(
+            alert_id=1,
+            verdict=AlertVerdict.TRUE_POSITIVE,
+            verdict_reason=FalsePositiveReason.OTHER,
+        )
+
+
+def test_true_positive_needs_no_reason():
+    payload = UpdateAlertVerdict(alert_id=1, verdict=AlertVerdict.TRUE_POSITIVE)
+    assert payload.verdict_reason is None
+
+
+def test_clearing_the_verdict_is_valid():
+    """Omitting the verdict clears it back to untriaged — an analyst who mis-clicked needs
+    a way back to "nobody has judged this", which is not the same as true positive."""
+    payload = UpdateAlertVerdict(alert_id=1)
+    assert payload.verdict is None
+    assert payload.verdict_reason is None
+
+
+def test_clearing_rejects_a_stray_reason():
+    with pytest.raises(ValidationError):
+        UpdateAlertVerdict(alert_id=1, verdict_reason=FalsePositiveReason.OTHER)
+
+
+def test_note_is_length_capped_to_the_column():
+    with pytest.raises(ValidationError):
+        UpdateAlertVerdict(
+            alert_id=1,
+            verdict=AlertVerdict.FALSE_POSITIVE,
+            verdict_reason=FalsePositiveReason.OTHER,
+            verdict_note="x" * 1025,
+        )
+
+
+def test_untriaged_sentinel_is_not_a_storable_verdict():
+    """UNTRIAGED is filter-only. If it ever became an AlertVerdict member, rows would start
+    storing the string and the NULL-means-untriaged invariant would quietly split in two."""
+    assert VERDICT_FILTER_UNTRIAGED not in {v.value for v in AlertVerdict}
+
+
+# --- build_alert_out projection ----------------------------------------------------
+
+
+def test_build_alert_out_projects_the_verdict_fields():
+    alert = _alert(
+        verdict=AlertVerdict.FALSE_POSITIVE.value,
+        verdict_reason=FalsePositiveReason.KNOWN_APPLICATION.value,
+        verdict_note="vendor agent",
+        verdict_by="analyst1",
+        verdict_at=datetime(2026, 8, 20, 13, 30, 0),
+    )
+    out = build_alert_out(alert)
+    assert out.verdict == "FALSE_POSITIVE"
+    assert out.verdict_reason == "KNOWN_APPLICATION"
+    assert out.verdict_note == "vendor agent"
+    assert out.verdict_by == "analyst1"
+    # Serialized like the model's other datetimes, not as a raw datetime.
+    assert out.verdict_at == "2026-08-20T13:30:00.000Z"
+
+
+def test_build_alert_out_untriaged_alert_reports_nulls():
+    out = build_alert_out(_alert())
+    assert out.verdict is None
+    assert out.verdict_reason is None
+    assert out.verdict_at is None
+
+
+def test_build_alert_out_defaults_omitted_relationships_to_empty():
+    """Callers eager-load different subsets; omitting one must keep meaning "empty" exactly
+    as it did when each site passed the lists positionally."""
+    out = build_alert_out(_alert())
+    assert out.comments == []
+    assert out.assets == []
+    assert out.tags == []
+    assert out.iocs == []
+    assert out.linked_cases == []
+
+
+def test_build_alert_out_carries_the_pre_existing_scalars():
+    """Guards the twenty-site extraction: every field the hand-written blocks passed must
+    still arrive."""
+    out = build_alert_out(_alert())
+    assert out.id == 1
+    assert out.alert_name == "Suspicious PowerShell"
+    assert out.alert_description == "encoded command"
+    assert out.status == "OPEN"
+    assert out.customer_code == "ACME"
+    assert out.source == "wazuh"
+    assert out.assigned_to == "analyst1"
+    assert out.escalated is False
+    assert out.alert_creation_time == "2026-08-20T12:00:00.000Z"

--- a/frontend/src/api/endpoints/incidentManagement/alerts.ts
+++ b/frontend/src/api/endpoints/incidentManagement/alerts.ts
@@ -8,7 +8,9 @@ import type {
 	AlertsFilter,
 	AlertStatus,
 	AlertTag,
-	AlertTimeline
+	AlertTimeline,
+	AlertVerdict,
+	FalsePositiveReason
 } from "@/types/incidentManagement/alerts"
 import _castArray from "lodash/castArray"
 import { HttpClient } from "../../http-client"
@@ -111,6 +113,12 @@ export default {
 						case "tag":
 							params.tags = _castArray(filter.value)
 							break
+						case "verdict":
+							params.verdict = filter.value
+							break
+						case "verdictReason":
+							params.verdict_reason = filter.value
+							break
 						default:
 							params[filter.type] = filter.value
 							break
@@ -168,6 +176,21 @@ export default {
 		return HttpClient.put<FlaskBaseResponse>(`/incidents/db_operations/alert/status`, {
 			alert_id: alertId,
 			status
+		})
+	},
+	updateAlertVerdict(
+		alertId: number,
+		verdict: AlertVerdict | null,
+		verdictReason?: FalsePositiveReason | null,
+		verdictNote?: string | null
+	) {
+		// A null verdict clears the classification back to untriaged; the backend wipes the
+		// reason, note and attribution alongside it.
+		return HttpClient.put<FlaskBaseResponse>(`/incidents/db_operations/alert/verdict`, {
+			alert_id: alertId,
+			verdict,
+			verdict_reason: verdict === "FALSE_POSITIVE" ? verdictReason : null,
+			verdict_note: verdict ? (verdictNote ?? null) : null
 		})
 	},
 	updateAlertAssignedUser(alertId: number, user: string) {

--- a/frontend/src/components/incidentManagement/alerts/AlertItem.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertItem.vue
@@ -111,6 +111,34 @@
 						</Badge>
 					</AlertStatusSwitch>
 
+					<AlertVerdictSwitch v-slot="{ loading: loadingVerdict }" :alert @updated="updateAlert($event)">
+						<Badge
+							type="splitted"
+							class="cursor-pointer"
+							bright
+							:color="
+								alert.verdict === 'FALSE_POSITIVE'
+									? 'warning'
+									: alert.verdict === 'TRUE_POSITIVE'
+										? 'danger'
+										: undefined
+							"
+						>
+							<template #iconLeft>
+								<n-spin :size="12" :show="loadingVerdict" content-class="flex flex-col justify-center">
+									<Icon :name="VerdictIcon" :size="13" />
+								</n-spin>
+							</template>
+							<template #label>Verdict</template>
+							<template #value>
+								<div class="flex items-center gap-2">
+									{{ verdictLabel(alert.verdict) }}
+									<Icon :name="EditIcon" :size="13" />
+								</div>
+							</template>
+						</Badge>
+					</AlertVerdictSwitch>
+
 					<AlertAssignUser v-slot="{ loading: loadingAssignee }" :alert @updated="updateAlert($event)">
 						<Badge
 							type="splitted"
@@ -290,7 +318,8 @@ import AlertAssignUser from "./AlertAssignUser.vue"
 import AlertDetails from "./AlertDetails.vue"
 import AlertStatusSwitch from "./AlertStatusSwitch.vue"
 import AlertTimeline from "./AlertTimeline.vue"
-import { handleDeleteAlert } from "./utils"
+import AlertVerdictSwitch from "./AlertVerdictSwitch.vue"
+import { handleDeleteAlert, verdictLabel } from "./utils"
 
 const props = defineProps<{
 	alertData?: Alert
@@ -318,6 +347,7 @@ const { alertData, alertId, compact, embedded, detailsOnMounted, highlight, sele
 const LinkIcon = "carbon:launch"
 const TimeIcon = "carbon:time"
 const EditIcon = "uil:edit-alt"
+const VerdictIcon = "carbon:task-view"
 const CommentsIcon = "carbon:chat"
 const AssetsIcon = "carbon:document-security"
 const IoCsIcon = "carbon:ibm-watson-discovery"

--- a/frontend/src/components/incidentManagement/alerts/AlertOverview.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertOverview.vue
@@ -44,6 +44,51 @@
 						</template>
 					</CardKV>
 
+					<CardKV :color="verdictCardColor" size="lg" class="w-full grow">
+						<template #key>
+							<div class="flex items-center gap-2">
+								<Icon :name="VerdictIcon" />
+								<span>Verdict</span>
+							</div>
+						</template>
+						<template #value>
+							<div class="flex flex-col gap-1">
+								<div class="flex">
+									<AlertVerdictSwitch
+										v-slot="{ loading: loadingVerdict }"
+										:alert
+										@updated="updateAlert($event)"
+									>
+										<div
+											class="flex items-center gap-3"
+											:class="{
+												'cursor-not-allowed': loadingVerdict,
+												'cursor-pointer': !loadingVerdict
+											}"
+										>
+											<span>{{ verdictLabel(alert.verdict) }}</span>
+											<n-spin
+												:size="14"
+												:show="loadingVerdict"
+												content-class="flex flex-col justify-center"
+											>
+												<Icon :name="EditIcon" />
+											</n-spin>
+										</div>
+									</AlertVerdictSwitch>
+								</div>
+								<div
+									v-if="alert.verdict === 'FALSE_POSITIVE'"
+									class="text-secondary flex flex-col gap-0.5 text-xs"
+								>
+									<span>{{ falsePositiveReasonLabel(alert.verdict_reason) }}</span>
+									<span v-if="alert.verdict_note" class="italic">{{ alert.verdict_note }}</span>
+									<span v-if="alert.verdict_by">Marked by {{ alert.verdict_by }}</span>
+								</div>
+							</div>
+						</template>
+					</CardKV>
+
 					<CardKV :color="alert.assigned_to ? 'success' : undefined" size="lg" class="w-full grow">
 						<template #key>
 							<div class="flex items-center gap-2">
@@ -206,7 +251,8 @@ import StatusIcon from "../common/StatusIcon.vue"
 import AlertAssignUser from "./AlertAssignUser.vue"
 import AlertStatusSwitch from "./AlertStatusSwitch.vue"
 import AlertTags from "./AlertTags.vue"
-import { handleDeleteAlert } from "./utils"
+import AlertVerdictSwitch from "./AlertVerdictSwitch.vue"
+import { falsePositiveReasonLabel, handleDeleteAlert, verdictLabel } from "./utils"
 
 const props = defineProps<{ alert: Alert; useFooterBackground?: boolean }>()
 const emit = defineEmits<{
@@ -220,7 +266,16 @@ const AlertLinkedCases = defineAsyncComponent(() => import("./AlertLinkedCases.v
 
 const { alert } = toRefs(props)
 
+// Untriaged stays uncoloured: it is the default state of every alert, so tinting it would
+// make the whole list look flagged.
+const verdictCardColor = computed(() => {
+	if (alert.value.verdict === "FALSE_POSITIVE") return "warning"
+	if (alert.value.verdict === "TRUE_POSITIVE") return "danger"
+	return undefined
+})
+
 const TrashIcon = "carbon:trash-can"
+const VerdictIcon = "carbon:task-view"
 const LinkIcon = "carbon:launch"
 const EditIcon = "uil:edit-alt"
 

--- a/frontend/src/components/incidentManagement/alerts/AlertVerdictSwitch.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertVerdictSwitch.vue
@@ -1,0 +1,194 @@
+<template>
+	<n-popselect
+		v-model:value="verdictSelected"
+		v-model:show="listVisible"
+		:options="verdictOptions"
+		:disabled="loading"
+		size="medium"
+		scrollable
+		to="body"
+	>
+		<slot :loading />
+	</n-popselect>
+
+	<!--
+		False positive is the only verdict that opens a dialog: a reason is mandatory for it,
+		because a free-form classification is exactly what made the previous tag-based
+		workaround useless for reporting. True positive and Clear submit straight away.
+	-->
+	<n-modal
+		v-model:show="showReasonDialog"
+		display-directive="show"
+		preset="card"
+		title="Mark as false positive"
+		:style="{ maxWidth: 'min(560px, 90vw)' }"
+		segmented
+		@after-leave="onDialogClosed()"
+	>
+		<div class="flex flex-col gap-4">
+			<n-form-item label="Reason" :show-feedback="false">
+				<n-select
+					v-model:value="reasonSelected"
+					:options="reasonOptions"
+					placeholder="Why is this a false positive?"
+				/>
+			</n-form-item>
+
+			<n-form-item :label="noteLabel" :show-feedback="false">
+				<n-input
+					v-model:value="noteValue"
+					type="textarea"
+					:rows="3"
+					:maxlength="1024"
+					show-count
+					placeholder="Optional detail for the next analyst who sees this alert"
+				/>
+			</n-form-item>
+		</div>
+
+		<template #footer>
+			<div class="flex items-center justify-end gap-3">
+				<n-button secondary :disabled="loading" @click="showReasonDialog = false">Cancel</n-button>
+				<n-button type="primary" :loading :disabled="!reasonSelected" @click="submitFalsePositive()">
+					Mark false positive
+				</n-button>
+			</div>
+		</template>
+	</n-modal>
+</template>
+
+<script setup lang="ts">
+import type { ApiError } from "@/types/common"
+import type { Alert, AlertVerdict, FalsePositiveReason } from "@/types/incidentManagement/alerts"
+import { NButton, NFormItem, NInput, NModal, NPopselect, NSelect, useMessage } from "naive-ui"
+import { computed, onBeforeMount, ref, toRefs, watch } from "vue"
+import Api from "@/api"
+import { falsePositiveReasonLabel } from "@/components/incidentManagement/alerts/utils"
+import { getApiErrorMessage } from "@/utils"
+
+const props = defineProps<{
+	alert: Alert
+}>()
+const emit = defineEmits<{
+	(e: "updated", value: Alert): void
+}>()
+
+const { alert } = toRefs(props)
+
+// Sentinel for the "back to untriaged" option. Distinct from `null`, which is what the
+// popselect holds before a choice is made — using null for both would make the watcher
+// unable to tell "nothing picked yet" from "picked Clear".
+const CLEAR_VERDICT = "__CLEAR__" as const
+type VerdictChoice = AlertVerdict | typeof CLEAR_VERDICT
+
+const loading = ref(false)
+const message = useMessage()
+const listVisible = ref(false)
+const showReasonDialog = ref(false)
+const reasonSelected = ref<FalsePositiveReason | null>(null)
+const noteValue = ref<string>("")
+
+const verdict = computed(() => alert.value.verdict)
+const verdictSelected = ref<VerdictChoice | null>(null)
+
+const verdictOptions = computed<{ label: string; value: VerdictChoice; disabled?: boolean }[]>(() => [
+	{ label: "True positive", value: "TRUE_POSITIVE" },
+	{ label: "False positive", value: "FALSE_POSITIVE" },
+	// Only offered once there is something to clear.
+	{ label: "Clear verdict", value: CLEAR_VERDICT, disabled: !verdict.value }
+])
+
+const reasonOptions: { label: string; value: FalsePositiveReason }[] = (
+	[
+		"EXPECTED_ACTIVITY",
+		"KNOWN_APPLICATION",
+		"AUTHORIZED_USER",
+		"RULE_TOO_SENSITIVE",
+		"OTHER"
+	] as FalsePositiveReason[]
+).map(value => ({ label: falsePositiveReasonLabel(value), value }))
+
+const noteLabel = computed(() => (reasonSelected.value === "OTHER" ? "Note (recommended for Other)" : "Note"))
+
+function applyVerdict(
+	nextVerdict: AlertVerdict | null,
+	reason: FalsePositiveReason | null,
+	note: string | null
+) {
+	loading.value = true
+
+	Api.incidentManagement.alerts
+		.updateAlertVerdict(alert.value.id, nextVerdict, reason, note)
+		.then(res => {
+			if (res.data.success) {
+				emit("updated", {
+					...alert.value,
+					verdict: nextVerdict,
+					verdict_reason: nextVerdict === "FALSE_POSITIVE" ? reason : null,
+					verdict_note: nextVerdict ? note : null,
+					// The authoritative attribution comes back on the next fetch; this keeps the
+					// row from showing a stale previous classifier in the meantime.
+					verdict_by: nextVerdict ? alert.value.verdict_by : null,
+					verdict_at: nextVerdict ? new Date() : null
+				})
+				showReasonDialog.value = false
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+				resetSelection()
+			}
+		})
+		.catch(err => {
+			message.error(getApiErrorMessage(err as ApiError) || "An error occurred. Please try again later.")
+			resetSelection()
+		})
+		.finally(() => {
+			loading.value = false
+		})
+}
+
+function submitFalsePositive() {
+	if (!reasonSelected.value) return
+	applyVerdict("FALSE_POSITIVE", reasonSelected.value, noteValue.value.trim() || null)
+}
+
+function resetSelection() {
+	verdictSelected.value = verdict.value ?? null
+}
+
+function onDialogClosed() {
+	// Cancelling the dialog must not leave the popselect showing a verdict that was never
+	// saved, otherwise re-picking "False positive" is a no-op against the watcher.
+	if (alert.value.verdict !== "FALSE_POSITIVE") {
+		resetSelection()
+	}
+	reasonSelected.value = null
+	noteValue.value = ""
+}
+
+watch(verdictSelected, value => {
+	if (value === null) return
+
+	if (value === CLEAR_VERDICT) {
+		if (verdict.value) applyVerdict(null, null, null)
+		return
+	}
+
+	if (value === verdict.value) return
+
+	if (value === "FALSE_POSITIVE") {
+		reasonSelected.value = alert.value.verdict_reason ?? null
+		noteValue.value = alert.value.verdict_note ?? ""
+		showReasonDialog.value = true
+		return
+	}
+
+	applyVerdict(value, null, null)
+})
+
+// Keep the control in step when the alert is replaced by a refetch or a sibling edit.
+watch(verdict, () => resetSelection())
+
+onBeforeMount(() => {
+	resetSelection()
+})
+</script>

--- a/frontend/src/components/incidentManagement/alerts/AlertsFilters.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertsFilters.vue
@@ -17,6 +17,38 @@
 				</n-button>
 			</n-input-group>
 
+			<n-input-group v-if="filter.type === 'verdict'">
+				<n-input-group-label size="small">{{ getFilterLabel(filter.type) }}</n-input-group-label>
+				<n-select
+					v-model:value="filter.value"
+					size="small"
+					:options="verdictOptions"
+					placeholder="Select..."
+					class="w-40!"
+				/>
+				<n-button size="small" secondary tabindex="-1" @click="delFilter(filter.type)">
+					<template #icon>
+						<Icon :name="DelIcon" />
+					</template>
+				</n-button>
+			</n-input-group>
+
+			<n-input-group v-if="filter.type === 'verdictReason'">
+				<n-input-group-label size="small">{{ getFilterLabel(filter.type) }}</n-input-group-label>
+				<n-select
+					v-model:value="filter.value"
+					size="small"
+					:options="falsePositiveReasonOptions"
+					placeholder="Select..."
+					class="w-56!"
+				/>
+				<n-button size="small" secondary tabindex="-1" @click="delFilter(filter.type)">
+					<template #icon>
+						<Icon :name="DelIcon" />
+					</template>
+				</n-button>
+			</n-input-group>
+
 			<n-input-group v-if="filter.type === 'assignedTo'">
 				<n-input-group-label size="small">{{ getFilterLabel(filter.type) }}</n-input-group-label>
 				<n-select
@@ -161,7 +193,7 @@ import type { AlertsListFilter } from "./types.d"
 import type { AlertsFilterTypes, AlertsListFilterValue } from "@/api/endpoints/incidentManagement/alerts"
 import type { ApiError } from "@/types/common"
 import type { Customer } from "@/types/customers"
-import type { AlertStatus } from "@/types/incidentManagement/alerts"
+import type { AlertStatus, AlertVerdictFilter, FalsePositiveReason } from "@/types/incidentManagement/alerts"
 import type { SourceName } from "@/types/incidentManagement/sources"
 import _castArray from "lodash/castArray"
 import _cloneDeep from "lodash/cloneDeep"
@@ -173,6 +205,7 @@ import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
 import { useGlobalCustomerFilter } from "@/composables/useGlobalCustomerFilter"
 import { getApiErrorMessage } from "@/utils"
+import { falsePositiveReasonLabel } from "./utils"
 
 const { useQueryString, preset } = defineProps<{ useQueryString?: boolean; preset?: AlertsListFilter[] }>()
 
@@ -202,6 +235,22 @@ const statusOptions: { label: string; value: AlertStatus }[] = [
 	{ label: "Closed", value: "CLOSED" },
 	{ label: "In progress", value: "IN_PROGRESS" }
 ]
+// UNTRIAGED is offered alongside the two stored verdicts because "not yet judged" is the
+// slice an analyst working a review backlog actually wants.
+const verdictOptions: { label: string; value: AlertVerdictFilter }[] = [
+	{ label: "True positive", value: "TRUE_POSITIVE" },
+	{ label: "False positive", value: "FALSE_POSITIVE" },
+	{ label: "Not triaged", value: "UNTRIAGED" }
+]
+const falsePositiveReasonOptions: { label: string; value: FalsePositiveReason }[] = (
+	[
+		"EXPECTED_ACTIVITY",
+		"KNOWN_APPLICATION",
+		"AUTHORIZED_USER",
+		"RULE_TOO_SENSITIVE",
+		"OTHER"
+	] as FalsePositiveReason[]
+).map(value => ({ label: falsePositiveReasonLabel(value), value }))
 const typeOptions: { label: string; value: AlertsFilterTypes }[] = [
 	{ label: "Status", value: "status" },
 	{ label: "Asset Name", value: "assetName" },
@@ -210,7 +259,9 @@ const typeOptions: { label: string; value: AlertsFilterTypes }[] = [
 	{ label: "Title", value: "title" },
 	{ label: "Customer Code", value: "customerCode" },
 	{ label: "Source", value: "source" },
-	{ label: "IoC", value: "iocValue" }
+	{ label: "IoC", value: "iocValue" },
+	{ label: "Verdict", value: "verdict" },
+	{ label: "FP Reason", value: "verdictReason" }
 ]
 
 const filters = ref<AlertsListFilter[]>([])

--- a/frontend/src/components/incidentManagement/alerts/utils.ts
+++ b/frontend/src/components/incidentManagement/alerts/utils.ts
@@ -1,7 +1,7 @@
 import type { DialogApiInjection } from "naive-ui/es/dialog/src/DialogProvider"
 import type { MessageApiInjection } from "naive-ui/es/message/src/MessageProvider"
 import type { ApiError } from "@/types/common"
-import type { Alert } from "@/types/incidentManagement/alerts"
+import type { Alert, AlertVerdict, FalsePositiveReason } from "@/types/incidentManagement/alerts"
 import { h } from "vue"
 import Api from "@/api"
 import { getApiErrorMessage } from "@/utils"
@@ -80,4 +80,35 @@ export function deleteAlert({ alert, cbBefore, cbSuccess, cbAfter, cbError, mess
 				cbAfter()
 			}
 		})
+}
+
+const FALSE_POSITIVE_REASON_LABELS: Record<FalsePositiveReason, string> = {
+	EXPECTED_ACTIVITY: "Expected / legitimate activity",
+	KNOWN_APPLICATION: "Known application or service",
+	AUTHORIZED_USER: "Authorized user activity",
+	RULE_TOO_SENSITIVE: "Detection rule too sensitive",
+	OTHER: "Other"
+}
+
+/**
+ * Human label for a stored false-positive reason. Falls back to the raw value so a reason
+ *  added on the backend before the frontend knows about it still renders something.
+ */
+export function falsePositiveReasonLabel(reason: FalsePositiveReason | string | null): string {
+	if (!reason) return ""
+	return FALSE_POSITIVE_REASON_LABELS[reason as FalsePositiveReason] ?? reason
+}
+
+const VERDICT_LABELS: Record<AlertVerdict, string> = {
+	TRUE_POSITIVE: "True positive",
+	FALSE_POSITIVE: "False positive"
+}
+
+/**
+ * Human label for a verdict. `null` is untriaged, which is a real state rather than an
+ *  error, so it gets a label of its own instead of an empty string.
+ */
+export function verdictLabel(verdict: AlertVerdict | null): string {
+	if (!verdict) return "Not triaged"
+	return VERDICT_LABELS[verdict] ?? verdict
 }

--- a/frontend/src/types/incidentManagement/alerts.ts
+++ b/frontend/src/types/incidentManagement/alerts.ts
@@ -10,6 +10,8 @@ export type AlertsFilter =
 	| { source: string }
 	| { source: string }
 	| { iocValue: string }
+	| { verdict: AlertVerdictFilter }
+	| { verdictReason: FalsePositiveReason }
 
 export interface Alert {
 	id: number
@@ -26,6 +28,11 @@ export interface Alert {
 	tags: AlertTag[]
 	linked_cases: Omit<Case, "alerts">[]
 	iocs: AlertIOC[]
+	verdict: AlertVerdict | null
+	verdict_reason: FalsePositiveReason | null
+	verdict_note: string | null
+	verdict_by: string | null
+	verdict_at: Date | null
 }
 
 export interface AlertIOC {
@@ -36,6 +43,19 @@ export interface AlertIOC {
 }
 
 export type AlertStatus = "OPEN" | "CLOSED" | "IN_PROGRESS"
+
+/** An analyst's triage verdict. `null` on an alert means untriaged — a distinct, meaningful state. */
+export type AlertVerdict = "TRUE_POSITIVE" | "FALSE_POSITIVE"
+
+/** `UNTRIAGED` is selectable as a filter but is never a stored verdict. */
+export type AlertVerdictFilter = AlertVerdict | "UNTRIAGED"
+
+export type FalsePositiveReason =
+	| "EXPECTED_ACTIVITY"
+	| "KNOWN_APPLICATION"
+	| "AUTHORIZED_USER"
+	| "RULE_TOO_SENSITIVE"
+	| "OTHER"
 
 export interface AlertAsset {
 	id: number


### PR DESCRIPTION
Phase 1 of #1085. Ships the analyst workflow; reporting aggregations follow in phase 2.

## What analysts get

A **Verdict** control on the alert detail card and on each list row: *True positive* / *False positive* / *Clear verdict*. Choosing false positive opens a dialog requiring a reason, with an optional note. Two new list filters — **Verdict** and **FP Reason**.

## Design decisions worth reviewing

**Tri-state `verdict`, not a `false_positive` boolean.** `NULL` means "nobody has judged this yet" — a different fact from "judged, and not a false positive". A NOT NULL boolean defaulting to false folds every never-triaged alert into the true-positive side, and the KPI a monthly service review needs is *"of the alerts we actually reviewed, X% were false positives"*. That ratio is only computable while unreviewed alerts stay distinguishable. Costs nothing extra, and the UI is still literally the requested Yes/No.

**No backfill.** Existing rows stay NULL because they genuinely were never triaged. Backfilling from an existing `FP`-style tag was considered and rejected — tag spelling is precisely what isn't trustworthy here. Verified on dev: 35 alerts, 35 untriaged.

**Orthogonal to `status`.** A CLOSED alert can be either verdict, and `status` already drives the OPEN/IN_PROGRESS/CLOSED counters. Folding a verdict in would break those and discard the true/false axis.

**Not a tag** — the reporter's own alternative. Tags are ACL-gated via `user_tag_access` / `role_tag_access`, so an analyst without a grant can neither see nor set one, and FP counts would silently vary by who's looking. Plus free-text naming, which is the original complaint.

**Closed reason vocabulary**, enforced in `UpdateAlertVerdict`: mandatory when marking FP, rejected otherwise. No CHECK constraint backs it — MySQL 5.7 parses and silently ignores CHECK, so it'd be an enforcement you *believe* you have.

**History in `audit_log`,** not in the columns. The columns carry the current verdict; `alert.verdict_set` / `alert.verdict_clear` carry the changes, so a verdict later reversed stays answerable. `verdict_by` is a username snapshot with no FK, matching `assigned_to` — the record of who made the call must survive that user's deletion.

## Two things to sign off on

1. **Route scope.** `PUT /alert/verdict` is `admin|analyst`, deliberately narrower than the sibling `/alert/status` which also admits `customer_user`. The verdict feeds SOC quality metrics, so I kept the people who can move those numbers to the SOC. Widening is a one-word change; narrowing after release breaks callers. Easy to flip if you disagree.

2. **`build_alert_out()` extraction.** Twenty call sites in `services/db_operations.py` spelled out the same ten scalar fields by hand, differing only in which relationship lists they'd loaded. That's why the service file shows −328 lines. It's the bulk of the diff and technically separable, but adding five fields to twenty hand-written blocks is exactly how a field ends up silently missing from four listing endpoints.

## Schema

Migration `b151c7ebbb95`, applied and verified on dev:

| Column | Type |
|---|---|
| `verdict` | `varchar(20)` NULL, indexed |
| `verdict_reason` | `varchar(50)` NULL |
| `verdict_note` | `varchar(1024)` NULL |
| `verdict_by` | `varchar(50)` NULL |
| `verdict_at` | `datetime` NULL |

Plus composite `(customer_code, verdict)` — every phase-2 reporting query is per-tenant.

Downgrade is honestly lossy and says so: a triage judgement isn't re-derivable. The audit rows survive it, so reconstruction is possible, but that's deliberately not automated inside a downgrade path.

## Testing

`backend/tests/test_alert_verdict.py` — 12 cases, all passing:

- FP without a reason rejected; FP with a reason accepted
- TP with an FP reason rejected; TP without one accepted
- clearing valid; clearing with a stray reason rejected
- note length-capped to the column
- `UNTRIAGED` is not an `AlertVerdict` member — if it ever became one, rows would start storing the string and the NULL-means-untriaged invariant would quietly split in two
- `build_alert_out` projects the verdict fields, serializes `verdict_at` like the model's other datetimes, reports nulls for an untriaged alert, defaults omitted relationships to empty, and still carries every pre-existing scalar

Verified against dev MySQL (read-only): both indexes present and correctly ordered, `alembic_version` at head, no rows backfilled.

`pnpm type-check`, `pnpm lint`, and `pre-commit run --all-files` all clean.

## Not in this PR

Phase 2 — FP count/pct, by reason, by alert name, by customer, and in the monthly trend, as siblings in `services/customer_report_aggregations.py`. Note for then: CoPilot stores no `rule_id` on alerts, so "FP by detection rule" becomes FP by `alert_name`; the rule id only exists inside the `AlertContext.context` JSON blob.