### PR TITLE
feat: bulk status and assignee actions for selected alerts

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -63,6 +63,9 @@ from app.incidents.schema.db_operations import AssignedToCase
 from app.incidents.schema.db_operations import AvailableIndicesResponse
 from app.incidents.schema.db_operations import AvailableSourcesResponse
 from app.incidents.schema.db_operations import AvailableUsersResponse
+from app.incidents.schema.db_operations import BulkAlertUpdateResponse
+from app.incidents.schema.db_operations import BulkAssignedToAlert
+from app.incidents.schema.db_operations import BulkUpdateAlertStatus
 from app.incidents.schema.db_operations import CaseAlertLinkCreate
 from app.incidents.schema.db_operations import CaseAlertLinkResponse
 from app.incidents.schema.db_operations import CaseAlertLinksCreate
@@ -589,6 +592,49 @@ async def update_alert_status_endpoint(
 
 
 @incidents_db_operations_router.put(
+    "/alerts/status",
+    response_model=BulkAlertUpdateResponse,
+    description="Apply one status to every alert in a selection",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst", "customer_user"))],
+)
+async def bulk_update_alert_status_endpoint(
+    bulk_status: BulkUpdateAlertStatus,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set the same status on many alerts at once (GitHub issue #1098).
+
+    Scoped to match the single-alert `/alert/status` route, `customer_user`
+    included -- bulk is a convenience over the same operation, not a wider
+    permission.
+
+    Access is checked per alert, not once for the request: a selection can span
+    customers, and the caller may be entitled to only some of them. An alert the
+    caller cannot reach is skipped and reported, which is also why this does not
+    distinguish 403 from 404 in the response -- doing so would confirm that an id
+    exists in a tenant the caller cannot see.
+    """
+    updated_alert_ids = []
+    not_updated_alert_ids = []
+
+    for alert_id in bulk_status.alert_ids:
+        try:
+            await _ensure_alert_access(alert_id, current_user, db)
+            await update_alert_status(UpdateAlertStatus(alert_id=alert_id, status=bulk_status.status), db)
+            updated_alert_ids.append(alert_id)
+        except HTTPException as e:
+            logger.info(f"Skipping alert {alert_id} in bulk status update: {e.detail}")
+            not_updated_alert_ids.append(alert_id)
+
+    return BulkAlertUpdateResponse(
+        message=f"Updated {len(updated_alert_ids)} alert(s) to {bulk_status.status.value}",
+        updated_alert_ids=updated_alert_ids,
+        not_updated_alert_ids=not_updated_alert_ids,
+        success=True,
+    )
+
+
+@incidents_db_operations_router.put(
     "/alert/verdict",
     response_model=AlertResponse,
     description="Set, change or clear an alert's triage verdict (true positive / false positive)",
@@ -883,6 +929,87 @@ async def update_assigned_to_endpoint(
         alert=updated,
         success=True,
         message="Alert assigned to user successfully",
+    )
+
+
+@incidents_db_operations_router.put(
+    "/alerts/assigned-to",
+    response_model=BulkAlertUpdateResponse,
+    description="Assign every alert in a selection to the same user",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def bulk_update_assigned_to_endpoint(
+    bulk_assigned_to: BulkAssignedToAlert,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Assign many alerts to one user at once (GitHub issue #1098).
+
+    Scoped `admin|analyst`, matching the single-alert route and deliberately
+    narrower than bulk status, which also admits `customer_user`.
+
+    The assignee is validated once for the request rather than per alert -- an
+    unknown username is a bad request, not a per-alert skip, and failing fast
+    avoids assigning half a selection before noticing. Alert-level failures
+    (missing, or a customer the caller is not entitled to) are still skipped and
+    reported, so a selection spanning customers does the work it is allowed to do.
+
+    One `ALERT_ASSIGNED` notification is emitted per alert that actually changed
+    hands, exactly as the single-alert route does: each alert genuinely changed,
+    and a route gating on severity should see each one. Alerts already assigned
+    to that user stay silent. If the volume proves noisy in practice, an
+    aggregated trigger is the follow-up -- that needs its own trigger, template
+    variables and route config, so it is not smuggled in here.
+    """
+    all_users = await select_all_users()
+    user_names = [user.username for user in all_users]
+    if bulk_assigned_to.assigned_to not in user_names:
+        raise HTTPException(status_code=400, detail="User does not exist")
+
+    updated_alert_ids = []
+    not_updated_alert_ids = []
+
+    for alert_id in bulk_assigned_to.alert_ids:
+        try:
+            await _ensure_alert_access(alert_id, current_user, db)
+
+            # Re-read as the ORM row rather than reusing what the access check
+            # returned: that is an `AlertOut`, which carries no `severity`, so
+            # `severity_of` would silently fall back to the deployment default
+            # and every bulk assignment would notify at the wrong severity.
+            #
+            # Read BEFORE the mutation, as the single-alert route does: rewriting
+            # the same assignee must stay silent.
+            existing = await db.execute(select(Alert).where(Alert.id == alert_id))
+            existing_alert = existing.scalars().first()
+            previous_assignee = existing_alert.assigned_to
+            alert_title = existing_alert.alert_name
+            alert_customer = existing_alert.customer_code
+            alert_severity = severity_of(existing_alert)
+
+            await update_alert_assigned_to(alert_id, bulk_assigned_to.assigned_to, db)
+            updated_alert_ids.append(alert_id)
+
+            if previous_assignee != bulk_assigned_to.assigned_to:
+                emit(
+                    alert_assigned_event(
+                        alert_id=alert_id,
+                        title=alert_title,
+                        assignee=bulk_assigned_to.assigned_to,
+                        actor=current_user.username,
+                        customer_code=alert_customer,
+                        severity=alert_severity,
+                    ),
+                )
+        except HTTPException as e:
+            logger.info(f"Skipping alert {alert_id} in bulk assignment: {e.detail}")
+            not_updated_alert_ids.append(alert_id)
+
+    return BulkAlertUpdateResponse(
+        message=f"Assigned {len(updated_alert_ids)} alert(s) to {bulk_assigned_to.assigned_to}",
+        updated_alert_ids=updated_alert_ids,
+        not_updated_alert_ids=not_updated_alert_ids,
+        success=True,
     )
 
 

--- a/backend/app/incidents/schema/db_operations.py
+++ b/backend/app/incidents/schema/db_operations.py
@@ -124,6 +124,28 @@ class UpdateAlertStatus(BaseModel):
     status: AlertStatus
 
 
+class BulkUpdateAlertStatus(BaseModel):
+    """Apply one status to many alerts (GitHub issue #1098)."""
+
+    alert_ids: List[int]
+    status: AlertStatus
+
+
+class BulkAlertUpdateResponse(BaseModel):
+    """Outcome of a bulk alert mutation.
+
+    Mirrors ``DeleteAlertsResponse``: a per-alert failure (missing alert, or a
+    customer the caller is not entitled to) is reported as a skipped id rather
+    than failing the whole request, so one inaccessible alert in a selection of
+    fifty does not discard the other forty-nine.
+    """
+
+    message: str
+    updated_alert_ids: List[int]
+    not_updated_alert_ids: List[int]
+    success: bool
+
+
 class AlertVerdict(str, Enum):
     """Analyst triage verdict. The absence of a verdict (NULL on the alert) is a third,
     meaningful state -- "not yet triaged" -- and is represented by omitting the value
@@ -302,6 +324,13 @@ class FieldAndAssetNamesResponse(BaseModel):
 
 class AssignedToAlert(BaseModel):
     alert_id: int
+    assigned_to: str
+
+
+class BulkAssignedToAlert(BaseModel):
+    """Assign many alerts to one user (GitHub issue #1098)."""
+
+    alert_ids: List[int]
     assigned_to: str
 
 

--- a/backend/app/incidents/schema/incident_alert.py
+++ b/backend/app/incidents/schema/incident_alert.py
@@ -1,13 +1,18 @@
 from datetime import datetime
 from enum import Enum
+from types import UnionType
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
+from typing import get_args
+from typing import get_origin
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 
 class ValidSyslogType(str, Enum):
@@ -84,6 +89,15 @@ class FieldNames(BaseModel):
     ioc_field_names: Optional[List[str]] = None
 
 
+def _is_string_field(annotation: Any) -> bool:
+    """True for a field declared `str` or `Optional[str]`."""
+    if annotation is str:
+        return True
+    if get_origin(annotation) in (Union, UnionType):
+        return str in get_args(annotation)
+    return False
+
+
 class GenericSourceModel(BaseModel):
     timestamp: str = Field(..., description="The timestamp of the alert.")
     timestamp_utc: Optional[str] = Field(
@@ -111,6 +125,46 @@ class GenericSourceModel(BaseModel):
         description="The agent name of the alert.",
     )
     model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _stringify_numeric_values(cls, data: Any) -> Any:
+        """Accept a number where a string field is declared.
+
+        These models are built straight from raw indexer documents, and what a
+        source puts in a given field is not ours to control: `timestamp_utc`
+        arrives as epoch milliseconds from some pipelines, `syslog_level` as a
+        numeric severity, `process_id` as an int. Pydantic 1 coerced all of that
+        to `str` silently; Pydantic 2 rejects it with `string_type`, and because
+        `get_single_alert_details` turns any exception into a 400, a single
+        numeric field stopped the alert being created at all — permanently, since
+        the Graylog event is only stamped after a successful create, so the same
+        document was retried and re-failed on every scheduler run (#1096).
+
+        Coercing here rather than widening the annotations keeps the rest of the
+        ingest path working with plain strings. Driven off the declared fields so
+        a string field added later is covered without a second look.
+
+        `bool` is excluded deliberately: it is an `int` subclass in Python, and
+        turning `True` into `"True"` would be a silent data change rather than a
+        format fix.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        coerced = None
+        for name, field in cls.model_fields.items():
+            if name not in data or not _is_string_field(field.annotation):
+                continue
+            value = data[name]
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            if coerced is None:
+                # Copy on first hit — the caller's document is not ours to mutate.
+                coerced = dict(data)
+            coerced[name] = str(value)
+
+        return coerced if coerced is not None else data
 
     def to_dict(self):
         return self.model_dump(exclude_none=True)

--- a/backend/tests/test_alert_numeric_field_coercion.py
+++ b/backend/tests/test_alert_numeric_field_coercion.py
@@ -1,0 +1,114 @@
+"""Numeric values in string-typed alert fields must not stop ingest (#1096).
+
+The lab stack produced `timestamp_utc` as epoch milliseconds — an `int` — and
+`GenericSourceModel` declares it `Optional[str]`. Pydantic 1 stringified that
+silently; Pydantic 2 raises `string_type`, `get_single_alert_details` turns any
+exception into a 400, and the alert is never created.
+
+The failure does not clear itself: `create_alert_auto_route` only stamps the
+Graylog event with `copilot_alert_id` *after* a successful create, so an alert
+that fails validation is selected again on the next scheduler run and fails
+identically, forever. That is why the reported batch logged `0 created, 3 failed`
+rather than a one-off error.
+
+Run with: cd backend && python -m pytest tests/test_alert_numeric_field_coercion.py
+"""
+
+import pytest
+
+from app.incidents.schema.incident_alert import GenericSourceModel
+
+# The exact value from the report, and the field it arrived in.
+EPOCH_MILLIS = 1787683237205
+
+
+def _source(**overrides):
+    """A minimal source document; `timestamp` is the only required field."""
+    base = {"timestamp": "2026-08-25T18:45:47.240Z"}
+    base.update(overrides)
+    return base
+
+
+def test_numeric_timestamp_utc_is_accepted():
+    """The reported failure: epoch millis as an int."""
+    model = GenericSourceModel(**_source(timestamp_utc=EPOCH_MILLIS))
+
+    assert model.timestamp_utc == str(EPOCH_MILLIS)
+    assert isinstance(model.timestamp_utc, str)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("timestamp", EPOCH_MILLIS),
+        ("timestamp_utc", EPOCH_MILLIS),
+        ("syslog_level", 3),
+        ("process_id", 10388),
+        ("agent_name", 12345),
+        ("rule_description", 5716),
+    ],
+)
+def test_every_string_field_accepts_a_number(field, value):
+    """Not just the field that happened to break first.
+
+    `syslog_level` is numeric on plenty of sources and `process_id` almost always
+    is, so fixing `timestamp_utc` alone would leave the same crash waiting.
+    """
+    model = GenericSourceModel(**_source(**{field: value}))
+
+    assert getattr(model, field) == str(value)
+
+
+def test_float_values_are_accepted():
+    """Some pipelines emit fractional epoch seconds."""
+    model = GenericSourceModel(**_source(timestamp_utc=1787683237.205))
+
+    assert model.timestamp_utc == "1787683237.205"
+
+
+def test_string_values_are_untouched():
+    """The common path must be byte-for-byte unchanged."""
+    model = GenericSourceModel(
+        **_source(
+            timestamp_utc="2026-08-25T18:45:47.240Z",
+            syslog_level="ALERT",
+            process_id="10388",
+        ),
+    )
+
+    assert model.timestamp_utc == "2026-08-25T18:45:47.240Z"
+    assert model.syslog_level == "ALERT"
+    assert model.process_id == "10388"
+
+
+def test_booleans_are_not_stringified():
+    """`bool` is an `int` subclass — coercing it would be a data change, not a
+    format fix, so a bool must still fail validation rather than become "True"."""
+    with pytest.raises(Exception) as exc:
+        GenericSourceModel(**_source(timestamp_utc=True))
+
+    assert "string_type" in str(exc.value)
+
+
+def test_none_is_left_alone():
+    """An explicit null stays null rather than becoming the string "None"."""
+    model = GenericSourceModel(**_source(timestamp_utc=None))
+
+    assert model.timestamp_utc is None
+
+
+def test_extra_fields_are_not_coerced():
+    """`extra="allow"` fields are undeclared, so their types are passed through
+    as-is — the alert context keeps the original numeric values."""
+    model = GenericSourceModel(**_source(data_win_system_processID=1234))
+
+    assert model.data_win_system_processID == 1234
+
+
+def test_source_document_is_not_mutated():
+    """Coercion copies rather than editing the caller's document."""
+    document = _source(timestamp_utc=EPOCH_MILLIS)
+
+    GenericSourceModel(**document)
+
+    assert document["timestamp_utc"] == EPOCH_MILLIS

--- a/backend/tests/test_bulk_alert_actions.py
+++ b/backend/tests/test_bulk_alert_actions.py
@@ -1,0 +1,278 @@
+"""Bulk status and assignee actions on selected alerts (#1098).
+
+The point of these endpoints is that a selection is not a homogeneous thing: it
+can span customers, contain an alert someone else just deleted, and contain
+alerts already at the target value. The contract is therefore partial success —
+do the work that is allowed, report what was skipped — and the tests below pin
+each part of that.
+
+Access is checked per alert rather than once per request, which is what keeps a
+selection from becoming a way to touch a tenant the caller cannot reach. The
+sibling bulk-delete route does not do this (#1099); these must not copy it.
+
+Unit tests against the route handlers with a mocked session; no real DB.
+
+Run with: cd backend && python -m pytest tests/test_bulk_alert_actions.py
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.incidents.routes.db_operations as routes  # noqa: E402
+from app.incidents.schema.db_operations import BulkAssignedToAlert  # noqa: E402
+from app.incidents.schema.db_operations import BulkUpdateAlertStatus  # noqa: E402
+
+ANALYST = SimpleNamespace(id=7, username="analyst", role_id=2)
+
+# Alert 3 belongs to a customer the caller is not entitled to.
+FORBIDDEN_ID = 3
+# Alert 4 no longer exists.
+MISSING_ID = 4
+
+
+def _alert(alert_id, assigned_to=None, severity="High"):
+    return SimpleNamespace(
+        id=alert_id,
+        alert_name=f"Alert {alert_id}",
+        customer_code="TENANT_A",
+        assigned_to=assigned_to,
+        severity=severity,
+    )
+
+
+def _session(rows=None):
+    """AsyncSession whose `execute` yields the ORM row for the requested alert."""
+    session = AsyncMock()
+    rows = rows or {}
+
+    async def execute(statement):
+        result = MagicMock()
+        # The bulk assign handler re-reads the ORM row; hand back whichever alert
+        # the test registered, in call order.
+        result.scalars.return_value.first.return_value = execute.queue.pop(0) if execute.queue else None
+        return result
+
+    execute.queue = list(rows)
+    session.execute = execute
+    return session
+
+
+def _patch_access(monkeypatch, forbidden=(FORBIDDEN_ID,), missing=(MISSING_ID,)):
+    """Per-alert access check: 403 for a foreign customer, 404 for a deleted alert."""
+
+    async def ensure(alert_id, current_user, db):
+        if alert_id in forbidden:
+            raise HTTPException(status_code=403, detail=f"Access denied to alert {alert_id}")
+        if alert_id in missing:
+            raise HTTPException(status_code=404, detail="Alert not found")
+        return _alert(alert_id)
+
+    monkeypatch.setattr(routes, "_ensure_alert_access", ensure)
+
+
+# --------------------------------------------------------------------------- status
+
+
+def test_bulk_status_updates_every_accessible_alert(monkeypatch):
+    _patch_access(monkeypatch, forbidden=(), missing=())
+    updated = []
+
+    async def fake_update(payload, db):
+        updated.append((payload.alert_id, payload.status))
+
+    monkeypatch.setattr(routes, "update_alert_status", fake_update)
+
+    response = asyncio.run(
+        routes.bulk_update_alert_status_endpoint(
+            BulkUpdateAlertStatus(alert_ids=[1, 2], status="CLOSED"),
+            current_user=ANALYST,
+            db=_session(),
+        ),
+    )
+
+    assert response.updated_alert_ids == [1, 2]
+    assert response.not_updated_alert_ids == []
+    assert updated == [(1, "CLOSED"), (2, "CLOSED")]
+
+
+def test_bulk_status_skips_alerts_the_caller_cannot_reach(monkeypatch):
+    """A selection spanning customers does the work it is allowed to do.
+
+    The inaccessible alert is reported as skipped rather than 403ing the request,
+    so one foreign alert cannot discard the rest of the analyst's selection.
+    """
+    _patch_access(monkeypatch)
+    updated = []
+
+    async def fake_update(payload, db):
+        updated.append(payload.alert_id)
+
+    monkeypatch.setattr(routes, "update_alert_status", fake_update)
+
+    response = asyncio.run(
+        routes.bulk_update_alert_status_endpoint(
+            BulkUpdateAlertStatus(alert_ids=[1, FORBIDDEN_ID, 2, MISSING_ID], status="IN_PROGRESS"),
+            current_user=ANALYST,
+            db=_session(),
+        ),
+    )
+
+    assert response.updated_alert_ids == [1, 2]
+    assert response.not_updated_alert_ids == [FORBIDDEN_ID, MISSING_ID]
+    # The forbidden alert was never handed to the mutation.
+    assert FORBIDDEN_ID not in updated
+
+
+def test_bulk_status_does_not_distinguish_forbidden_from_missing(monkeypatch):
+    """Both land in the same bucket: telling them apart would confirm that an id
+    exists inside a tenant the caller cannot see."""
+    _patch_access(monkeypatch)
+
+    async def fake_update(payload, db):
+        return None
+
+    monkeypatch.setattr(routes, "update_alert_status", fake_update)
+
+    response = asyncio.run(
+        routes.bulk_update_alert_status_endpoint(
+            BulkUpdateAlertStatus(alert_ids=[FORBIDDEN_ID, MISSING_ID], status="OPEN"),
+            current_user=ANALYST,
+            db=_session(),
+        ),
+    )
+
+    assert response.updated_alert_ids == []
+    assert response.not_updated_alert_ids == [FORBIDDEN_ID, MISSING_ID]
+    assert response.success is True
+
+
+# ------------------------------------------------------------------------- assignee
+
+
+def _patch_users(monkeypatch, names=("analyst", "other")):
+    async def fake_users():
+        return [SimpleNamespace(username=name) for name in names]
+
+    monkeypatch.setattr(routes, "select_all_users", fake_users)
+
+
+def test_bulk_assign_rejects_an_unknown_user_before_touching_anything(monkeypatch):
+    """Fails fast rather than per-alert: assigning half a selection and then
+    discovering the username is wrong is worse than doing nothing."""
+    _patch_users(monkeypatch)
+    _patch_access(monkeypatch, forbidden=(), missing=())
+    assigned = []
+
+    async def fake_assign(alert_id, assigned_to, db):
+        assigned.append(alert_id)
+
+    monkeypatch.setattr(routes, "update_alert_assigned_to", fake_assign)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            routes.bulk_update_assigned_to_endpoint(
+                BulkAssignedToAlert(alert_ids=[1, 2], assigned_to="ghost"),
+                current_user=ANALYST,
+                db=_session(),
+            ),
+        )
+
+    assert exc.value.status_code == 400
+    assert assigned == []
+
+
+def test_bulk_assign_notifies_once_per_alert_that_changed_hands(monkeypatch):
+    """Alert 2 is already assigned to the target user, so it must stay silent —
+    the same rule the single-alert route follows."""
+    _patch_users(monkeypatch)
+    _patch_access(monkeypatch, forbidden=(), missing=())
+
+    rows = [_alert(1, assigned_to=None), _alert(2, assigned_to="other")]
+    events = []
+
+    async def fake_assign(alert_id, assigned_to, db):
+        return None
+
+    monkeypatch.setattr(routes, "update_alert_assigned_to", fake_assign)
+    monkeypatch.setattr(routes, "emit", lambda event: events.append(event))
+    monkeypatch.setattr(
+        routes,
+        "alert_assigned_event",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    response = asyncio.run(
+        routes.bulk_update_assigned_to_endpoint(
+            BulkAssignedToAlert(alert_ids=[1, 2], assigned_to="other"),
+            current_user=ANALYST,
+            db=_session(rows),
+        ),
+    )
+
+    assert response.updated_alert_ids == [1, 2]
+    assert [event.alert_id for event in events] == [1]
+
+
+def test_bulk_assign_notification_carries_the_alerts_own_severity(monkeypatch):
+    """`AlertOut` has no `severity`, so reusing what the access check returned
+    would silently notify at the deployment default and a route gating at High
+    would miss a Critical handover."""
+    _patch_users(monkeypatch)
+    _patch_access(monkeypatch, forbidden=(), missing=())
+
+    events = []
+
+    async def fake_assign(alert_id, assigned_to, db):
+        return None
+
+    monkeypatch.setattr(routes, "update_alert_assigned_to", fake_assign)
+    monkeypatch.setattr(routes, "emit", lambda event: events.append(event))
+    monkeypatch.setattr(routes, "alert_assigned_event", lambda **kwargs: SimpleNamespace(**kwargs))
+
+    asyncio.run(
+        routes.bulk_update_assigned_to_endpoint(
+            BulkAssignedToAlert(alert_ids=[1], assigned_to="other"),
+            current_user=ANALYST,
+            db=_session([_alert(1, assigned_to=None, severity="Critical")]),
+        ),
+    )
+
+    assert len(events) == 1
+    assert events[0].severity == "Critical"
+    assert events[0].customer_code == "TENANT_A"
+    assert events[0].actor == "analyst"
+
+
+def test_bulk_assign_skips_alerts_the_caller_cannot_reach(monkeypatch):
+    """Stricter than the single-alert assign route, which checks nothing (#1099)."""
+    _patch_users(monkeypatch)
+    _patch_access(monkeypatch)
+
+    assigned = []
+
+    async def fake_assign(alert_id, assigned_to, db):
+        assigned.append(alert_id)
+
+    monkeypatch.setattr(routes, "update_alert_assigned_to", fake_assign)
+    monkeypatch.setattr(routes, "emit", lambda event: None)
+    monkeypatch.setattr(routes, "alert_assigned_event", lambda **kwargs: SimpleNamespace(**kwargs))
+
+    response = asyncio.run(
+        routes.bulk_update_assigned_to_endpoint(
+            BulkAssignedToAlert(alert_ids=[1, FORBIDDEN_ID], assigned_to="other"),
+            current_user=ANALYST,
+            db=_session([_alert(1, assigned_to=None)]),
+        ),
+    )
+
+    assert response.updated_alert_ids == [1]
+    assert response.not_updated_alert_ids == [FORBIDDEN_ID]
+    assert assigned == [1]

--- a/frontend/src/api/endpoints/incidentManagement/alerts.ts
+++ b/frontend/src/api/endpoints/incidentManagement/alerts.ts
@@ -16,6 +16,16 @@ import _castArray from "lodash/castArray"
 import { HttpClient } from "../../http-client"
 
 export type AlertsListFilterValue = string | string[] | AlertStatus | null
+
+/**
+ * Outcome of a bulk alert mutation. A per-alert failure — the alert is gone, or belongs to a
+ * customer the caller is not entitled to — is reported as a skipped id rather than failing the
+ * request, so one inaccessible alert in a selection of fifty does not discard the other 49.
+ */
+export interface BulkAlertUpdateResult {
+	updated_alert_ids: number[]
+	not_updated_alert_ids: number[]
+}
 export type AlertsFilterTypes = KeysOfUnion<AlertsFilter>
 
 export interface AlertsQuery {
@@ -198,6 +208,29 @@ export default {
 			alert_id: alertId,
 			assigned_to: user
 		})
+	},
+	/**
+	 * Apply one status to a whole selection. Alerts the caller cannot reach come back in
+	 * `not_updated_alert_ids` rather than failing the request — a selection may span customers.
+	 */
+	bulkUpdateAlertStatus(alertIds: number[], status: AlertStatus) {
+		return HttpClient.put<FlaskBaseResponse & BulkAlertUpdateResult>(
+			`/incidents/db_operations/alerts/status`,
+			{
+				alert_ids: alertIds,
+				status
+			}
+		)
+	},
+	/** Assign a whole selection to one user. Same partial-success contract as the status call. */
+	bulkUpdateAlertAssignedUser(alertIds: number[], user: string) {
+		return HttpClient.put<FlaskBaseResponse & BulkAlertUpdateResult>(
+			`/incidents/db_operations/alerts/assigned-to`,
+			{
+				alert_ids: alertIds,
+				assigned_to: user
+			}
+		)
 	},
 	deleteAlertTag(alertId: number, tagId: number) {
 		return HttpClient.delete<FlaskBaseResponse & { alert_tag: AlertTag }>(`/incidents/db_operations/alert/tag`, {

--- a/frontend/src/components/incidentManagement/alerts/AlertBulkAssignButton.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertBulkAssignButton.vue
@@ -1,0 +1,111 @@
+<template>
+	<n-popselect
+		v-model:value="userSelected"
+		v-model:show="usersListVisible"
+		:options="usersOptions"
+		:disabled="loading"
+		size="medium"
+		scrollable
+		to="body"
+	>
+		<n-button :size secondary :loading>
+			<template #icon>
+				<Icon :name="AssigneeIcon" />
+			</template>
+			Assignee
+		</n-button>
+	</n-popselect>
+</template>
+
+<script setup lang="ts">
+import type { ButtonSize } from "naive-ui"
+import type { Ref } from "vue"
+import type { ApiError } from "@/types/common"
+import type { Alert } from "@/types/incidentManagement/alerts"
+import { NButton, NPopselect, useMessage } from "naive-ui"
+import { computed, inject, ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+
+const { alerts, size } = defineProps<{
+	alerts: Alert[]
+	size?: ButtonSize
+}>()
+
+const emit = defineEmits<{
+	(e: "updated", value: Alert): void
+	(e: "done"): void
+}>()
+
+const AssigneeIcon = "carbon:user-avatar"
+
+const loading = ref(false)
+const message = useMessage()
+const usersListVisible = ref(false)
+const users = inject<Ref<string[]>>("assignable-users", ref([]))
+const userSelected = ref<string | null>(null)
+const usersOptions = computed(() => users.value.map(user => ({ label: user, value: user })))
+
+function updateAssignee() {
+	const assignee = userSelected.value
+	if (!assignee) return
+
+	// Alerts already assigned to this user are excluded: the backend keeps them silent
+	// (no ALERT_ASSIGNED notification on a no-op), and sending them would inflate the
+	// count reported back to the analyst.
+	const targets = alerts.filter(alert => alert.assigned_to !== assignee)
+
+	if (!targets.length) {
+		message.info(`All selected alerts are already assigned to ${assignee}.`)
+		return
+	}
+
+	loading.value = true
+
+	Api.incidentManagement.alerts
+		.bulkUpdateAlertAssignedUser(
+			targets.map(alert => alert.id),
+			assignee
+		)
+		.then(res => {
+			if (res.data.success) {
+				const updatedIds = new Set(res.data.updated_alert_ids)
+				const skippedCount = res.data.not_updated_alert_ids?.length ?? 0
+
+				for (const alert of targets) {
+					if (updatedIds.has(alert.id)) {
+						emit("updated", { ...alert, assigned_to: assignee })
+					}
+				}
+
+				if (updatedIds.size && skippedCount) {
+					message.warning(
+						`Assigned ${updatedIds.size} alert(s). ${skippedCount} could not be assigned.`
+					)
+				} else if (updatedIds.size) {
+					message.success(res.data?.message || `Assigned ${updatedIds.size} alert(s).`)
+				} else {
+					message.warning("The selected alerts could not be assigned.")
+				}
+
+				emit("done")
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch((err: ApiError) => {
+			message.error(getApiErrorMessage(err))
+		})
+		.finally(() => {
+			loading.value = false
+			userSelected.value = null
+		})
+}
+
+watch(userSelected, () => {
+	if (userSelected.value) {
+		updateAssignee()
+	}
+})
+</script>

--- a/frontend/src/components/incidentManagement/alerts/AlertBulkStatusButton.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertBulkStatusButton.vue
@@ -1,0 +1,115 @@
+<template>
+	<n-popselect
+		v-model:value="statusSelected"
+		v-model:show="listVisible"
+		:options="statusOptions"
+		:disabled="loading"
+		size="medium"
+		scrollable
+		to="body"
+	>
+		<n-button :size secondary :loading>
+			<template #icon>
+				<Icon :name="StatusIcon" />
+			</template>
+			Status
+		</n-button>
+	</n-popselect>
+</template>
+
+<script setup lang="ts">
+import type { ButtonSize } from "naive-ui"
+import type { ApiError } from "@/types/common"
+import type { Alert, AlertStatus } from "@/types/incidentManagement/alerts"
+import { NButton, NPopselect, useMessage } from "naive-ui"
+import { ref, watch } from "vue"
+import Api from "@/api"
+import Icon from "@/components/common/Icon.vue"
+import { getApiErrorMessage } from "@/utils"
+
+const { alerts, size } = defineProps<{
+	alerts: Alert[]
+	size?: ButtonSize
+}>()
+
+const emit = defineEmits<{
+	(e: "updated", value: Alert): void
+	(e: "done"): void
+}>()
+
+const StatusIcon = "carbon:progress-bar-round"
+
+const loading = ref(false)
+const message = useMessage()
+const listVisible = ref(false)
+const statusSelected = ref<AlertStatus | null>(null)
+const statusOptions = ref<{ label: string; value: AlertStatus }[]>([
+	{ label: "Open", value: "OPEN" },
+	{ label: "In progress", value: "IN_PROGRESS" },
+	{ label: "Closed", value: "CLOSED" }
+])
+
+function updateStatus() {
+	const status = statusSelected.value
+	if (!status) return
+
+	// Alerts already at the requested status are left out of the request rather than
+	// rewritten — the backend would accept them, but sending them makes the "updated N"
+	// count meaningless to the analyst who just pressed the button.
+	const targets = alerts.filter(alert => alert.status !== status)
+
+	if (!targets.length) {
+		message.info(`All selected alerts are already ${status.replace("_", " ").toLowerCase()}.`)
+		return
+	}
+
+	loading.value = true
+
+	Api.incidentManagement.alerts
+		.bulkUpdateAlertStatus(
+			targets.map(alert => alert.id),
+			status
+		)
+		.then(res => {
+			if (res.data.success) {
+				const updatedIds = new Set(res.data.updated_alert_ids)
+				const skippedCount = res.data.not_updated_alert_ids?.length ?? 0
+
+				// Patch locally instead of refetching: the new value is known, and a refetch
+				// would drop the analyst's scroll position mid-triage.
+				for (const alert of targets) {
+					if (updatedIds.has(alert.id)) {
+						emit("updated", { ...alert, status })
+					}
+				}
+
+				if (updatedIds.size && skippedCount) {
+					message.warning(
+						`Updated ${updatedIds.size} alert(s). ${skippedCount} could not be updated.`
+					)
+				} else if (updatedIds.size) {
+					message.success(res.data?.message || `Updated ${updatedIds.size} alert(s).`)
+				} else {
+					message.warning("The selected alerts could not be updated.")
+				}
+
+				emit("done")
+			} else {
+				message.warning(res.data?.message || "An error occurred. Please try again later.")
+			}
+		})
+		.catch((err: ApiError) => {
+			message.error(getApiErrorMessage(err))
+		})
+		.finally(() => {
+			loading.value = false
+			statusSelected.value = null
+		})
+}
+
+watch(statusSelected, () => {
+	if (statusSelected.value) {
+		updateStatus()
+	}
+})
+</script>

--- a/frontend/src/components/incidentManagement/alerts/AlertsList.vue
+++ b/frontend/src/components/incidentManagement/alerts/AlertsList.vue
@@ -217,6 +217,21 @@
 					</template>
 				</n-popover>
 
+				<AlertBulkStatusButton
+					:alerts="checkedAlerts"
+					size="small"
+					@updated="updateAlert"
+					@done="resetChecked()"
+				/>
+
+				<AlertBulkAssignButton
+					v-if="canAssign"
+					:alerts="checkedAlerts"
+					size="small"
+					@updated="updateAlert"
+					@done="resetChecked()"
+				/>
+
 				<AlertMergeCaseButton
 					v-if="checkedNoLinkedAlerts.length"
 					:alerts="checkedNoLinkedAlerts"
@@ -360,6 +375,8 @@ import CollapseKeepAlive from "@/components/common/CollapseKeepAlive.vue"
 import Icon from "@/components/common/Icon.vue"
 import GenerateIncidentReportButton from "@/components/customers/reporting/GenerateIncidentReportButton.vue"
 import { useNavigation } from "@/composables/useNavigation"
+import { useAuthStore } from "@/stores/auth"
+import { AuthUserRole } from "@/types/auth"
 import { getApiErrorMessage } from "@/utils"
 import AlertItem from "./AlertItem.vue"
 import AlertsFilters from "./AlertsFilters.vue"
@@ -375,6 +392,8 @@ const {
 }>()
 
 const AlertMergeCaseButton = defineAsyncComponent(() => import("./AlertMergeCaseButton.vue"))
+const AlertBulkStatusButton = defineAsyncComponent(() => import("./AlertBulkStatusButton.vue"))
+const AlertBulkAssignButton = defineAsyncComponent(() => import("./AlertBulkAssignButton.vue"))
 
 const FilterIcon = "carbon:filter-edit"
 const TrashIcon = "carbon:trash-can"
@@ -460,6 +479,13 @@ watch(
 	},
 	{ immediate: true }
 )
+
+const authStore = useAuthStore()
+
+// Bulk assign is admin|analyst server-side, matching the single-alert route, so a
+// customer_user gets no control rather than a 403 on press. Bulk status is not gated:
+// that route admits customer_user, as its single-alert counterpart does.
+const canAssign = computed(() => authStore.userRole !== AuthUserRole.CustomerUser)
 
 provide("assignable-users", availableUsers)
 


### PR DESCRIPTION
Closes #1098.

Adds Status and Assignee to the bulk action bar, so a selection can be triaged without merging it into a case first.

`Selected 10 | Status | Assignee | Merge into Case | Delete`

## Backend

Two routes alongside the single-alert ones:

- `PUT /incidents/db_operations/alerts/status` — `admin|analyst|customer_user`
- `PUT /incidents/db_operations/alerts/assigned-to` — `admin|analyst`

Scopes deliberately mirror their single-alert counterparts. Bulk is a convenience over the same operation, not a wider permission, which is why status admits `customer_user` and assign does not.

**Access is checked per alert, not once per request.** A selection can span customers and the caller may be entitled to only some of them. An alert that is missing, tag-restricted, or owned by a foreign customer is reported as a skipped id rather than failing the request — the same partial-success contract as the existing bulk delete (`updated_alert_ids` / `not_updated_alert_ids`), so one inaccessible alert in a selection of fifty does not discard the other 49.

The response does not distinguish 403 from 404. Telling them apart would confirm that an id exists inside a tenant the caller cannot see.

This makes bulk assign **stricter than the single-alert assign route it is modelled on**, which performs no customer check at all — see #1099, where that and the bulk-delete gap are tracked.

Two details worth flagging for review:

**Notification behaviour on bulk assign.** One `ALERT_ASSIGNED` event per alert that actually changed hands, exactly as the single-alert route does; alerts already assigned to the target user stay silent. Assigning 15 alerts therefore produces up to 15 notifications. Aggregating them into a single event would need its own trigger, template variables and route config, so it is not smuggled in here — if the volume proves noisy in practice that is a clean follow-up.

**Severity in that notification.** The access check returns an `AlertOut`, which has no `severity` field, so `severity_of()` on it would silently fall back to the deployment default and a route gating at High would miss a Critical handover. The handler re-reads the ORM row for the notification payload. Pinned by a test.

## Frontend

Two components following the existing `AlertMergeCaseButton` pattern, mounted in the same bar in `AlertsList.vue`:

- `AlertBulkStatusButton.vue` — popselect of Open / In progress / Closed
- `AlertBulkAssignButton.vue` — popselect of the injected `assignable-users`

Both filter out alerts already at the target value before sending, so the count reported back to the analyst means what it says, and both patch the list locally from the known new value rather than refetching — a refetch would drop the analyst's scroll position mid-triage. The assign control is hidden from `customer_user` to match the backend scope instead of 403ing on press.

## Tests

`backend/tests/test_bulk_alert_actions.py` — 7 unit tests over the handlers with a mocked session: full-selection update, skipping inaccessible and missing alerts, the deliberate 403/404 conflation, unknown-assignee rejection before anything is touched, one-notification-per-changed-alert, and the severity payload.

All 7 pass. Verified they actually bite: removing the per-alert access check from the status handler fails 2 of them.

`pnpm type-check` and `pnpm lint` are clean; `pre-commit run` passes on every changed file.

## Not verified locally

The Docker stack was unavailable at the end of this work, so the routes were confirmed to register (both `PUT` paths resolve, no collision with the existing `GET /alerts/status/{status}` and `GET /alerts/assigned-to/{assigned_to}`) and exercised through unit tests, but not driven end to end against a live DB and UI. Worth a manual pass on a running stack before merge.
