### PR TITLE
fix: coerce numeric values in string-typed alert source fields

### DIFF
--- a/backend/app/incidents/schema/incident_alert.py
+++ b/backend/app/incidents/schema/incident_alert.py
@@ -1,13 +1,18 @@
 from datetime import datetime
 from enum import Enum
+from types import UnionType
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
+from typing import get_args
+from typing import get_origin
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 
 class ValidSyslogType(str, Enum):
@@ -84,6 +89,15 @@ class FieldNames(BaseModel):
     ioc_field_names: Optional[List[str]] = None
 
 
+def _is_string_field(annotation: Any) -> bool:
+    """True for a field declared `str` or `Optional[str]`."""
+    if annotation is str:
+        return True
+    if get_origin(annotation) in (Union, UnionType):
+        return str in get_args(annotation)
+    return False
+
+
 class GenericSourceModel(BaseModel):
     timestamp: str = Field(..., description="The timestamp of the alert.")
     timestamp_utc: Optional[str] = Field(
@@ -111,6 +125,46 @@ class GenericSourceModel(BaseModel):
         description="The agent name of the alert.",
     )
     model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _stringify_numeric_values(cls, data: Any) -> Any:
+        """Accept a number where a string field is declared.
+
+        These models are built straight from raw indexer documents, and what a
+        source puts in a given field is not ours to control: `timestamp_utc`
+        arrives as epoch milliseconds from some pipelines, `syslog_level` as a
+        numeric severity, `process_id` as an int. Pydantic 1 coerced all of that
+        to `str` silently; Pydantic 2 rejects it with `string_type`, and because
+        `get_single_alert_details` turns any exception into a 400, a single
+        numeric field stopped the alert being created at all — permanently, since
+        the Graylog event is only stamped after a successful create, so the same
+        document was retried and re-failed on every scheduler run (#1096).
+
+        Coercing here rather than widening the annotations keeps the rest of the
+        ingest path working with plain strings. Driven off the declared fields so
+        a string field added later is covered without a second look.
+
+        `bool` is excluded deliberately: it is an `int` subclass in Python, and
+        turning `True` into `"True"` would be a silent data change rather than a
+        format fix.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        coerced = None
+        for name, field in cls.model_fields.items():
+            if name not in data or not _is_string_field(field.annotation):
+                continue
+            value = data[name]
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            if coerced is None:
+                # Copy on first hit — the caller's document is not ours to mutate.
+                coerced = dict(data)
+            coerced[name] = str(value)
+
+        return coerced if coerced is not None else data
 
     def to_dict(self):
         return self.model_dump(exclude_none=True)

--- a/backend/tests/test_alert_numeric_field_coercion.py
+++ b/backend/tests/test_alert_numeric_field_coercion.py
@@ -1,0 +1,114 @@
+"""Numeric values in string-typed alert fields must not stop ingest (#1096).
+
+The lab stack produced `timestamp_utc` as epoch milliseconds — an `int` — and
+`GenericSourceModel` declares it `Optional[str]`. Pydantic 1 stringified that
+silently; Pydantic 2 raises `string_type`, `get_single_alert_details` turns any
+exception into a 400, and the alert is never created.
+
+The failure does not clear itself: `create_alert_auto_route` only stamps the
+Graylog event with `copilot_alert_id` *after* a successful create, so an alert
+that fails validation is selected again on the next scheduler run and fails
+identically, forever. That is why the reported batch logged `0 created, 3 failed`
+rather than a one-off error.
+
+Run with: cd backend && python -m pytest tests/test_alert_numeric_field_coercion.py
+"""
+
+import pytest
+
+from app.incidents.schema.incident_alert import GenericSourceModel
+
+# The exact value from the report, and the field it arrived in.
+EPOCH_MILLIS = 1787683237205
+
+
+def _source(**overrides):
+    """A minimal source document; `timestamp` is the only required field."""
+    base = {"timestamp": "2026-08-25T18:45:47.240Z"}
+    base.update(overrides)
+    return base
+
+
+def test_numeric_timestamp_utc_is_accepted():
+    """The reported failure: epoch millis as an int."""
+    model = GenericSourceModel(**_source(timestamp_utc=EPOCH_MILLIS))
+
+    assert model.timestamp_utc == str(EPOCH_MILLIS)
+    assert isinstance(model.timestamp_utc, str)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("timestamp", EPOCH_MILLIS),
+        ("timestamp_utc", EPOCH_MILLIS),
+        ("syslog_level", 3),
+        ("process_id", 10388),
+        ("agent_name", 12345),
+        ("rule_description", 5716),
+    ],
+)
+def test_every_string_field_accepts_a_number(field, value):
+    """Not just the field that happened to break first.
+
+    `syslog_level` is numeric on plenty of sources and `process_id` almost always
+    is, so fixing `timestamp_utc` alone would leave the same crash waiting.
+    """
+    model = GenericSourceModel(**_source(**{field: value}))
+
+    assert getattr(model, field) == str(value)
+
+
+def test_float_values_are_accepted():
+    """Some pipelines emit fractional epoch seconds."""
+    model = GenericSourceModel(**_source(timestamp_utc=1787683237.205))
+
+    assert model.timestamp_utc == "1787683237.205"
+
+
+def test_string_values_are_untouched():
+    """The common path must be byte-for-byte unchanged."""
+    model = GenericSourceModel(
+        **_source(
+            timestamp_utc="2026-08-25T18:45:47.240Z",
+            syslog_level="ALERT",
+            process_id="10388",
+        ),
+    )
+
+    assert model.timestamp_utc == "2026-08-25T18:45:47.240Z"
+    assert model.syslog_level == "ALERT"
+    assert model.process_id == "10388"
+
+
+def test_booleans_are_not_stringified():
+    """`bool` is an `int` subclass — coercing it would be a data change, not a
+    format fix, so a bool must still fail validation rather than become "True"."""
+    with pytest.raises(Exception) as exc:
+        GenericSourceModel(**_source(timestamp_utc=True))
+
+    assert "string_type" in str(exc.value)
+
+
+def test_none_is_left_alone():
+    """An explicit null stays null rather than becoming the string "None"."""
+    model = GenericSourceModel(**_source(timestamp_utc=None))
+
+    assert model.timestamp_utc is None
+
+
+def test_extra_fields_are_not_coerced():
+    """`extra="allow"` fields are undeclared, so their types are passed through
+    as-is — the alert context keeps the original numeric values."""
+    model = GenericSourceModel(**_source(data_win_system_processID=1234))
+
+    assert model.data_win_system_processID == 1234
+
+
+def test_source_document_is_not_mutated():
+    """Coercion copies rather than editing the caller's document."""
+    document = _source(timestamp_utc=EPOCH_MILLIS)
+
+    GenericSourceModel(**document)
+
+    assert document["timestamp_utc"] == EPOCH_MILLIS


### PR DESCRIPTION
Fixes #1096.

## The bug

`GenericSourceModel` is built straight from the raw indexer document, and the lab stack emitted `timestamp_utc` as epoch milliseconds — an `int` — where the model declares `Optional[str]`:

```
Failed to collect alert details: 1 validation error for GenericSourceModel
timestamp_utc
  Input should be a valid string [type=string_type, input_value=1787683237205, input_type=int]
```

This is the Pydantic v1 → v2 strictness family documented in `CLAUDE.md`: v1 coerced `int → str` silently, v2 rejects it. `get_single_alert_details` converts any exception into a 400 and `create_alert` propagates, so the alert is never created.

**It does not self-heal.** `create_alert_auto_route` only calls `add_copilot_alert_id` *after* a successful create, so the Graylog event is never stamped, the same document is selected on the next scheduler run, and it fails identically — forever. That is why the report showed `0 created, 3 failed` for the batch rather than a single error.

## The fix

A `mode="before"` model validator on `GenericSourceModel` that stringifies numeric values for string-declared fields.

Three decisions worth calling out:

**Coerce rather than widen the annotation.** Changing the fields to `int | str` would push the problem downstream — the timefield is parsed and stored as a string, so every consumer would need to handle both shapes.

**Driven off `model_fields`, not a hardcoded list.** Every string field on the model is covered, and a string field added later is covered without anyone remembering to update the validator. This matters because `timestamp_utc` is not the only exposure: `syslog_level` is numeric on plenty of sources and `process_id` almost always is, so patching just the field that happened to break first would leave the same crash waiting.

**`bool` is excluded deliberately.** `bool` is an `int` subclass in Python, so a naive numeric check would turn `True` into `"True"` — a silent data change rather than a format fix. A bool still fails validation.

Coercion copies the input dict on first hit rather than mutating the caller's document, and `extra="allow"` fields are untouched, so the alert context keeps its original numeric values.

## Tests

`backend/tests/test_alert_numeric_field_coercion.py` — 13 cases covering the reported value, every string field on the model, floats, unchanged strings, the bool exclusion, explicit `None`, extra-field passthrough, and non-mutation of the source document.

Verified the tests actually exercise the bug: with the fix reverted, **9 of 13 fail**; with it applied, all 13 pass. (The 4 that pass either way are the untouched-string, `None`, and extra-field paths, which were never broken.)

`pre-commit run` passes on both files.

## Not included

Two secondary items from the issue, both worth their own change:

1. The duplicate `GenericSourceModel` in `app/integrations/alert_escalation/schema/escalate_alert.py` — only `CustomerCodeKeys` is imported from that module anywhere, so both models there appear dead. Deleting them is a separate call from fixing this crash.
2. Poison-pill handling in `create_alert_auto_route`, so a permanently-unvalidatable document stops consuming batch capacity on every run. That is a behavioural change to the ingest loop, independent of this field.
