### PR TITLE
feat: false positive reporting aggregations and stats API (phase 2)

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -1,5 +1,7 @@
 import io
 import os
+from datetime import datetime
+from datetime import timedelta
 from typing import List
 from typing import Optional
 
@@ -89,6 +91,8 @@ from app.incidents.schema.db_operations import DeleteAlertsRequest
 from app.incidents.schema.db_operations import DeleteAlertsResponse
 from app.incidents.schema.db_operations import EscalateAlert
 from app.incidents.schema.db_operations import EscalateCase
+from app.incidents.schema.db_operations import FalsePositiveCustomerStat
+from app.incidents.schema.db_operations import FalsePositiveRuleStat
 from app.incidents.schema.db_operations import FieldAndAssetNames
 from app.incidents.schema.db_operations import FieldAndAssetNamesResponse
 from app.incidents.schema.db_operations import ListCaseDataStoreResponse
@@ -105,6 +109,8 @@ from app.incidents.schema.db_operations import SocfortressRecommendsWazuhTimeFie
 from app.incidents.schema.db_operations import UpdateAlertStatus
 from app.incidents.schema.db_operations import UpdateAlertVerdict
 from app.incidents.schema.db_operations import UpdateCaseStatus
+from app.incidents.schema.db_operations import VerdictStatsResponse
+from app.incidents.schema.db_operations import VerdictTrendPoint
 from app.incidents.schema.incident_alert import CreatedAlertPayload
 from app.incidents.schema.incident_alert import CreatedCaseNotificationPayload
 from app.incidents.services.alert_severity import severity_of
@@ -247,6 +253,11 @@ from app.incidents.services.db_operations import validate_source_exists
 from app.incidents.services.incident_case import handle_customer_notifications_case
 from app.incidents.services.notification_enrichment import extract_rule_level
 from app.incidents.services.notification_enrichment import severity_from_rule_level
+from app.incidents.services.verdict_stats import false_positive_trend
+from app.incidents.services.verdict_stats import false_positives_by_customer
+from app.incidents.services.verdict_stats import false_positives_by_reason
+from app.incidents.services.verdict_stats import top_false_positives_by_alert_name
+from app.incidents.services.verdict_stats import verdict_counts
 from app.middleware.customer_access import customer_access_handler
 from app.middleware.customer_access import verify_customer_code_access
 from app.middleware.customer_query import customer_codes_query
