### PR TITLE
fix: give Velociraptor flows their own, configurable gRPC deadline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,17 @@ SHUFFLE_WORKFLOW_ID=dummy
 
 VELOCIRAPTOR_URL=https://127.1.1.1
 VELOCIRAPTOR_API_KEY_PATH=dummy
+# gRPC deadlines for the backend's Velociraptor calls, in seconds.
+# VELOCIRAPTOR_QUERY_TIMEOUT covers ordinary VQL (listing clients, reading results) --
+# those hit the Velociraptor server's own datastore and should be quick.
+# VELOCIRAPTOR_FLOW_TIMEOUT covers waiting for a collection to finish, which takes as
+# long as the endpoint needs to run the artifact. Raise it if collections on this
+# deployment legitimately run longer than five minutes; a 504 from CoPilot does not
+# stop the flow, which keeps running on the Velociraptor server.
+# NOTE: not the same knob as VELOCIRAPTOR_TIMEOUT further down -- that one is the MCP
+# server's HTTP timeout and has no effect on these calls.
+# VELOCIRAPTOR_QUERY_TIMEOUT=30
+# VELOCIRAPTOR_FLOW_TIMEOUT=300
 
 SUBLIME_URL=http://127.1.1.1
 SUBLIME_API_KEY=dummy
@@ -199,6 +210,9 @@ MCP_WAZUH_SERVER_ENABLED=true
 # External Velociraptor Configuration
 VELOCIRAPTOR_API_KEY=/app/velociraptor-config.yaml # Dont change this
 VELOCIRAPTOR_SSL_VERIFY=false
+# MCP server only. The backend's own deadlines are VELOCIRAPTOR_QUERY_TIMEOUT /
+# VELOCIRAPTOR_FLOW_TIMEOUT above -- raising this one will not make a slow artifact
+# collection succeed.
 VELOCIRAPTOR_TIMEOUT=30
 # Quarantine artifact overrides. Leave unset to use Velociraptor's built-in
 # artifacts. On Velociraptor 0.76.x+ the built-in Linux.Remediation.Quarantine

--- a/backend/app/connectors/velociraptor/utils/universal.py
+++ b/backend/app/connectors/velociraptor/utils/universal.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime
 from typing import Any
 from typing import Dict
@@ -18,6 +19,33 @@ from app.connectors.velociraptor.utils.validation import validate_hostname
 from app.connectors.velociraptor.utils.validation import validate_org_id
 from app.db.db_session import AsyncSessionLocal
 from app.db.db_session import get_db_session
+
+
+def _timeout_seconds(name: str, default: int) -> int:
+    """Read a gRPC deadline from the environment, falling back to `default`."""
+    raw = os.getenv(name, str(default))
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(f"{name}={raw!r} is not an integer; falling back to {default}s")
+        return default
+    if parsed <= 0:
+        logger.warning(f"{name}={parsed} is not a positive number of seconds; falling back to {default}s")
+        return default
+    return parsed
+
+
+# Ordinary VQL — listing clients, resolving a client_id, reading collection results.
+# These talk to the Velociraptor server's own datastore and should answer quickly; a
+# slow one means the server is unwell, and waiting minutes on it just moves the failure.
+QUERY_TIMEOUT_SECONDS = _timeout_seconds("VELOCIRAPTOR_QUERY_TIMEOUT", 30)
+
+# Waiting for a *flow* to finish is a different kind of wait: the deadline has to cover
+# however long the endpoint takes to run the artifact, which for anything touching disk
+# is routinely minutes rather than seconds. Sharing the 30s query deadline meant a
+# perfectly healthy collection failed with DEADLINE_EXCEEDED while it was still running
+# (the flow completed server-side; only CoPilot gave up), which is what this splits.
+FLOW_TIMEOUT_SECONDS = _timeout_seconds("VELOCIRAPTOR_FLOW_TIMEOUT", 300)
 
 
 async def verify_velociraptor_credentials(attributes: Dict[str, Any]) -> Dict[str, Any]:
@@ -173,23 +201,28 @@ class UniversalService:
             ],
         )
 
-    def execute_query(self, vql: str, org_id: str = "root"):
+    def execute_query(self, vql: str, org_id: str = "root", timeout: int = None):
         """
         Executes a VQL query and returns the results.
 
         Args:
             vql (str): The VQL query to be executed.
+            org_id (str): The Velociraptor org to run against.
+            timeout (int, optional): gRPC deadline in seconds. Defaults to
+                `QUERY_TIMEOUT_SECONDS`; callers that wait on a flow pass
+                `FLOW_TIMEOUT_SECONDS` instead.
 
         Returns:
             dict: A dictionary with the success status, a message, and potentially the results.
         """
