### PR TITLE
fix: enforce per-object access on alert child routes and bulk case linking

### DIFF
--- a/backend/app/incidents/routes/db_operations.py
+++ b/backend/app/incidents/routes/db_operations.py
@@ -571,7 +571,15 @@ async def delete_alert_title_name_endpoint(alert_title_name: str, source: str, d
     response_model=Alert,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def create_alert_endpoint(alert: AlertCreate, db: AsyncSession = Depends(get_db)):
+async def create_alert_endpoint(
+    alert: AlertCreate,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # `customer_code` is taken from the request body, so it has to be asserted
+    # against the caller's entitlements the way `/case/create` does -- otherwise a
+    # scoped analyst can file an alert against any tenant (#1102).
+    await _ensure_customer_access(alert.customer_code, current_user, db)
     return await create_alert(alert, db)
 
 
@@ -1050,7 +1058,13 @@ async def get_alert_context_by_id_endpoint(alert_context_id: int, db: AsyncSessi
     response_model=AssetResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def create_asset_endpoint(asset: AssetCreate, db: AsyncSession = Depends(get_db)):
+async def create_asset_endpoint(
+    asset: AssetCreate,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # `alert_linked` is this schema's name for the alert id (#1102).
+    await _ensure_alert_access(asset.alert_linked, current_user, db)
     return AssetResponse(asset=await create_asset(asset, db), success=True, message="Asset created successfully")
 
 
@@ -1059,7 +1073,12 @@ async def create_asset_endpoint(asset: AssetCreate, db: AsyncSession = Depends(g
     response_model=AlertIoCResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def create_alert_ioc_endpoint(ioc: AlertIoCCreate, db: AsyncSession = Depends(get_db)):
+async def create_alert_ioc_endpoint(
+    ioc: AlertIoCCreate,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _ensure_alert_access(ioc.alert_id, current_user, db)
     return AlertIoCResponse(alert_ioc=await create_alert_ioc(ioc, db), success=True, message="Alert IoC created successfully")
 
 
@@ -1119,7 +1138,12 @@ async def list_alerts_by_ioc_value_endpoint(
     response_model=AlertIoCResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def delete_alert_ioc_endpoint(ioc: AlertIoCDelete, db: AsyncSession = Depends(get_db)):
+async def delete_alert_ioc_endpoint(
+    ioc: AlertIoCDelete,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _ensure_alert_access(ioc.alert_id, current_user, db)
     return AlertIoCResponse(
         alert_ioc=await delete_alert_ioc(ioc=ioc, db=db),
         success=True,
@@ -1132,7 +1156,12 @@ async def delete_alert_ioc_endpoint(ioc: AlertIoCDelete, db: AsyncSession = Depe
     response_model=AlertTagResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def create_alert_tag_endpoint(alert_tag: AlertTagCreate, db: AsyncSession = Depends(get_db)):
+async def create_alert_tag_endpoint(
+    alert_tag: AlertTagCreate,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _ensure_alert_access(alert_tag.alert_id, current_user, db)
     return AlertTagResponse(alert_tag=await create_alert_tag(alert_tag, db), success=True, message="Alert tag created successfully")
 
 
@@ -1193,7 +1222,16 @@ async def list_alerts_by_tag_endpoint(
     response_model=AlertTagResponse,
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def delete_alert_tag_endpoint(alert_tag: AlertTagDelete, db: AsyncSession = Depends(get_db)):
+async def delete_alert_tag_endpoint(
+    alert_tag: AlertTagDelete,
+    current_user: User = Depends(AuthHandler().get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Tags are not just labels: `user_tag_access` / `role_tag_access` gate which
+    # alerts a user can see when tag ACLs are enabled, so removing the tag that
+    # scopes an alert changes who can see it. That makes an unscoped tag delete an
+    # access-control mutation rather than a cosmetic one (#1102).
+    await _ensure_alert_access(alert_tag.alert_id, current_user, db)
     return AlertTagResponse(
         alert_tag=await delete_alert_tag(alert_tag.alert_id, alert_tag.tag_id, db),
         success=True,
@@ -1297,6 +1335,17 @@ async def create_case_alert_links_endpoint(
     current_user: User = Depends(AuthHandler().get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    # Both ends, as the single-alert `/case/alert-link` route does (#1102): the case
+    # once for the request, then every alert being attached.
+    #
+    # Unlike bulk delete, a denied alert fails the request rather than being skipped.
+    # There is no partial-success shape in this response to report a skip through, and
+    # the caller builds the list from alerts it can already see -- so a denial here means
+    # a bug or a probe, not an ordinary mixed selection.
+    await _ensure_case_access(case_alert_links.case_id, current_user, db)
+    for alert_id in case_alert_links.alert_ids:
+        await _ensure_alert_access(alert_id, current_user, db)
+
     links = await create_case_alert_links_bulk(case_alert_links, db, actor=current_user.username)
 
     from app.incidents.schema.case_templates import CaseEventType

--- a/backend/tests/test_alert_child_access_enforcement.py
+++ b/backend/tests/test_alert_child_access_enforcement.py
@@ -1,0 +1,309 @@
+"""Per-object access on the alert child-object routes and bulk case linking (#1102).
+
+Follow-up to #1099/#1101, which covered bulk delete and single assign. The routes
+below mutate an alert (or attach one to a case) by id and had no access check at
+all -- most of them took no `current_user` to check against.
+
+Two are worth calling out beyond the general tenancy point:
+
+* `DELETE /alert/tag` is not cosmetic. `user_tag_access` / `role_tag_access` gate
+  which alerts a user can see when tag ACLs are on, so removing the tag that
+  scopes an alert changes who can see it.
+* `POST /alert` takes `customer_code` straight from the request body, so without
+  a check a scoped analyst can file an alert against any tenant.
+
+`POST /case/alert-links` fails the request on a denied alert rather than skipping
+it, unlike bulk delete: there is no partial-success shape in its response, and
+the caller builds the list from alerts it can already see.
+
+Unit tests against the route handlers with a mocked session; no real DB.
+
+Run with: cd backend && python -m pytest tests/test_alert_child_access_enforcement.py
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.incidents.routes.db_operations as routes  # noqa: E402
+from app.incidents.models import AlertTag  # noqa: E402
+from app.incidents.models import CaseAlertLink  # noqa: E402
+from app.incidents.schema.db_operations import AlertCreate  # noqa: E402
+from app.incidents.schema.db_operations import AlertIoCCreate  # noqa: E402
+from app.incidents.schema.db_operations import AlertIoCDelete  # noqa: E402
+from app.incidents.schema.db_operations import AlertTagCreate  # noqa: E402
+from app.incidents.schema.db_operations import AlertTagDelete  # noqa: E402
+from app.incidents.schema.db_operations import AssetCreate  # noqa: E402
+from app.incidents.schema.db_operations import CaseAlertLinksCreate  # noqa: E402
+
+ANALYST = SimpleNamespace(id=7, username="analyst", role_id=2)
+
+OWN_ID = 1
+FOREIGN_ID = 2
+OWN_CASE = 10
+FOREIGN_CASE = 20
+OWN_CUSTOMER = "TENANT_A"
+FOREIGN_CUSTOMER = "TENANT_B"
+
+
+def _patch_access(monkeypatch):
+    """The three helpers, each denying the foreign object."""
+
+    async def ensure_alert(alert_id, current_user, db):
+        if alert_id == FOREIGN_ID:
+            raise HTTPException(status_code=403, detail=f"Access denied to alert {alert_id}")
+        return SimpleNamespace(id=alert_id, customer_code=OWN_CUSTOMER)
+
+    async def ensure_case(case_id, current_user, db):
+        if case_id == FOREIGN_CASE:
+            raise HTTPException(status_code=403, detail=f"Access denied to case {case_id}")
+
+    async def ensure_customer(customer_code, current_user, db):
+        if customer_code == FOREIGN_CUSTOMER:
+            raise HTTPException(status_code=403, detail=f"Access denied to customer {customer_code}")
+
+    monkeypatch.setattr(routes, "_ensure_alert_access", ensure_alert)
+    monkeypatch.setattr(routes, "_ensure_case_access", ensure_case)
+    monkeypatch.setattr(routes, "_ensure_customer_access", ensure_customer)
+
+
+def _alert_create(customer_code):
+    return AlertCreate(
+        alert_name="Alert",
+        alert_description="Description",
+        status="OPEN",
+        alert_creation_time=datetime(2026, 8, 26, 12, 0, 0),
+        customer_code=customer_code,
+        source="wazuh",
+        assigned_to="analyst",
+    )
+
+
+def _denied(coro_factory):
+    """Run a handler expected to 403, returning the exception."""
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(coro_factory())
+    return exc.value
+
+
+# ------------------------------------------------------- alert creation and children
+
+
+def test_create_alert_refuses_a_foreign_customer(monkeypatch):
+    """`customer_code` is caller-supplied, so it has to be checked like /case/create."""
+    _patch_access(monkeypatch)
+    created = AsyncMock()
+    monkeypatch.setattr(routes, "create_alert", created)
+
+    error = _denied(
+        lambda: routes.create_alert_endpoint(
+            _alert_create(FOREIGN_CUSTOMER),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_create_alert_still_works_for_an_entitled_customer(monkeypatch):
+    _patch_access(monkeypatch)
+    created = AsyncMock(return_value=SimpleNamespace(id=1))
+    monkeypatch.setattr(routes, "create_alert", created)
+
+    asyncio.run(
+        routes.create_alert_endpoint(
+            _alert_create(OWN_CUSTOMER),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    created.assert_awaited_once()
+
+
+def test_create_asset_refuses_a_foreign_alert(monkeypatch):
+    """This schema calls the alert id `alert_linked`, which is why it was missed."""
+    _patch_access(monkeypatch)
+    created = AsyncMock()
+    monkeypatch.setattr(routes, "create_asset", created)
+
+    error = _denied(
+        lambda: routes.create_asset_endpoint(
+            AssetCreate(
+                alert_linked=FOREIGN_ID,
+                asset_name="host",
+                alert_context_id=1,
+                customer_code=FOREIGN_CUSTOMER,
+                index_name="wazuh-alerts",
+                index_id="abc123",
+            ),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_create_alert_ioc_refuses_a_foreign_alert(monkeypatch):
+    _patch_access(monkeypatch)
+    created = AsyncMock()
+    monkeypatch.setattr(routes, "create_alert_ioc", created)
+
+    error = _denied(
+        lambda: routes.create_alert_ioc_endpoint(
+            AlertIoCCreate(alert_id=FOREIGN_ID, ioc_value="1.2.3.4", ioc_type="IP"),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_delete_alert_ioc_refuses_a_foreign_alert(monkeypatch):
+    _patch_access(monkeypatch)
+    deleted = AsyncMock()
+    monkeypatch.setattr(routes, "delete_alert_ioc", deleted)
+
+    error = _denied(
+        lambda: routes.delete_alert_ioc_endpoint(
+            AlertIoCDelete(alert_id=FOREIGN_ID, ioc_id=5),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    deleted.assert_not_awaited()
+
+
+def test_create_alert_tag_refuses_a_foreign_alert(monkeypatch):
+    _patch_access(monkeypatch)
+    created = AsyncMock()
+    monkeypatch.setattr(routes, "create_alert_tag", created)
+
+    error = _denied(
+        lambda: routes.create_alert_tag_endpoint(
+            AlertTagCreate(alert_id=FOREIGN_ID, tag="malware"),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_delete_alert_tag_refuses_a_foreign_alert(monkeypatch):
+    """The one with teeth: tags gate visibility when tag ACLs are enabled, so an
+    unscoped tag delete is an access-control mutation."""
+    _patch_access(monkeypatch)
+    deleted = AsyncMock()
+    monkeypatch.setattr(routes, "delete_alert_tag", deleted)
+
+    error = _denied(
+        lambda: routes.delete_alert_tag_endpoint(
+            AlertTagDelete(alert_id=FOREIGN_ID, tag_id=3),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    deleted.assert_not_awaited()
+
+
+def test_delete_alert_tag_still_works_on_an_accessible_alert(monkeypatch):
+    """The check must not break ordinary tag management."""
+    _patch_access(monkeypatch)
+    monkeypatch.setattr(routes, "delete_alert_tag", AsyncMock(return_value=AlertTag(id=3, tag="malware")))
+
+    response = asyncio.run(
+        routes.delete_alert_tag_endpoint(
+            AlertTagDelete(alert_id=OWN_ID, tag_id=3),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert response.success is True
+    assert response.alert_tag.tag == "malware"
+
+
+# ------------------------------------------------------------------ bulk case links
+
+
+def _patch_links(monkeypatch, links=None):
+    created = AsyncMock(return_value=links or [])
+    monkeypatch.setattr(routes, "create_case_alert_links_bulk", created)
+
+    import app.incidents.services.case_events as case_events
+
+    monkeypatch.setattr(case_events, "emit_case_event", AsyncMock())
+    return created
+
+
+def test_bulk_case_links_refuses_a_foreign_alert(monkeypatch):
+    """One foreign alert in the list fails the request; nothing is linked.
+
+    Deliberately unlike bulk delete, which skips: this response has no
+    partial-success shape, and the caller builds the list from alerts it can see.
+    """
+    _patch_access(monkeypatch)
+    created = _patch_links(monkeypatch)
+
+    error = _denied(
+        lambda: routes.create_case_alert_links_endpoint(
+            CaseAlertLinksCreate(case_id=OWN_CASE, alert_ids=[OWN_ID, FOREIGN_ID]),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_bulk_case_links_refuses_a_foreign_case(monkeypatch):
+    """Both ends are checked, as the single-alert link route does."""
+    _patch_access(monkeypatch)
+    created = _patch_links(monkeypatch)
+
+    error = _denied(
+        lambda: routes.create_case_alert_links_endpoint(
+            CaseAlertLinksCreate(case_id=FOREIGN_CASE, alert_ids=[OWN_ID]),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert error.status_code == 403
+    created.assert_not_awaited()
+
+
+def test_bulk_case_links_still_works_when_everything_is_accessible(monkeypatch):
+    _patch_access(monkeypatch)
+    created = _patch_links(monkeypatch, links=[CaseAlertLink(case_id=OWN_CASE, alert_id=OWN_ID)])
+
+    response = asyncio.run(
+        routes.create_case_alert_links_endpoint(
+            CaseAlertLinksCreate(case_id=OWN_CASE, alert_ids=[OWN_ID]),
+            current_user=ANALYST,
+            db=AsyncMock(),
+        ),
+    )
+
+    assert response.success is True
+    created.assert_awaited_once()


### PR DESCRIPTION
Fixes #1102.

## Scope is larger than the issue said

#1102 listed two routes. Writing the fix turned up five more, because my original audit had two blind spots: it only searched for routes whose body literally mentioned `alert_id`, so it missed routes that pass the whole request schema straight through (`POST /alert/tag`), and ones where the alert id has a different name (`AssetCreate.alert_linked`).

Re-run without that filter — every non-GET route, then triaged by hand:

| Route | Was | Note |
|---|---|---|
| `POST /alert` | no `current_user` | `customer_code` comes from the request body |
| `POST /alert/asset` | no `current_user` | alert id is spelled `alert_linked` |
| `POST /alert/ioc` | no `current_user` | |
| `DELETE /alert/ioc` | no `current_user` | |
| `POST /alert/tag` | no `current_user` | |
| `DELETE /alert/tag` | no `current_user` | tags gate visibility — see below |
| `POST /case/alert-links` | actor only | bulk sibling of the checked `/case/alert-link` |

Six of the seven took no `current_user` at all, so there was nothing to check against.

## Two worth reading closely

**`DELETE /alert/tag` is not cosmetic.** `user_tag_access` / `role_tag_access` gate which alerts a user can see when `incident_management_tag_access_settings.enabled` is on. Removing the tag that scopes an alert changes **who can see that alert** — so an unscoped tag delete is an access-control mutation, not a labelling one.

**`POST /alert` takes `customer_code` straight from the request body.** Without a check, a scoped analyst can file an alert against any tenant. It now asserts entitlement through `_ensure_customer_access`, the same helper `/case/create` uses for the same reason.

## Contract choice on bulk linking

`POST /case/alert-links` **fails the request** on a denied alert rather than skipping it — deliberately unlike the bulk delete in #1101. That response has no partial-success shape to report a skip through, and the caller builds the list from alerts it can already see, so a denial means a bug or a probe rather than an ordinary mixed selection. It checks both ends, as its single-alert sibling does.

## After this PR

Every non-GET route in `db_operations.py` that touches a tenant-scoped object carries a check. Fourteen remain unchecked and are all deployment-wide configuration with no tenant dimension: the ingest field-mapping dictionaries (`/fields-assets-title-and-timefield`, `/field_name/*`, `/alert_title_name/*`, `/asset_name/*`, `/timefield_name/*`), `/configured/sources/*`, `/case-report-template/*`, `/notification`, `/ai_trigger`, and `POST /alert/context` (which creates a standalone context row carrying no alert id). Whether those should be admin-only rather than admin|analyst is a scope-hardening question, not a tenancy one — happy to raise it separately if you want it looked at.

## Tests

`backend/tests/test_alert_child_access_enforcement.py` — 11 tests: a denial case per route asserting the underlying mutation is never awaited, plus happy paths for tag delete, alert creation and bulk linking so the checks don't break ordinary use.

All 11 pass, and 25 across this plus `test_alert_access_enforcement.py` and `test_bulk_alert_actions.py`. Verified they bite: stripping all seven checks fails 8 of them.

No frontend change needed — the UI only reaches these routes for alerts the user can already see. Confirmed nothing internal calls the handlers directly.

`pre-commit run` passes on both files.