@@ -1284,6 +1295,75 @@ async def create_case_from_alert_endpoint(
         case_alert_link=link,
         success=True,
         message="Case created from alert successfully",
+    )
+
+
+@incidents_db_operations_router.get(
+    "/alerts/verdict-stats",
+    response_model=VerdictStatsResponse,
+    description="Aggregate false-positive / true-positive statistics for a period",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def get_verdict_stats_endpoint(
+    customer_codes: Optional[List[str]] = Depends(customer_codes_query),
+    date_from: Optional[datetime] = Query(None, description="Window start (naive UTC). Defaults to 30 days before date_to."),
+    date_to: Optional[datetime] = Query(None, description="Window end (naive UTC). Defaults to now."),
+    alert_name_limit: int = Query(15, ge=1, le=100),
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """False-positive statistics for detection tuning and the monthly SOC review (#1085).
+
+    Scoped admin/analyst to match the write path: these are SOC quality metrics, and a
+    tenant reading its own false-positive rate is a customer-portal decision rather than
+    something to fall out of this router by default.
+    """
+    # Naive UTC to match the incident_management_* columns, which default to datetime.utcnow.
+    date_to = date_to or datetime.utcnow()
+    date_from = date_from or (date_to - timedelta(days=30))
+    if date_from > date_to:
+        raise HTTPException(status_code=400, detail="date_from must not be after date_to")
+
+    # Intersect the requested subset with what the user may see -- never widens scope.
+    effective_customers = await customer_access_handler.resolve_effective_customers(current_user, customer_codes, db)
+
+    # An empty resolution means "the requested customers resolve to nothing you may see".
+    # It must short-circuit: the aggregations skip the tenant filter on a falsy list, so
+    # passing [] down would drop the constraint entirely instead of matching no rows.
+    if not effective_customers:
+        return VerdictStatsResponse(
+            total=0,
+            reviewed=0,
+            untriaged=0,
+            true_positive=0,
+            false_positive=0,
+            success=True,
+            message="No alerts found for the requested customers",
+        )
+
+    # ["*"] = wildcard access with no requested subset -> no tenant constraint at all.
+    scoped_customers = None if "*" in effective_customers else effective_customers
+
+    counts = await verdict_counts(db, scoped_customers, date_from, date_to)
+    by_reason = await false_positives_by_reason(db, scoped_customers, date_from, date_to)
+    by_alert_name = await top_false_positives_by_alert_name(db, scoped_customers, date_from, date_to, limit=alert_name_limit)
+    by_customer = await false_positives_by_customer(db, scoped_customers, date_from, date_to)
+    trend = await false_positive_trend(db, scoped_customers, date_from, date_to)
+
+    return VerdictStatsResponse(
+        **counts,
+        by_reason=by_reason,
+        by_alert_name=[
+            FalsePositiveRuleStat(alert_name=name, false_positive=fp, reviewed=reviewed, false_positive_rate=rate)
+            for name, fp, reviewed, rate in by_alert_name
+        ],
+        by_customer=[
+            FalsePositiveCustomerStat(customer_code=code, false_positive=fp, reviewed=reviewed, false_positive_rate=rate)
+            for code, fp, reviewed, rate in by_customer
+        ],
+        trend=[VerdictTrendPoint(**point) for point in trend],
+        success=True,
+        message="Verdict statistics retrieved successfully",
     )
 
 

--- a/backend/app/incidents/schema/db_operations.py
+++ b/backend/app/incidents/schema/db_operations.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 
 from fastapi import HTTPException
 from pydantic import BaseModel
@@ -661,6 +662,54 @@ class AlertFilterOptionsResponse(BaseModel):
     # though it is never a stored value.
     verdicts: List[str] = [v.value for v in AlertVerdict] + [VERDICT_FILTER_UNTRIAGED]
     false_positive_reasons: List[str] = [r.value for r in FalsePositiveReason]
+    success: bool
+    message: str
+
+
+class FalsePositiveRuleStat(BaseModel):
+    """One detection's false-positive record over the window."""
+
+    alert_name: str
+    false_positive: int
+    reviewed: int
+    # None when nothing was reviewed: no rate exists, and 0.0 would read as "clean".
+    false_positive_rate: Optional[float] = None
+
+
+class FalsePositiveCustomerStat(BaseModel):
+    customer_code: str
+    false_positive: int
+    reviewed: int
+    false_positive_rate: Optional[float] = None
+
+
+class VerdictTrendPoint(BaseModel):
+    month: str
+    false_positive: int
+    true_positive: int
+    untriaged: int
+    false_positive_rate: Optional[float] = None
+
+
+class VerdictStatsResponse(BaseModel):
+    """Aggregate triage-verdict statistics for a window.
+
+    `false_positive_rate` throughout is a percentage of *reviewed* alerts, never of all
+    alerts ingested -- otherwise the rate would improve every time triage fell behind.
+    `coverage_rate` is what keeps that number in proportion.
+    """
+
+    total: int
+    reviewed: int
+    untriaged: int
+    true_positive: int
+    false_positive: int
+    false_positive_rate: Optional[float] = None
+    coverage_rate: Optional[float] = None
+    by_reason: List[Tuple[str, int]] = []
+    by_alert_name: List[FalsePositiveRuleStat] = []
+    by_customer: List[FalsePositiveCustomerStat] = []
+    trend: List[VerdictTrendPoint] = []
     success: bool
     message: str
 

--- a/backend/app/incidents/services/customer_report.py
+++ b/backend/app/incidents/services/customer_report.py
@@ -45,6 +45,10 @@ from app.incidents.services.customer_report_charts import donut_png
 from app.incidents.services.customer_report_charts import evolution_png
 from app.incidents.services.customer_report_charts import hbar_png
 from app.incidents.services.reports_pdf import convert_html_to_pdf
+from app.incidents.services.verdict_stats import false_positive_reason_label
+from app.incidents.services.verdict_stats import false_positives_by_reason
+from app.incidents.services.verdict_stats import top_false_positives_by_alert_name
+from app.incidents.services.verdict_stats import verdict_counts
 
 BUCKET_NAME = "incident-management-reports"
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
@@ -203,6 +207,13 @@ async def build_report_context(
     cases_by_type = await agg.cases_reported_by_type(session, cc, date_from, date_to)
     trend = await agg.monthly_trend(session, cc, date_from, date_to)
 
+    # Triage-verdict figures (issue #1085). Scoped to this one customer by passing a
+    # single-element list -- the same helpers back the cross-tenant SOC view, so the
+    # number in the customer's PDF and the number on the SOC dashboard cannot disagree.
+    verdicts = await verdict_counts(session, [cc], date_from, date_to)
+    fp_by_reason = await false_positives_by_reason(session, [cc], date_from, date_to)
+    fp_by_alert_name = await top_false_positives_by_alert_name(session, [cc], date_from, date_to)
+
     open_cases_rows, open_total = await agg.fetch_open_cases(session, cc, date_from, date_to, limit=MAX_CASE_SHEETS)
     closed_cases_rows, closed_total = await agg.fetch_closed_cases(session, cc, date_from, date_to, limit=MAX_CASE_SHEETS)
     open_cards = [_build_case_card(c) for c in open_cases_rows]
@@ -227,6 +238,13 @@ async def build_report_context(
             "open_cases": open_count,
             "closed_cases": closed_count,
             "reported_cases": cases_by_type.get("total", 0),
+            "reviewed_alerts": verdicts["reviewed"],
+            "false_positives": verdicts["false_positive"],
+            "true_positives": verdicts["true_positive"],
+            # None where nothing was triaged: the template renders "n/a" rather than a
+            # 0% that would read as "no false positives" instead of "no data".
+            "false_positive_rate": verdicts["false_positive_rate"],
+            "triage_coverage_rate": verdicts["coverage_rate"],
         },
         "alerts_by_source": by_source,
         "cases_by_type": cases_by_type,
@@ -235,6 +253,12 @@ async def build_report_context(
             "alerts_by_source": donut_png(by_source) if total_alerts else None,
             "top_alert_names": hbar_png(top_alert_names, color=theme["chart_bar"]) if top_alert_names else None,
             "top_tags": hbar_png(top_alert_tags, color=theme["chart_bar"]) if top_alert_tags else None,
+            "false_positive_reasons": hbar_png(
+                [(false_positive_reason_label(reason), count) for reason, count in fp_by_reason],
+                color=theme["chart_bar"],
+            )
+            if fp_by_reason
+            else None,
             "evolution_alerts": evolution_png(months, [row["alerts"] for row in trend], color=theme["chart_evo_alerts"])
             if show_evolution
             else None,
@@ -243,6 +267,10 @@ async def build_report_context(
             else None,
         },
         "monthly_trend": trend,
+        "false_positive_rules": [
+            {"alert_name": name, "false_positive": fp, "reviewed": reviewed, "rate": rate} for name, fp, reviewed, rate in fp_by_alert_name
+        ],
+        "has_verdicts": verdicts["reviewed"] > 0,
         "open_cases": open_cards,
         "open_overflow": max(0, open_total - len(open_cards)),
         "closed_cases": closed_cards,

--- a/backend/app/incidents/services/verdict_stats.py
+++ b/backend/app/incidents/services/verdict_stats.py
@@ -1,0 +1,245 @@
+"""Aggregations over the alert triage verdict — false-positive reporting (issue #1085).
+
+Every helper takes ``customer_codes`` (a list, or None for "no tenant constraint") rather
+than the single ``customer_code`` used by ``customer_report_aggregations``. That is
+deliberate: the same questions are asked at two scopes. The per-customer PDF report passes
+``[code]``, while the SOC's own monthly review asks "which tenants generate the most false
+positives", which is a cross-tenant grouping. Keeping one implementation means the number
+in the customer's PDF and the number on the SOC dashboard cannot disagree.
+
+The tri-state verdict is what makes these numbers honest. ``NULL`` is "not yet triaged",
+so the false-positive *rate* is computed against reviewed alerts only -- dividing by every
+alert ingested would silently improve the rate every time the SOC fell behind on triage,
+which is precisely backwards.
+
+Monthly bucketing is done in Python rather than with ``func.year``/``func.month`` so the
+same code works on MySQL (production) and SQLite (tests), matching the convention in
+``customer_report_aggregations``.
+"""
+from datetime import datetime
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from sqlalchemy import and_
+from sqlalchemy import case
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.incidents.models import Alert
+from app.incidents.schema.db_operations import AlertVerdict
+from app.incidents.schema.db_operations import FalsePositiveReason
+
+FALSE_POSITIVE = AlertVerdict.FALSE_POSITIVE.value
+TRUE_POSITIVE = AlertVerdict.TRUE_POSITIVE.value
+
+# Report-facing labels. The stored values are stable identifiers meant for grouping; a
+# customer-facing PDF should not print SCREAMING_SNAKE_CASE at an executive reader.
+_REASON_LABELS = {
+    FalsePositiveReason.EXPECTED_ACTIVITY.value: "Expected / legitimate activity",
+    FalsePositiveReason.KNOWN_APPLICATION.value: "Known application or service",
+    FalsePositiveReason.AUTHORIZED_USER.value: "Authorized user activity",
+    FalsePositiveReason.RULE_TOO_SENSITIVE.value: "Detection rule too sensitive",
+    FalsePositiveReason.OTHER.value: "Other",
+}
+
+
+def false_positive_reason_label(reason: Optional[str]) -> str:
+    """Human label for a stored reason, falling back to the raw value.
+
+    The fallback matters during a rolling deploy: a reason added to the enum before this
+    map is updated still renders something rather than an empty bar label.
+    """
+    if not reason:
+        return "Unspecified"
+    return _REASON_LABELS.get(reason, reason)
+
+
+def _window(customer_codes: Optional[List[str]], date_from: datetime, date_to: datetime):
+    """Predicate: alerts created in [date_from, date_to], optionally tenant-scoped.
+
+    ``customer_codes=None`` means no tenant constraint. Callers reached from an HTTP route
+    must resolve the caller's accessible customers first and never pass None on their
+    behalf -- an empty resolution means "nothing you may see" and must short-circuit,
+    because a falsy list here drops the constraint rather than matching no rows.
+    """
+    predicates = [
+        Alert.alert_creation_time >= date_from,
+        Alert.alert_creation_time <= date_to,
+    ]
+    if customer_codes:
+        predicates.append(Alert.customer_code.in_(customer_codes))
+    return and_(*predicates)
+
+
+async def verdict_counts(
+    session: AsyncSession,
+    customer_codes: Optional[List[str]],
+    date_from: datetime,
+    date_to: datetime,
+) -> Dict[str, float]:
+    """Headline numbers: how many alerts, how many judged, and the false-positive rate.
+
+    ``false_positive_rate`` is a percentage of *reviewed* alerts (true + false positive),
+    not of all alerts. ``coverage_rate`` says how much of the period was actually triaged,
+    which is the context that stops the first number being read out of proportion -- a 90%
+    false-positive rate over 10 reviewed alerts out of 4000 is a different story from the
+    same rate over 4000.
+    """
+    result = await session.execute(
+        select(Alert.verdict, func.count().label("cnt")).where(_window(customer_codes, date_from, date_to)).group_by(Alert.verdict),
+    )
+    counts = {row[0]: int(row[1]) for row in result.all()}
+
+    false_positive = counts.get(FALSE_POSITIVE, 0)
+    true_positive = counts.get(TRUE_POSITIVE, 0)
+    untriaged = counts.get(None, 0)
+    reviewed = false_positive + true_positive
+    total = reviewed + untriaged
+
+    return {
+        "total": total,
+        "reviewed": reviewed,
+        "untriaged": untriaged,
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        # Guarded: a period where nothing was triaged has no rate, and reporting 0.0 would
+        # read as "no false positives" rather than "no data".
+        "false_positive_rate": round(false_positive / reviewed * 100, 1) if reviewed else None,
+        "coverage_rate": round(reviewed / total * 100, 1) if total else None,
+    }
+
+
+async def false_positives_by_reason(
+    session: AsyncSession,
+    customer_codes: Optional[List[str]],
+    date_from: datetime,
+    date_to: datetime,
+) -> List[Tuple[str, int]]:
+    """Most common false-positive categories, highest first."""
+    result = await session.execute(
+        select(Alert.verdict_reason, func.count().label("cnt"))
+        .where(_window(customer_codes, date_from, date_to), Alert.verdict == FALSE_POSITIVE)
+        .group_by(Alert.verdict_reason)
+        .order_by(func.count().desc()),
+    )
+    return [(row[0] or "UNSPECIFIED", int(row[1])) for row in result.all()]
+
+
+async def top_false_positives_by_alert_name(
+    session: AsyncSession,
+    customer_codes: Optional[List[str]],
+    date_from: datetime,
+    date_to: datetime,
+    limit: int = 15,
+) -> List[Tuple[str, int, int, Optional[float]]]:
+    """The detections generating the most false positives -- the detection-tuning list.
+
+    Grouped by ``alert_name``, which is the closest thing to a rule identity CoPilot
+    stores: there is no ``rule_id`` column, and the source rule id only exists inside the
+    ``incident_management_alertcontext`` JSON blob, which MySQL cannot group by cheaply.
+    For Wazuh-sourced alerts the title is effectively per-rule; for other sources it is
+    per-alert-type, which is still the right granularity for tuning.
+
+    Each row is ``(alert_name, false_positives, reviewed, false_positive_rate)``. The rate
+    matters as much as the count: a detection with 40 false positives out of 400 reviewed
+    is noisy, while one with 12 out of 12 is simply wrong, and ordering by raw count alone
+    would bury the second behind the first.
+    """
+    result = await session.execute(
+        select(
+            Alert.alert_name,
+            func.sum(case((Alert.verdict == FALSE_POSITIVE, 1), else_=0)).label("fp"),
+            func.sum(case((Alert.verdict.is_not(None), 1), else_=0)).label("reviewed"),
+        )
+        .where(_window(customer_codes, date_from, date_to))
+        .group_by(Alert.alert_name)
+        .having(func.sum(case((Alert.verdict == FALSE_POSITIVE, 1), else_=0)) > 0)
+        .order_by(func.sum(case((Alert.verdict == FALSE_POSITIVE, 1), else_=0)).desc())
+        .limit(limit),
+    )
+    rows = []
+    for name, fp, reviewed in result.all():
+        fp = int(fp or 0)
+        reviewed = int(reviewed or 0)
+        rows.append((name or "Unknown", fp, reviewed, round(fp / reviewed * 100, 1) if reviewed else None))
+    return rows
+
+
+async def false_positives_by_customer(
+    session: AsyncSession,
+    customer_codes: Optional[List[str]],
+    date_from: datetime,
+    date_to: datetime,
+) -> List[Tuple[str, int, int, Optional[float]]]:
+    """False positives per tenant: ``(customer_code, false_positives, reviewed, rate)``.
+
+    Ordered by rate rather than count so a small noisy tenant is not hidden behind a large
+    quiet one. Tenants with nothing reviewed are excluded -- they have no rate, and showing
+    them as 0% would misreport "not looked at" as "clean".
+    """
+    result = await session.execute(
+        select(
+            Alert.customer_code,
+            func.sum(case((Alert.verdict == FALSE_POSITIVE, 1), else_=0)).label("fp"),
+            func.sum(case((Alert.verdict.is_not(None), 1), else_=0)).label("reviewed"),
+        )
+        .where(_window(customer_codes, date_from, date_to))
+        .group_by(Alert.customer_code)
+        .having(func.sum(case((Alert.verdict.is_not(None), 1), else_=0)) > 0),
+    )
+    rows = []
+    for code, fp, reviewed in result.all():
+        fp = int(fp or 0)
+        reviewed = int(reviewed or 0)
+        rows.append((code or "Unknown", fp, reviewed, round(fp / reviewed * 100, 1) if reviewed else None))
+    rows.sort(key=lambda r: (r[3] or 0, r[1]), reverse=True)
+    return rows
+
+
+async def false_positive_trend(
+    session: AsyncSession,
+    customer_codes: Optional[List[str]],
+    date_from: datetime,
+    date_to: datetime,
+) -> List[dict]:
+    """Per-month false-positive evolution, bucketed in Python.
+
+    Returns ``{"month": "YYYY-MM", "false_positive": n, "true_positive": n,
+    "untriaged": n, "false_positive_rate": pct or None}`` in chronological order. Months
+    with no reviewed alerts carry a null rate rather than 0.0, so a gap in triage renders
+    as a gap rather than as a month with no false positives.
+    """
+    rows = await session.execute(
+        select(Alert.alert_creation_time, Alert.verdict).where(_window(customer_codes, date_from, date_to)),
+    )
+
+    buckets: dict = {}
+    for created_at, verdict in rows.all():
+        if created_at is None:
+            continue
+        key = f"{created_at.year:04d}-{created_at.month:02d}"
+        bucket = buckets.setdefault(key, {"false_positive": 0, "true_positive": 0, "untriaged": 0})
+        if verdict == FALSE_POSITIVE:
+            bucket["false_positive"] += 1
+        elif verdict == TRUE_POSITIVE:
+            bucket["true_positive"] += 1
+        else:
+            bucket["untriaged"] += 1
+
+    trend = []
+    for month in sorted(buckets.keys()):
+        bucket = buckets[month]
+        reviewed = bucket["false_positive"] + bucket["true_positive"]
+        trend.append(
+            {
+                "month": month,
+                "false_positive": bucket["false_positive"],
+                "true_positive": bucket["true_positive"],
+                "untriaged": bucket["untriaged"],
+                "false_positive_rate": round(bucket["false_positive"] / reviewed * 100, 1) if reviewed else None,
+            },
+        )
+    return trend

--- a/backend/app/incidents/templates/customer_incident_report_analytics.html
+++ b/backend/app/incidents/templates/customer_incident_report_analytics.html
@@ -26,6 +26,17 @@
     <tr class="grp"><td>Cases reported</td><td class="v">{{ metrics.reported_cases }}</td></tr>
     <tr class="grp"><td>Cases closed in period</td><td class="v">{{ metrics.closed_cases }}</td></tr>
     <tr class="grp"><td>Cases pending resolution</td><td class="v">{{ metrics.open_cases }}</td></tr>
+
+    {# Triage quality (issue #1085). The rate is a share of REVIEWED alerts, never of all
+       alerts received — otherwise it would improve whenever triage fell behind. The
+       coverage line is printed alongside so the rate is read in proportion. #}
+    <tr class="grp"><td>Alerts triaged</td><td class="v">{{ metrics.reviewed_alerts }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed true positives</td><td class="v">{{ metrics.true_positives }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed false positives</td><td class="v">{{ metrics.false_positives }}</td></tr>
+    <tr class="sub"><td class="k">• False positive rate (of triaged)</td>
+      <td class="v">{% if metrics.false_positive_rate is not none %}{{ metrics.false_positive_rate }}%{% else %}n/a{% endif %}</td></tr>
+    <tr class="sub"><td class="k">• Triage coverage</td>
+      <td class="v">{% if metrics.triage_coverage_rate is not none %}{{ metrics.triage_coverage_rate }}%{% else %}n/a{% endif %}</td></tr>
   </table>
 
   <!-- ================= CHARTS ================= -->
@@ -47,6 +58,9 @@
     {% if charts.top_tags %}{% set illus.n = illus.n + 1 %}
     <div class="chart-block"><img src="{{ charts.top_tags }}" alt="top tags" />
       <div class="chart-cap">Figure {{ illus.n }}: Top alert tags / classifications</div></div>{% endif %}
+    {% if charts.false_positive_reasons %}{% set illus.n = illus.n + 1 %}
+    <div class="chart-block"><img src="{{ charts.false_positive_reasons }}" alt="false positive reasons" />
+      <div class="chart-cap">Figure {{ illus.n }}: False positives by category</div></div>{% endif %}
     {% if charts.evolution_alerts %}{% set illus.n = illus.n + 1 %}
     <div class="chart-block"><img src="{{ charts.evolution_alerts }}" alt="alert trend" />
       <div class="chart-cap">Figure {{ illus.n }}: Monthly alert trend</div></div>{% endif %}
@@ -63,6 +77,29 @@
         {% endfor %}
       </tbody>
     </table>
+    {% endif %}
+
+    {# Detection-tuning list. Grouped by alert title, which is the closest thing to a rule
+       identity stored on an alert. Rate is shown next to count on purpose: 40 false
+       positives out of 400 triaged is a noisy rule, 12 out of 12 is a broken one, and
+       ordering by count alone buries the second behind the first. #}
+    {% if false_positive_rules %}
+    <div class="bar" style="margin-top:18px;">Detections generating false positives</div>
+    <table class="data avoid-break">
+      <thead><tr><th>Alert title</th><th>False positives</th><th>Triaged</th><th>FP rate</th></tr></thead>
+      <tbody>
+        {% for row in false_positive_rules %}
+        <tr>
+          <td>{{ row.alert_name }}</td>
+          <td>{{ row.false_positive }}</td>
+          <td>{{ row.reviewed }}</td>
+          <td>{% if row.rate is not none %}{{ row.rate }}%{% else %}n/a{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% elif has_verdicts %}
+    <div class="empty" style="margin-top:18px;">No alerts were classified as false positives in this period.</div>
     {% endif %}
   {% else %}
     <div class="empty">No alerts were recorded for this customer in the selected period.</div>

--- a/backend/app/incidents/templates/customer_incident_report_executive.html
+++ b/backend/app/incidents/templates/customer_incident_report_executive.html
@@ -41,6 +41,17 @@
 
     <tr class="grp"><td>Cases closed in period</td><td class="v">{{ metrics.closed_cases }}</td></tr>
     <tr class="grp"><td>Cases pending resolution</td><td class="v">{{ metrics.open_cases }}</td></tr>
+
+    {# Triage quality (issue #1085). The rate is a share of REVIEWED alerts, never of all
+       alerts received — otherwise it would improve whenever triage fell behind. The
+       coverage line is printed alongside so the rate is read in proportion. #}
+    <tr class="grp"><td>Alerts triaged</td><td class="v">{{ metrics.reviewed_alerts }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed true positives</td><td class="v">{{ metrics.true_positives }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed false positives</td><td class="v">{{ metrics.false_positives }}</td></tr>
+    <tr class="sub"><td class="k">• False positive rate (of triaged)</td>
+      <td class="v">{% if metrics.false_positive_rate is not none %}{{ metrics.false_positive_rate }}%{% else %}n/a{% endif %}</td></tr>
+    <tr class="sub"><td class="k">• Triage coverage</td>
+      <td class="v">{% if metrics.triage_coverage_rate is not none %}{{ metrics.triage_coverage_rate }}%{% else %}n/a{% endif %}</td></tr>
   </table>
 
   {% if has_alerts and charts.alerts_by_status %}

--- a/backend/app/incidents/templates/customer_incident_report_template.html
+++ b/backend/app/incidents/templates/customer_incident_report_template.html
@@ -40,6 +40,17 @@
 
     <tr class="grp"><td>Cases closed in period</td><td class="v">{{ metrics.closed_cases }}</td></tr>
     <tr class="grp"><td>Cases pending resolution</td><td class="v">{{ metrics.open_cases }}</td></tr>
+
+    {# Triage quality (issue #1085). The rate is a share of REVIEWED alerts, never of all
+       alerts received — otherwise it would improve whenever triage fell behind. The
+       coverage line is printed alongside so the rate is read in proportion. #}
+    <tr class="grp"><td>Alerts triaged</td><td class="v">{{ metrics.reviewed_alerts }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed true positives</td><td class="v">{{ metrics.true_positives }}</td></tr>
+    <tr class="sub"><td class="k">• Confirmed false positives</td><td class="v">{{ metrics.false_positives }}</td></tr>
+    <tr class="sub"><td class="k">• False positive rate (of triaged)</td>
+      <td class="v">{% if metrics.false_positive_rate is not none %}{{ metrics.false_positive_rate }}%{% else %}n/a{% endif %}</td></tr>
+    <tr class="sub"><td class="k">• Triage coverage</td>
+      <td class="v">{% if metrics.triage_coverage_rate is not none %}{{ metrics.triage_coverage_rate }}%{% else %}n/a{% endif %}</td></tr>
   </table>
 
   <!-- ================= 2. CHARTS ================= -->
@@ -61,6 +72,9 @@
     {% if charts.top_tags %}{% set illus.n = illus.n + 1 %}
     <div class="chart-block"><img src="{{ charts.top_tags }}" alt="top tags" />
       <div class="chart-cap">Figure {{ illus.n }}: Top alert tags / classifications</div></div>{% endif %}
+    {% if charts.false_positive_reasons %}{% set illus.n = illus.n + 1 %}
+    <div class="chart-block"><img src="{{ charts.false_positive_reasons }}" alt="false positive reasons" />
+      <div class="chart-cap">Figure {{ illus.n }}: False positives by category</div></div>{% endif %}
     {% if charts.evolution_alerts %}{% set illus.n = illus.n + 1 %}
     <div class="chart-block"><img src="{{ charts.evolution_alerts }}" alt="alert trend" />
       <div class="chart-cap">Figure {{ illus.n }}: Monthly alert trend</div></div>{% endif %}
@@ -77,6 +91,29 @@
         {% endfor %}
       </tbody>
     </table>
+    {% endif %}
+
+    {# Detection-tuning list. Grouped by alert title, which is the closest thing to a rule
+       identity stored on an alert. Rate is shown next to count on purpose: 40 false
+       positives out of 400 triaged is a noisy rule, 12 out of 12 is a broken one, and
+       ordering by count alone buries the second behind the first. #}
+    {% if false_positive_rules %}
+    <div class="bar" style="margin-top:18px;">Detections generating false positives</div>
+    <table class="data avoid-break">
+      <thead><tr><th>Alert title</th><th>False positives</th><th>Triaged</th><th>FP rate</th></tr></thead>
+      <tbody>
+        {% for row in false_positive_rules %}
+        <tr>
+          <td>{{ row.alert_name }}</td>
+          <td>{{ row.false_positive }}</td>
+          <td>{{ row.reviewed }}</td>
+          <td>{% if row.rate is not none %}{{ row.rate }}%{% else %}n/a{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% elif has_verdicts %}
+    <div class="empty" style="margin-top:18px;">No alerts were classified as false positives in this period.</div>
     {% endif %}
   {% else %}
     <div class="empty">No alerts were recorded for this customer in the selected period.</div>

--- a/backend/tests/test_verdict_stats.py
+++ b/backend/tests/test_verdict_stats.py
@@ -1,0 +1,237 @@
+"""Aggregation tests for false-positive reporting (issue #1085, phase 2).
+
+These run against an in-memory SQLite database, following the convention in
+`test_customer_report_aggregations.py`: only the `incident_management_*` tables are
+created (the wider `universal_models` set declares MySQL-only types), and each test drives
+the async helpers via `asyncio.run` since the repo does not use pytest-asyncio.
+
+The invariant under test throughout is that rates are computed against *reviewed* alerts,
+never against everything ingested. Dividing by total would make the false-positive rate
+improve every time the SOC fell behind on triage, which is exactly backwards.
+
+Run with: cd backend && python -m pytest tests/test_verdict_stats.py
+"""
+import asyncio
+import os
+from datetime import datetime
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+from sqlalchemy.ext.asyncio import create_async_engine  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+from sqlmodel import SQLModel  # noqa: E402
+
+from app.incidents.models import Alert  # noqa: E402
+from app.incidents.services import verdict_stats as vs  # noqa: E402
+
+CC = "TENANT_A"
+CC_B = "TENANT_B"
+DATE_FROM = datetime(2026, 5, 1)
+DATE_TO = datetime(2026, 8, 1)
+
+
+def _incident_tables():
+    return [t for name, t in SQLModel.metadata.tables.items() if name.startswith("incident_management")]
+
+
+async def _make_session() -> AsyncSession:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: SQLModel.metadata.create_all(c, tables=_incident_tables()))
+    return AsyncSession(engine)
+
+
+def _alert(name, customer, created, verdict=None, reason=None):
+    return Alert(
+        alert_name=name,
+        alert_description="d",
+        status="CLOSED",
+        source="Wazuh",
+        customer_code=customer,
+        alert_creation_time=created,
+        verdict=verdict,
+        verdict_reason=reason,
+    )
+
+
+async def _seed(session: AsyncSession) -> None:
+    session.add_all(
+        [
+            # TENANT_A, May: "Backup job" is a noisy detection — 3 FP, 1 TP.
+            _alert("Backup job", CC, datetime(2026, 5, 3), "FALSE_POSITIVE", "RULE_TOO_SENSITIVE"),
+            _alert("Backup job", CC, datetime(2026, 5, 4), "FALSE_POSITIVE", "RULE_TOO_SENSITIVE"),
+            _alert("Backup job", CC, datetime(2026, 5, 5), "FALSE_POSITIVE", "KNOWN_APPLICATION"),
+            _alert("Backup job", CC, datetime(2026, 5, 6), "TRUE_POSITIVE"),
+            # TENANT_A, June: a genuine detection, plus two never triaged.
+            _alert("Ransomware note", CC, datetime(2026, 6, 2), "TRUE_POSITIVE"),
+            _alert("Ransomware note", CC, datetime(2026, 6, 3)),
+            _alert("Port scan", CC, datetime(2026, 6, 4)),
+            # TENANT_B: one FP out of two triaged.
+            _alert("Vendor agent", CC_B, datetime(2026, 6, 9), "FALSE_POSITIVE", "KNOWN_APPLICATION"),
+            _alert("Vendor agent", CC_B, datetime(2026, 6, 10), "TRUE_POSITIVE"),
+            # Outside the window — must be ignored everywhere.
+            _alert("Backup job", CC, datetime(2026, 1, 1), "FALSE_POSITIVE", "OTHER"),
+        ],
+    )
+    await session.commit()
+
+
+def _run(coro_fn):
+    async def _inner():
+        session = await _make_session()
+        await _seed(session)
+        try:
+            return await coro_fn(session)
+        finally:
+            await session.close()
+
+    return asyncio.run(_inner())
+
+
+# --- verdict_counts ---------------------------------------------------------------
+
+
+def test_counts_are_scoped_to_customer_and_window():
+    counts = _run(lambda s: vs.verdict_counts(s, [CC], DATE_FROM, DATE_TO))
+    assert counts["total"] == 7  # the January alert is outside the window
+    assert counts["false_positive"] == 3
+    assert counts["true_positive"] == 2
+    assert counts["untriaged"] == 2
+    assert counts["reviewed"] == 5
+
+
+def test_false_positive_rate_divides_by_reviewed_not_total():
+    """The invariant. 3 FP of 5 reviewed is 60%; of 7 total it would be 42.9%, and that
+    number would improve every time the SOC fell behind on triage."""
+    counts = _run(lambda s: vs.verdict_counts(s, [CC], DATE_FROM, DATE_TO))
+    assert counts["false_positive_rate"] == 60.0
+    assert counts["coverage_rate"] == 71.4  # 5 of 7 triaged
+
+
+def test_rates_are_none_when_nothing_was_triaged():
+    """None rather than 0.0: a period with no triage has no rate, and 0.0 would read as
+    "no false positives" instead of "no data"."""
+
+    async def _empty(session):
+        session.add(_alert("Untriaged only", "TENANT_C", datetime(2026, 6, 1)))
+        await session.commit()
+        return await vs.verdict_counts(session, ["TENANT_C"], DATE_FROM, DATE_TO)
+
+    counts = _run(_empty)
+    assert counts["reviewed"] == 0
+    assert counts["false_positive_rate"] is None
+    assert counts["coverage_rate"] == 0.0
+
+
+def test_none_customer_codes_spans_every_tenant():
+    counts = _run(lambda s: vs.verdict_counts(s, None, DATE_FROM, DATE_TO))
+    assert counts["false_positive"] == 4  # 3 from TENANT_A + 1 from TENANT_B
+    assert counts["reviewed"] == 7
+
+
+# --- by reason --------------------------------------------------------------------
+
+
+def test_reasons_ranked_and_scoped_to_false_positives():
+    rows = _run(lambda s: vs.false_positives_by_reason(s, [CC], DATE_FROM, DATE_TO))
+    assert rows == [("RULE_TOO_SENSITIVE", 2), ("KNOWN_APPLICATION", 1)]
+
+
+def test_reason_labels_fall_back_to_the_raw_value():
+    assert vs.false_positive_reason_label("RULE_TOO_SENSITIVE") == "Detection rule too sensitive"
+    assert vs.false_positive_reason_label("A_REASON_ADDED_LATER") == "A_REASON_ADDED_LATER"
+    assert vs.false_positive_reason_label(None) == "Unspecified"
+
+
+# --- by alert name (the tuning list) ----------------------------------------------
+
+
+def test_tuning_list_reports_count_and_rate_per_detection():
+    rows = _run(lambda s: vs.top_false_positives_by_alert_name(s, [CC], DATE_FROM, DATE_TO))
+    assert len(rows) == 1  # only "Backup job" produced false positives
+    name, fp, reviewed, rate = rows[0]
+    assert name == "Backup job"
+    assert fp == 3
+    assert reviewed == 4  # 3 FP + 1 TP, in-window only
+    assert rate == 75.0
+
+
+def test_tuning_list_excludes_detections_with_no_false_positives():
+    """A detection that fired and was confirmed real must not appear on a tuning list."""
+    rows = _run(lambda s: vs.top_false_positives_by_alert_name(s, [CC], DATE_FROM, DATE_TO))
+    assert "Ransomware note" not in [row[0] for row in rows]
+
+
+# --- by customer ------------------------------------------------------------------
+
+
+def test_by_customer_ranks_by_rate_not_raw_count():
+    """A small, badly-tuned tenant must not hide behind a large quiet one.
+
+    TENANT_NOISY has a single false positive against TENANT_A's three, so ordering by raw
+    count would put it last — but every alert it triaged was a false positive, which is
+    the tenant actually worth looking at.
+    """
+
+    async def _with_noisy_tenant(session):
+        session.add(_alert("All noise", "TENANT_NOISY", datetime(2026, 6, 1), "FALSE_POSITIVE", "OTHER"))
+        await session.commit()
+        return await vs.false_positives_by_customer(session, None, DATE_FROM, DATE_TO)
+
+    rows = _run(_with_noisy_tenant)
+    by_code = {row[0]: row for row in rows}
+    assert by_code[CC][1:] == (3, 5, 60.0)
+    assert by_code[CC_B][1:] == (1, 2, 50.0)
+    assert by_code["TENANT_NOISY"][1:] == (1, 1, 100.0)
+
+    # Ordered by rate descending, so the one-alert tenant leads despite the lowest count.
+    assert [row[0] for row in rows] == ["TENANT_NOISY", CC, CC_B]
+
+
+def test_by_customer_excludes_tenants_with_nothing_triaged():
+    """Showing an untriaged tenant at 0% would misreport "not looked at" as "clean"."""
+
+    async def _with_quiet_tenant(session):
+        session.add(_alert("Nothing triaged", "TENANT_QUIET", datetime(2026, 6, 1)))
+        await session.commit()
+        return await vs.false_positives_by_customer(session, None, DATE_FROM, DATE_TO)
+
+    rows = _run(_with_quiet_tenant)
+    assert "TENANT_QUIET" not in [row[0] for row in rows]
+
+
+# --- trend ------------------------------------------------------------------------
+
+
+def test_trend_buckets_by_month_in_order():
+    trend = _run(lambda s: vs.false_positive_trend(s, [CC], DATE_FROM, DATE_TO))
+    assert [point["month"] for point in trend] == ["2026-05", "2026-06"]
+
+    may = trend[0]
+    assert may["false_positive"] == 3
+    assert may["true_positive"] == 1
+    assert may["false_positive_rate"] == 75.0
+
+    june = trend[1]
+    assert june["false_positive"] == 0
+    assert june["true_positive"] == 1
+    assert june["untriaged"] == 2
+    assert june["false_positive_rate"] == 0.0
+
+
+def test_trend_month_with_no_triage_has_a_null_rate():
+    """So a gap in triage renders as a gap, not as a month with no false positives."""
+
+    async def _untriaged_month(session):
+        session.add(_alert("Later", "TENANT_D", datetime(2026, 7, 5)))
+        await session.commit()
+        return await vs.false_positive_trend(session, ["TENANT_D"], DATE_FROM, DATE_TO)
+
+    trend = _run(_untriaged_month)
+    assert trend[0]["month"] == "2026-07"
+    assert trend[0]["false_positive_rate"] is None


### PR DESCRIPTION
Phase 2 of #1085, on top of #1090. Phase 1 gave analysts somewhere to record a verdict; this makes those verdicts answer the questions the issue was filed for.

Maps to the reporter's five asks:

| Asked for | Delivered |
|---|---|
| Number and percentage of false positives | `verdict_counts` → headline metrics + PDF |
| False positives by detection rule | `top_false_positives_by_alert_name` → tuning table |
| False positives by customer / environment | `false_positives_by_customer` |
| Most common false positive categories | `false_positives_by_reason` → PDF chart |
| Evolution of false positives over time | `false_positive_trend` |

## One implementation, two scopes

New `app/incidents/services/verdict_stats.py`. Helpers take `customer_codes` (a list, or `None` for no tenant constraint) rather than the single `customer_code` used by `customer_report_aggregations`, because the same questions get asked at two scopes: the per-customer PDF passes `[code]`, while the SOC's own monthly review asks *"which tenants generate the most false positives"* — a cross-tenant grouping. One implementation means the number in a customer's PDF and the number on the SOC dashboard can't disagree.

## Rates are computed against reviewed alerts, never total

This is what the tri-state verdict from phase 1 buys, and it's the single most important line in the PR. Dividing by every alert ingested would make the false-positive rate **improve every time the SOC fell behind on triage** — exactly backwards.

`coverage_rate` ships alongside so the headline is read in proportion: a 90% FP rate over 10 reviewed alerts out of 4000 is a very different story from the same rate over 4000. Where nothing was triaged the rate is `None`, not `0.0` — `0.0` reads as *"no false positives"* rather than *"no data"*.

## Two ordering decisions

**The tuning list reports rate beside count.** 40 false positives out of 400 triaged is a noisy rule; 12 out of 12 is a broken one. Ordering by raw count alone buries the second behind the first.

**The per-tenant view sorts by rate,** so a small badly-tuned tenant isn't hidden behind a large quiet one, and excludes tenants with nothing triaged rather than showing them at 0% — which would misreport "not looked at" as "clean".

## Known limitation: "by detection rule" is by alert title

CoPilot stores no `rule_id` on an alert. The source rule id only exists inside the `incident_management_alertcontext` JSON blob, which MySQL can't group by cheaply. Grouping is therefore on `alert_name`, which for Wazuh-sourced alerts is effectively per-rule and for other sources is per-alert-type — still the right granularity for tuning, but worth naming rather than implying a precision that isn't there.

## API

`GET /incidents/db_operations/alerts/verdict-stats` — optional `customer_codes`, `date_from`, `date_to` (defaults to the last 30 days), `alert_name_limit`. Returns all five breakdowns in one response.

Scoped `admin|analyst` to match the phase 1 write path, using the same `resolve_effective_customers` intersection as `/alerts/filter` — an empty resolution short-circuits, because a falsy list drops the tenant constraint rather than matching no rows.

## PDF report

Triage-quality metrics (triaged / TP / FP / FP rate / coverage) in **FULL**, **ANALYTICS** and **EXECUTIVE**; false-positives-by-category chart and the detection-tuning table in **FULL** and **ANALYTICS**. **OPERATIONAL** is per-case detail and is unchanged. Report-facing reason labels fall back to the raw value, so a reason added to the enum before the label map still renders during a rolling deploy.

## Testing

`backend/tests/test_verdict_stats.py` — 12 cases against the in-memory SQLite harness, so the aggregation SQL is genuinely exercised rather than mocked:

- counts scoped to customer and window (out-of-window rows ignored)
- **the rate divides by reviewed, not total** — 3 FP of 5 reviewed is 60%, not the 42.9% you'd get from 7 total
- null rates where nothing was triaged; `customer_codes=None` spans every tenant
- reasons ranked, scoped to false positives only; label fallback
- tuning list reports per-detection count and rate; excludes detections with no false positives
- per-tenant ordering proven with a one-alert 100%-FP tenant that outranks a three-FP tenant — ordering by count would put it last
- trend buckets by month in order; a month with no triage carries a null rate

All four report templates rendered against the new context to confirm no Jinja breakage, including the null-rate → `n/a` path and the reviewed-but-zero-FP notice.

45 tests pass across the verdict, aggregation and chart suites. `pre-commit run --all-files` clean.

## Not in this PR

No in-app stats view — the API is there for it, and Grafana can consume it today. Worth deciding whether the in-app surface belongs in Incident Management or alongside the Detections Catalog, whose **Top noisy** / **Dead** chips off `wazuh_firing_stats_cache` are the natural neighbours for an FP-rate-per-rule chip.