-        logger.info(f"Executing query: {vql}")
+        timeout = timeout or QUERY_TIMEOUT_SECONDS
+        logger.info(f"Executing query: {vql} (timeout {timeout}s)")
 
         client_request = self.create_vql_request(vql, org_id)
 
         try:
             results = []
-            for response in self.stub.Query(client_request, timeout=30):
+            for response in self.stub.Query(client_request, timeout=timeout):
                 if response.Response:
                     results += json.loads(response.Response)
                 elif response.log:
@@ -202,10 +235,18 @@ class UniversalService:
             }
         except grpc.RpcError as e:  # Catch gRPC-specific errors
             if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-                logger.error("Failed to execute query due to timeout.")
+                # Name the deadline that was hit and the knob that raises it: the flow
+                # itself usually finished on the server, and the operator's next question
+                # is always "how do I give it longer?".
+                env_var = "VELOCIRAPTOR_FLOW_TIMEOUT" if timeout == FLOW_TIMEOUT_SECONDS else "VELOCIRAPTOR_QUERY_TIMEOUT"
+                logger.error(f"Failed to execute query: deadline of {timeout}s exceeded.")
                 raise HTTPException(
-                    status_code=500,
-                    detail="Failed to execute query due to timeout. Make sure the Velocraptor server has stopped this artifact collection.",
+                    status_code=504,
+                    detail=(
+                        f"Velociraptor did not respond within {timeout}s. The collection may still be "
+                        f"running on the server -- check the flow there before re-running it. "
+                        f"Raise {env_var} (seconds) if collections on this deployment legitimately take longer."
+                    ),
                 )
             else:
                 logger.error(f"Failed to execute query: {e}")
@@ -232,20 +273,24 @@ class UniversalService:
             logger.error(f"Failed to execute query: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to execute query: {e}")
 
-    def watch_flow_completion(self, flow_id: str, org_id: str = "root"):
+    def watch_flow_completion(self, flow_id: str, org_id: str = "root", timeout: int = None):
         """
         Watch for the completion of a flow.
 
         Args:
             flow_id (str): The ID of the flow.
+            org_id (str): The Velociraptor org the flow belongs to.
+            timeout (int, optional): gRPC deadline in seconds. Defaults to
+                `FLOW_TIMEOUT_SECONDS` -- this call blocks for as long as the endpoint
+                takes to run the artifact, not for as long as the server takes to answer.
 
         Returns:
             dict: A dictionary with the success status and a message.
         """
         validate_flow_id(flow_id)
         vql = f"SELECT * FROM watch_monitoring(artifact='System.Flow.Completion') WHERE FlowId='{flow_id}' LIMIT 1"
