### PR TITLE
fix: cascade agents.agent_id FK so agent re-registration doesn't break sync

### DIFF
--- a/backend/alembic/versions/344a0d58f444_agent_fk.py
+++ b/backend/alembic/versions/344a0d58f444_agent_fk.py
@@ -1,0 +1,106 @@
+"""cascade the agents.agent_id FK to agent_vulnerabilities and agent_datastore
+
+Revision ID: 344a0d58f444
+Revises: b151c7ebbb95
+Create Date: 2026-08-24 11:42:07.293041
+
+Agent sync failed with a 500 whenever Wazuh reassigned an agent_id.
+
+`agents.agent_id` is the Wazuh-assigned id, not the surrogate PK, and it is
+mutable: re-registering an agent gets it a new one. The sync matches agents on
+hostname and updates that column in place, but both child tables carry a foreign
+key against it that was left at the MySQL default of RESTRICT, so the UPDATE was
+rejected with errno 1451 and the whole sync aborted at the affected agent —
+every agent after it went unprocessed.
+
+Both child tables are affected, not just the one in the bug report: whichever
+constraint MySQL evaluates first is the one that surfaces, so a deployment with
+Velociraptor artifacts hits `agent_datastore` and one without hits
+`agent_vulnerabilities`.
+
+ON DELETE differs between the two, deliberately:
+
+- `agent_vulnerabilities` cascades. Vulnerabilities are derived data, rebuilt
+  from the Wazuh Indexer on the next scan, and hold no external reference. This
+  also fixes agent deletion, which hit the same 1451 for any agent that had ever
+  been scanned.
+- `agent_datastore` stays RESTRICT. Every row is a pointer to a MinIO object
+  that has to be removed explicitly, so a silent cascade would orphan the blob.
+  `delete_agent_from_database` deletes those rows itself, in order.
+
+See issue #1086.
+
+"""
+from typing import Sequence
+from typing import Union
+
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "344a0d58f444"
+down_revision: Union[str, None] = "b151c7ebbb95"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+REFERRED = "agents"
+COLUMN = "agent_id"
+
+# (table, new constraint name, ondelete)
+TARGETS = [
+    ("agent_vulnerabilities", "fk_agent_vulnerabilities_agent_id", "CASCADE"),
+    ("agent_datastore", "fk_agent_datastore_agent_id", None),
+]
+
+
+def _agent_fk_names(conn, table: str) -> list:
+    """Every FK on `table` pointing at `agents.agent_id`.
+
+    Looked up rather than hardcoded: the original constraints were never named,
+    so MySQL auto-named them `<table>_ibfk_N`, and the number depends on the
+    order constraints were created — `agent_vulnerabilities_ibfk_1` is correct
+    on some installs and not others. Returning a list also makes this a no-op on
+    SQLite, which never enforced the constraint.
+    """
+    return [
+        fk["name"]
+        for fk in inspect(conn).get_foreign_keys(table)
+        if fk.get("referred_table") == REFERRED and fk.get("constrained_columns") == [COLUMN] and fk.get("name")
+    ]
+
+
+def _recreate(conn, table: str, name: str, onupdate: Union[str, None], ondelete: Union[str, None]) -> None:
+    for existing in _agent_fk_names(conn, table):
+        op.drop_constraint(existing, table, type_="foreignkey")
+
+    op.create_foreign_key(
+        name,
+        table,
+        REFERRED,
+        [COLUMN],
+        [COLUMN],
+        onupdate=onupdate,
+        ondelete=ondelete,
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Named explicitly on the way in so later migrations have a stable target
+    # instead of another auto-generated `_ibfk_N`.
+    for table, name, ondelete in TARGETS:
+        _recreate(conn, table, name, onupdate="CASCADE", ondelete=ondelete)
+
+
+def downgrade() -> None:
+    """Restore the RESTRICT behaviour.
+
+    Agent sync will start failing again on re-registration — that is the bug
+    this revision fixes, and the point of a downgrade.
+    """
+    conn = op.get_bind()
+
+    for table, name, _ in TARGETS:
+        _recreate(conn, table, name, onupdate=None, ondelete=None)

--- a/backend/app/agents/routes/agents.py
+++ b/backend/app/agents/routes/agents.py
@@ -66,6 +66,7 @@ from app.db.db_session import get_db
 # from app.db.db_session import session
 from app.db.universal_models import AgentDataStore
 from app.db.universal_models import Agents
+from app.db.universal_models import AgentVulnerabilities
 from app.incidents.schema.db_operations import CaseOutResponse
 from app.incidents.services.db_operations import list_cases_by_asset_name
 from app.middleware.customer_access import customer_access_handler
@@ -226,6 +227,9 @@ async def delete_agent_from_database(db: AsyncSession, agent_id: str):
     try:
         # First delete related records from agent_datastore
         await db.execute(delete(AgentDataStore).filter(AgentDataStore.agent_id == agent_id))
+        # ...and the agent's vulnerabilities. The FK cascades on delete, but doing it
+        # explicitly keeps the delete working on databases that predate that migration.
+        await db.execute(delete(AgentVulnerabilities).filter(AgentVulnerabilities.agent_id == agent_id))
         # Then delete the agent
         await db.execute(delete(Agents).filter(Agents.agent_id == agent_id))
         await db.commit()

--- a/backend/app/agents/services/sync.py
+++ b/backend/app/agents/services/sync.py
@@ -148,7 +148,13 @@ async def update_wazuh_agent_in_db(
 
     """
     existing_agent.update_wazuh_agent_from_model(agent, customer_code)
-    await session.commit()  # Use the await keyword to commit asynchronously
+    try:
+        await session.commit()  # Use the await keyword to commit asynchronously
+    except Exception:
+        # Roll back so the session stays usable for the remaining agents — without this
+        # the failed transaction poisons every subsequent iteration of the sync loop.
+        await session.rollback()
+        raise
     logger.info(f"Agent {agent.agent_name} updated in the database")
 
 
@@ -250,33 +256,48 @@ async def sync_agents_wazuh() -> SyncedAgentsResponse:
     logger.info(f"Collected Wazuh Agents: {wazuh_agents_list}")
 
     agents_added_list: List[WazuhAgent] = []
+    failed_agents: List[str] = []
 
     async with get_db_session() as session:  # Create a new session here
         for wazuh_agent in wazuh_agents_list.agents:
-            customer_code = extract_customer_code(wazuh_agent.agent_label)
+            # One bad agent must not abort the run. A single failure used to propagate out of
+            # this loop and 500 the whole sync, leaving every agent after it unprocessed.
+            try:
+                customer_code = extract_customer_code(wazuh_agent.agent_label)
 
-            existing_agent_query = select(Agents).filter(
-                Agents.hostname == wazuh_agent.agent_name,
-            )
-            result = await session.execute(existing_agent_query)
-            existing_agent = result.scalars().first()
+                existing_agent_query = select(Agents).filter(
+                    Agents.hostname == wazuh_agent.agent_name,
+                )
+                result = await session.execute(existing_agent_query)
+                existing_agent = result.scalars().first()
 
-            if existing_agent:
-                await update_wazuh_agent_in_db(session, existing_agent, wazuh_agent, customer_code)
-            else:
-                await add_wazuh_agent_in_db(session, wazuh_agent, customer_code)
+                if existing_agent:
+                    await update_wazuh_agent_in_db(session, existing_agent, wazuh_agent, customer_code)
+                else:
+                    await add_wazuh_agent_in_db(session, wazuh_agent, customer_code)
 
-            synced_wazuh_agent = SyncedWazuhAgent(**wazuh_agent.model_dump())
-            agents_added_list.append(synced_wazuh_agent)
+                synced_wazuh_agent = SyncedWazuhAgent(**wazuh_agent.model_dump())
+                agents_added_list.append(synced_wazuh_agent)
+            except Exception as e:
+                await session.rollback()
+                failed_agents.append(wazuh_agent.agent_name)
+                logger.opt(exception=True).error(
+                    f"Failed to sync Wazuh agent {wazuh_agent.agent_name} " f"(agent_id {wazuh_agent.agent_id}): {type(e).__name__}: {e}",
+                )
 
     logger.info(f"Agents Added List: {agents_added_list}")
 
     # Close the session
     await session.close()
 
+    message = f"Agents synced successfully ({len(agents_added_list)} of {len(wazuh_agents_list.agents)})"
+    if failed_agents:
+        message += f". Failed to sync {len(failed_agents)}: {', '.join(failed_agents)}"
+        logger.warning(f"Wazuh agent sync completed with {len(failed_agents)} failure(s): {failed_agents}")
+
     return SyncedAgentsResponse(
         success=True,
-        message="Agents synced successfully",
+        message=message,
     )
 
 

--- a/backend/app/db/universal_models.py
+++ b/backend/app/db/universal_models.py
@@ -6,7 +6,9 @@ from loguru import logger
 from sqlalchemy import JSON
 from sqlalchemy import Column
 from sqlalchemy import Float
+from sqlalchemy import ForeignKey
 from sqlalchemy import LargeBinary
+from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.mysql import LONGTEXT
@@ -236,7 +238,19 @@ class AgentDataStore(SQLModel, table=True):
     id: Optional[int] = Field(primary_key=True)
 
     # Agent information
-    agent_id: str = Field(foreign_key="agents.agent_id", max_length=256, index=True, nullable=False)
+    # ON UPDATE CASCADE: Wazuh reassigns agent_id when an agent re-registers, and the sync
+    # updates it in place on the matching hostname. Without the cascade MySQL rejects that
+    # UPDATE (errno 1451) and the whole agent sync aborts. ON DELETE stays RESTRICT: each row
+    # points at a MinIO object that has to be removed explicitly, so a silent cascade would
+    # orphan the blobs.
+    agent_id: str = Field(
+        sa_column=Column(
+            String(256),
+            ForeignKey("agents.agent_id", onupdate="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+    )
     velociraptor_id: str = Field(max_length=256, nullable=False)
     # Removed customer_code - access via agent.customer_code relationship
 
@@ -323,7 +337,17 @@ class AgentVulnerabilities(SQLModel, table=True):
     package_name: Optional[str] = Field(default=None, max_length=255)
 
     # Foreign keys
-    agent_id: str = Field(foreign_key="agents.agent_id", max_length=256, index=True)
+    # ON UPDATE CASCADE for the same re-registration reason as agent_datastore above.
+    # ON DELETE CASCADE is safe here where it is not there: vulnerabilities are derived data,
+    # regenerated from the Wazuh Indexer on the next scan, and hold no external blob.
+    agent_id: str = Field(
+        sa_column=Column(
+            String(256),
+            ForeignKey("agents.agent_id", onupdate="CASCADE", ondelete="CASCADE"),
+            index=True,
+            nullable=False,
+        ),
+    )
     customer_code: Optional[str] = Field(foreign_key="customers.customer_code", max_length=50, index=True)
 
     # Relationship back to the Agents model


### PR DESCRIPTION
Fixes #1086.

## The bug

`agents.agent_id` is the Wazuh-assigned id, not the surrogate PK, and it is mutable — re-registering an agent gets it a new one. Agent sync matches on hostname and updates that column in place, but `agent_vulnerabilities` and `agent_datastore` both carry a foreign key against it that was left at the MySQL default of RESTRICT. The UPDATE was rejected with errno 1451, and because the sync loop had no per-agent error handling, the exception propagated out and 500'd the entire run — every agent after the affected one went unprocessed.

**Both child tables are affected, not just the one in the report.** Whichever constraint MySQL evaluates first is the one that surfaces, so a deployment with Velociraptor artifacts hits `agent_datastore` and one without hits `agent_vulnerabilities`. Fixing only the reported table would have left the bug live for half of deployments.

## Changes

**`app/db/universal_models.py`** + migration `344a0d58f444`

| Table | ON UPDATE | ON DELETE |
|---|---|---|
| `agent_vulnerabilities` | CASCADE | **CASCADE** |
| `agent_datastore` | CASCADE | RESTRICT (unchanged) |

ON DELETE differs deliberately. Vulnerabilities are derived data, rebuilt from the Wazuh Indexer on the next scan and holding no external reference, so cascading is safe — and it fixes agent deletion, which hit the same 1451 for any agent that had ever been scanned. `agent_datastore` rows are MinIO blob pointers, so a silent cascade would orphan the objects; `delete_agent_from_database` removes them explicitly, in order.

The migration looks the existing constraint names up through `inspect()` rather than hardcoding `agent_vulnerabilities_ibfk_1` — the constraints were never named, so MySQL auto-named them `<table>_ibfk_N` and the number depends on creation order, which is not portable across installs. Replacements are named explicitly so later migrations have a stable target. Follows the pattern in `b4c7e2a91f38_drop_dispatch_log_route_fk.py`, and no-ops on SQLite.

**`app/agents/services/sync.py`** — per-agent failures are now isolated, with a rollback so a poisoned transaction doesn't break every later iteration. The response reports `synced N of M` plus the names that failed instead of a bare success string. This half is independent of the FK: any per-agent error used to abort the whole sync.

**`app/agents/routes/agents.py`** — `delete_agent_from_database` deleted `agent_datastore` children but never `agent_vulnerabilities`. Now removed explicitly, which keeps deletion working on databases that haven't run the migration yet.

## Verification

Ran the actual revision module's `upgrade()` and `downgrade()` against a real mysql:8.0.46-debian seeded with the pre-fix schema:

| Stage | `agent_vulnerabilities` | `agent_datastore` | `UPDATE agents SET agent_id` |
|---|---|---|---|
| before | `_ibfk_1`, no cascade | `_ibfk_1`, no cascade | **BLOCKED** — errno 1451, matching the report |
| after `upgrade()` | UPDATE + DELETE CASCADE | UPDATE CASCADE | **OK** — children follow, history preserved |
| after `downgrade()` | no cascade | no cascade | **BLOCKED** again |

Also confirmed: deleting an agent that still has datastore rows is correctly blocked, and deleting datastore rows first then the agent cascades the vulnerabilities away with zero orphans.

`pre-commit run` passes on all changed files.

## Note for anyone stuck before this ships

The `TRUNCATE TABLE agent_vulnerabilities` workaround in the issue remains valid — that data is regenerated from the Wazuh Indexer on the next scan.