-        logger.info(f"Watching flow {flow_id} for completion")
-        return self.execute_query(vql, org_id)
+        logger.info(f"Watching flow {flow_id} for completion (timeout {timeout or FLOW_TIMEOUT_SECONDS}s)")
+        return self.execute_query(vql, org_id, timeout=timeout or FLOW_TIMEOUT_SECONDS)
 
     def read_collection_results(
         self,

--- a/backend/tests/test_velociraptor_timeouts.py
+++ b/backend/tests/test_velociraptor_timeouts.py
@@ -1,0 +1,176 @@
+"""Velociraptor gRPC deadlines are configurable, and flows get their own.
+
+A flow that ran longer than 30 seconds failed with DEADLINE_EXCEEDED even though
+the collection was healthy and still running on the Velociraptor server -- the
+gRPC deadline was hardcoded at 30s and shared between ordinary VQL and waiting
+for a flow to finish. Those are different kinds of wait: a query hits the
+server's datastore and should be quick, while a flow takes as long as the
+endpoint needs to run the artifact.
+
+Run with: cd backend && python -m pytest tests/test_velociraptor_timeouts.py
+"""
+
+import importlib
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+import app.connectors.velociraptor.utils.universal as universal  # noqa: E402
+
+
+def _reload(monkeypatch, **env):
+    """Re-import the module with `env` applied, since the deadlines are read at import."""
+    for key in ("VELOCIRAPTOR_QUERY_TIMEOUT", "VELOCIRAPTOR_FLOW_TIMEOUT"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return importlib.reload(universal)
+
+
+def test_defaults_preserve_the_old_query_deadline(monkeypatch):
+    """30s stays the default for ordinary VQL -- this change must not make a
+    healthy deployment wait longer on queries that were already fine."""
+    module = _reload(monkeypatch)
+
+    assert module.QUERY_TIMEOUT_SECONDS == 30
+
+
+def test_flow_deadline_defaults_well_above_the_query_one(monkeypatch):
+    module = _reload(monkeypatch)
+
+    assert module.FLOW_TIMEOUT_SECONDS == 300
+    assert module.FLOW_TIMEOUT_SECONDS > module.QUERY_TIMEOUT_SECONDS
+
+
+def test_both_deadlines_are_configurable(monkeypatch):
+    module = _reload(
+        monkeypatch,
+        VELOCIRAPTOR_QUERY_TIMEOUT="45",
+        VELOCIRAPTOR_FLOW_TIMEOUT="1800",
+    )
+
+    assert module.QUERY_TIMEOUT_SECONDS == 45
+    assert module.FLOW_TIMEOUT_SECONDS == 1800
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "0", "-5", "30s"])
+def test_a_bad_value_falls_back_rather_than_crashing_the_import(monkeypatch, bad):
+    """These are read at import time, so a typo in .env must not stop the app
+    booting -- and must not turn into a zero/negative deadline, which gRPC would
+    treat as "already expired"."""
+    module = _reload(monkeypatch, VELOCIRAPTOR_FLOW_TIMEOUT=bad)
+
+    assert module.FLOW_TIMEOUT_SECONDS == 300
+
+
+def test_timeout_error_names_the_knob_that_raises_it(monkeypatch):
+    """The operator's next question is always "how do I give it longer?"."""
+    import grpc
+
+    module = _reload(monkeypatch)
+
+    class _DeadlineExceeded(grpc.RpcError):
+        def code(self):
+            return grpc.StatusCode.DEADLINE_EXCEEDED
+
+        def details(self):
+            return "Deadline Exceeded"
+
+    class _Stub:
+        def Query(self, request, timeout=None):
+            raise _DeadlineExceeded()
+
+    service = module.UniversalService.__new__(module.UniversalService)
+    service.stub = _Stub()
+
+    with pytest.raises(HTTPException) as exc:
+        service.watch_flow_completion("F.CQMNTHE1CSPKC", org_id="root")
+
+    assert exc.value.status_code == 504
+    detail = exc.value.detail
+    assert "VELOCIRAPTOR_FLOW_TIMEOUT" in detail
+    assert "300s" in detail
+    # The flow keeps running server-side; saying so stops an operator re-running it.
+    assert "still be running" in detail
+
+
+def test_a_plain_query_timeout_points_at_the_query_knob(monkeypatch):
+    import grpc
+
+    module = _reload(monkeypatch)
+
+    class _DeadlineExceeded(grpc.RpcError):
+        def code(self):
+            return grpc.StatusCode.DEADLINE_EXCEEDED
+
+        def details(self):
+            return "Deadline Exceeded"
+
+    class _Stub:
+        def Query(self, request, timeout=None):
+            raise _DeadlineExceeded()
+
+    service = module.UniversalService.__new__(module.UniversalService)
+    service.stub = _Stub()
+
+    with pytest.raises(HTTPException) as exc:
+        service.execute_query("SELECT * FROM clients()")
+
+    assert "VELOCIRAPTOR_QUERY_TIMEOUT" in exc.value.detail
+
+
+def test_flow_watch_uses_the_flow_deadline_not_the_query_one(monkeypatch):
+    """The regression that started this: watch_flow_completion inherited the 30s
+    query deadline, so a two-minute collection failed while still running."""
+    module = _reload(monkeypatch)
+    seen = {}
+
+    class _Stub:
+        def Query(self, request, timeout=None):
+            seen["timeout"] = timeout
+            return iter(())
+
+    service = module.UniversalService.__new__(module.UniversalService)
+    service.stub = _Stub()
+
+    service.watch_flow_completion("F.CQMNTHE1CSPKC", org_id="root")
+
+    assert seen["timeout"] == module.FLOW_TIMEOUT_SECONDS
+
+
+def test_an_ordinary_query_still_uses_the_short_deadline(monkeypatch):
+    module = _reload(monkeypatch)
+    seen = {}
+
+    class _Stub:
+        def Query(self, request, timeout=None):
+            seen["timeout"] = timeout
+            return iter(())
+
+    service = module.UniversalService.__new__(module.UniversalService)
+    service.stub = _Stub()
+
+    service.execute_query("SELECT * FROM clients()")
+
+    assert seen["timeout"] == module.QUERY_TIMEOUT_SECONDS
+
+
+def test_an_explicit_timeout_overrides_the_default(monkeypatch):
+    """Keeps a per-call override available for a caller that knows better."""
+    module = _reload(monkeypatch)
+    seen = {}
+
+    class _Stub:
+        def Query(self, request, timeout=None):
+            seen["timeout"] = timeout
+            return iter(())
+
+    service = module.UniversalService.__new__(module.UniversalService)
+    service.stub = _Stub()
+
+    service.execute_query("SELECT * FROM clients()", timeout=7)
+
+    assert seen["timeout"] == 7


### PR DESCRIPTION
## The problem

A Velociraptor collection that takes longer than 30 seconds fails, even when it is perfectly healthy and still running on the server.

`execute_query` in `app/connectors/velociraptor/utils/universal.py` hardcoded `timeout=30` on the gRPC stream, and **every** caller shared it — including `watch_flow_completion`, which by definition blocks until the endpoint finishes running the artifact.

Those are different kinds of wait:

- **Ordinary VQL** (listing clients, resolving a `client_id`, reading collection results) hits the Velociraptor server's own datastore and should answer in well under a second. A slow one means the server is unwell, and waiting minutes on it just moves the failure somewhere less obvious.
- **Waiting for a flow** takes as long as the endpoint needs. Anything touching disk — a file collection, a hash sweep — is routinely minutes.

Five call sites wait on a flow: collect artifact (×2), run command, and quarantine.

## The change

Two deadlines instead of one, both read from the environment at import:

| Variable | Default | Covers |
|---|---|---|
| `VELOCIRAPTOR_QUERY_TIMEOUT` | 30 | ordinary VQL — **unchanged from today** |
| `VELOCIRAPTOR_FLOW_TIMEOUT` | 300 | waiting for a collection to finish |

`execute_query` takes an optional per-call `timeout` so a caller that knows better can override; `watch_flow_completion` passes the flow deadline.

A bad value (`""`, `abc`, `0`, `-5`) logs and falls back rather than crashing the boot — these are read at import, and a zero or negative deadline is one gRPC treats as already expired.

**The error is now a 504 rather than a 500**, names the deadline that was hit and the variable that raises it, and says the flow is probably still running server-side. The old message told operators to "make sure the Velociraptor server has stopped this artifact collection," which is the opposite of what has usually happened.

## Naming trap worth knowing about

`VELOCIRAPTOR_TIMEOUT` **already exists** in `.env.example` and `docker-compose.yml` — and it belongs to the **copilot-mcp** service, not the backend. Nothing in `backend/` reads it.

It is exactly the variable an operator hitting this bug would reach for, and raising it would do nothing. Hence the deliberately distinct names, and a cross-reference in both directions in `.env.example` so neither can be mistaken for the other.

## Tests

`backend/tests/test_velociraptor_timeouts.py` — 13 tests: defaults (30 query / 300 flow), both configurable, five bad-value fallbacks, flow watch using the flow deadline, ordinary queries using the short one, per-call override, and the 504 naming the right variable for each path.

All pass. Verified they bite: pointing `watch_flow_completion` back at the query default fails 2 of them.

## Two things to be aware of when deploying

**The reverse proxy is now the binding constraint.** The analyst frontend's own `nginx.conf` doesn't proxy `/api` at all, so on a real deployment that traffic goes through whatever sits in front — and nginx's default `proxy_read_timeout` is 60s. Raising `VELOCIRAPTOR_FLOW_TIMEOUT` past that gets you a 504 from the proxy instead of from CoPilot unless the proxy is raised too. (For reference, `customer-portal/nginx.conf` already sets 300.)

**A long collection now occupies a worker for up to five minutes.** That is the honest cost of a synchronous wait, and it is inherent to the current design rather than introduced here. The structural fix is to return the `flow_id` immediately and let the client poll — a real change to the collect endpoints and the UI, worth doing separately if this becomes a throughput problem.

Not verified against a live Velociraptor server — the tests drive a stubbed gRPC stub. Worth confirming on the demo stack with a collection known to take more than 30s.
