### PR TITLE
feat(talon): make Clear chat actually start a new conversation

### DIFF
--- a/backend/app/connectors/talon/routes/talon.py
+++ b/backend/app/connectors/talon/routes/talon.py
@@ -5,17 +5,22 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
+from app.auth.models.users import User
 from app.auth.utils import AuthHandler
 from app.connectors.talon.schema.talon import TalonInvestigateRequest
 from app.connectors.talon.schema.talon import TalonInvestigateResponse
 from app.connectors.talon.schema.talon import TalonJobResponse
 from app.connectors.talon.schema.talon import TalonMessageRequest
+from app.connectors.talon.schema.talon import TalonSessionContextResponse
+from app.connectors.talon.schema.talon import TalonSessionResetResponse
 from app.connectors.talon.schema.talon import TalonStatusResponse
 from app.connectors.talon.schema.talon import TalonTemplatesResponse
 from app.connectors.talon.services.talon import get_talon_job
+from app.connectors.talon.services.talon import get_talon_session_context
 from app.connectors.talon.services.talon import get_talon_status
 from app.connectors.talon.services.talon import investigate_alert
 from app.connectors.talon.services.talon import list_talon_templates
+from app.connectors.talon.services.talon import reset_talon_session
 from app.connectors.talon.services.talon import stream_talon_message
 from app.db.db_session import get_db
 
@@ -28,11 +33,20 @@ talon_router = APIRouter()
     description="Send a message to Talon and stream the SSE response",
     dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
 )
-async def send_message(request: TalonMessageRequest) -> StreamingResponse:
-    """Send a message to Talon and stream the response as SSE."""
-    logger.info(f"Sending message to Talon: {request.message}")
+async def send_message(
+    request: TalonMessageRequest,
+    current_user: User = Depends(AuthHandler().get_current_user),
+) -> StreamingResponse:
+    """
+    Send a message to Talon and stream the response as SSE.
+
+    The authenticated user selects the Talon conversation lane, so concurrent
+    analysts get separate conversations rather than being batched into one
+    prompt. It is read from the JWT, never from the request body.
+    """
+    logger.info(f"User {current_user.id} sending message to Talon")
     return StreamingResponse(
-        stream_talon_message(request),
+        stream_talon_message(request, user_id=current_user.id, user_name=current_user.username),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -52,6 +66,38 @@ async def trigger_investigation(request: TalonInvestigateRequest) -> TalonInvest
     """Trigger an investigation for a specific alert."""
     logger.info(f"Triggering investigation for alert ID: {request.alert_id}")
     return await investigate_alert(request)
+
+
+@talon_router.post(
+    "/session/reset",
+    response_model=TalonSessionResetResponse,
+    description="Clear the calling user's Talon conversation session",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def reset_session(
+    current_user: User = Depends(AuthHandler().get_current_user),
+) -> TalonSessionResetResponse:
+    """
+    Start a fresh Talon conversation for the calling analyst.
+
+    Scoped to this user's lane — clearing your own chat must not discard a
+    colleague's conversation.
+    """
+    logger.info(f"User {current_user.id} resetting their Talon session")
+    return await reset_talon_session(user_id=current_user.id)
+
+
+@talon_router.get(
+    "/session/context",
+    response_model=TalonSessionContextResponse,
+    description="Size of the calling user's Talon conversation, for the chat header readout",
+    dependencies=[Security(AuthHandler().require_any_scope("admin", "analyst"))],
+)
+async def get_session_context(
+    current_user: User = Depends(AuthHandler().get_current_user),
+) -> TalonSessionContextResponse:
+    """Report only the caller's own lane — never another analyst's."""
+    return await get_talon_session_context(user_id=current_user.id)
 
 
 @talon_router.get(

--- a/backend/app/connectors/talon/schema/talon.py
+++ b/backend/app/connectors/talon/schema/talon.py
@@ -10,6 +10,10 @@ from pydantic import Field
 class TalonMessageRequest(BaseModel):
     message: str = Field(..., description="The message to send to Talon")
     sender: str = Field(default="copilot", description="The sender identifier")
+    # NOTE: the Talon conversation lane (user_id / user_name) is deliberately
+    # NOT part of this schema. It is stamped server-side from the JWT, because
+    # a caller able to name its own user_id could read or reset a colleague's
+    # conversation.
 
 
 class TalonMessageResponse(BaseModel):
@@ -47,6 +51,19 @@ class TalonTemplate(BaseModel):
     size_bytes: int = Field(..., description="File size in bytes")
     modified_at: str = Field(..., description="Last modification ISO timestamp")
     first_line: Optional[str] = Field(None, description="First non-empty line (preview, ≤200 chars)")
+
+
+class TalonSessionResetResponse(BaseModel):
+    success: bool
+    message: str
+    lanes_cleared: int = Field(default=0, description="Number of Talon conversation lanes cleared")
+
+
+class TalonSessionContextResponse(BaseModel):
+    success: bool
+    message: str
+    input_tokens: Optional[int] = Field(default=None, description="Size of the caller's Talon conversation, in tokens")
+    updated_at: Optional[str] = Field(default=None, description="When that figure was last recorded")
 
 
 class TalonTemplatesResponse(BaseModel):

--- a/backend/app/connectors/talon/services/talon.py
+++ b/backend/app/connectors/talon/services/talon.py
@@ -13,6 +13,8 @@ from app.connectors.talon.schema.talon import TalonInvestigateResponse
 from app.connectors.talon.schema.talon import TalonJobResponse
 from app.connectors.talon.schema.talon import TalonMessageRequest
 from app.connectors.talon.schema.talon import TalonMessageResponse
+from app.connectors.talon.schema.talon import TalonSessionContextResponse
+from app.connectors.talon.schema.talon import TalonSessionResetResponse
 from app.connectors.talon.schema.talon import TalonStatusResponse
 from app.connectors.talon.schema.talon import TalonTemplatesResponse
 from app.connectors.talon.utils.universal import send_get_request
@@ -21,7 +23,33 @@ from app.connectors.talon.utils.universal import send_post_request_sse
 from app.db.universal_models import AiAnalystJob
 
 
-async def send_talon_message(request: TalonMessageRequest) -> TalonMessageResponse:
+def _message_payload(
+    request: TalonMessageRequest,
+    user_id: Optional[int] = None,
+    user_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build the Talon /message body.
+
+    user_id selects the caller's conversation lane in Talon: their own session,
+    queue slot and response stream. Omitting it drops the caller into the
+    shared anonymous lane, where concurrent analysts are batched into one
+    prompt and can receive each other's replies — so it is always stamped from
+    the authenticated user rather than taken from the request body.
+    """
+    payload: Dict[str, Any] = {"message": request.message, "sender": request.sender}
+    if user_id is not None:
+        payload["user_id"] = str(user_id)
+    if user_name:
+        payload["user_name"] = user_name
+    return payload
+
+
+async def send_talon_message(
+    request: TalonMessageRequest,
+    user_id: Optional[int] = None,
+    user_name: Optional[str] = None,
+) -> TalonMessageResponse:
     """
     Send a message to Talon for ad-hoc analyst prompts.
 
@@ -34,7 +62,7 @@ async def send_talon_message(request: TalonMessageRequest) -> TalonMessageRespon
     logger.info(f"Sending message to Talon: {request.message}")
     response = await send_post_request(
         endpoint="/message",
-        data=request.model_dump(),
+        data=_message_payload(request, user_id, user_name),
         timeout=600,
     )
     if not response.get("success"):
@@ -49,7 +77,11 @@ async def send_talon_message(request: TalonMessageRequest) -> TalonMessageRespon
     )
 
 
-async def stream_talon_message(request: TalonMessageRequest):
+async def stream_talon_message(
+    request: TalonMessageRequest,
+    user_id: Optional[int] = None,
+    user_name: Optional[str] = None,
+):
     """
     Stream a message response from Talon via SSE.
 
@@ -62,9 +94,69 @@ async def stream_talon_message(request: TalonMessageRequest):
     logger.info(f"Streaming message to Talon: {request.message}")
     async for chunk in send_post_request_sse(
         endpoint="/message",
-        data=request.model_dump(),
+        data=_message_payload(request, user_id, user_name),
     ):
         yield chunk
+
+
+async def reset_talon_session(user_id: int) -> TalonSessionResetResponse:
+    """
+    Clear the calling analyst's Talon conversation.
+
+    Talon holds the conversation, not CoPilot: the chat UI sends only the
+    current message and the agent resumes its own stored session. Clearing the
+    browser therefore leaves the agent remembering every prior turn, which is
+    both the surprise ("I cleared the chat and it still knows") and the cost —
+    a resumed session grows without bound and eventually takes minutes to
+    answer.
+
+    Scoped to this user's lane. An analyst starting a fresh conversation must
+    not discard a colleague's.
+    """
+    logger.info(f"Resetting Talon session for user {user_id}")
+    response = await send_post_request(
+        endpoint="/session/reset",
+        data={"scope": "chat", "user_id": str(user_id)},
+    )
+    if not response.get("success"):
+        raise HTTPException(
+            status_code=500,
+            detail=response.get("message", "Failed to reset Talon session"),
+        )
+    data = response.get("data") or {}
+    return TalonSessionResetResponse(
+        success=True,
+        message="Talon session cleared",
+        lanes_cleared=data.get("cleared", 0),
+    )
+
+
+async def get_talon_session_context(user_id: int) -> TalonSessionContextResponse:
+    """
+    Size of the calling analyst's Talon conversation.
+
+    Resolved server-side so the caller only ever learns about its own lane —
+    Talon's /status lists every lane, and with per-user conversations those
+    figures are another analyst's activity, not this one's.
+
+    Advisory: a Talon that is down or has no record of the lane yields a null
+    rather than an error, because this only decorates the chat header.
+    """
+    response = await send_get_request(endpoint="/status")
+    if not response.get("success"):
+        return TalonSessionContextResponse(success=True, message="Talon session context unavailable")
+
+    sessions = (response.get("data") or {}).get("sessions") or []
+    lane = next((s for s in sessions if str(s.get("user_id") or "") == str(user_id)), None)
+    if lane is None:
+        return TalonSessionContextResponse(success=True, message="No active Talon conversation")
+
+    return TalonSessionContextResponse(
+        success=True,
+        message="Talon session context retrieved",
+        input_tokens=lane.get("input_tokens"),
+        updated_at=lane.get("updated_at"),
+    )
 
 
 async def investigate_alert(request: TalonInvestigateRequest) -> TalonInvestigateResponse:

--- a/frontend/src/api/endpoints/talon.ts
+++ b/frontend/src/api/endpoints/talon.ts
@@ -10,6 +10,28 @@ export default {
 	getStatus(signal?: AbortSignal) {
 		return HttpClient.get<FlaskBaseResponse & { data?: Record<string, unknown> }>(`/talon/status`, { signal })
 	},
+	/**
+	 * Start a fresh Talon conversation for the signed-in user.
+	 *
+	 * Talon holds the conversation, not CoPilot — the chat sends only the current
+	 * message and the agent resumes its own stored session. Emptying the local
+	 * message list alone leaves the agent remembering every prior turn.
+	 *
+	 * Scoped server-side to the caller's own lane; the user is read from the JWT.
+	 */
+	resetSession() {
+		return HttpClient.post<FlaskBaseResponse & { lanes_cleared?: number }>(`/talon/session/reset`)
+	},
+	/**
+	 * Size of the signed-in user's Talon conversation. Resolved server-side, so
+	 * this never reports another analyst's activity.
+	 */
+	getSessionContext(signal?: AbortSignal) {
+		return HttpClient.get<FlaskBaseResponse & { input_tokens?: number | null, updated_at?: string | null }>(
+			`/talon/session/context`,
+			{ signal }
+		)
+	},
 	getJob(alertId: number, signal?: AbortSignal) {
 		return HttpClient.get<FlaskBaseResponse & { data?: TalonJobData }>(`/talon/jobs/${alertId}`, { signal })
 	},

--- a/frontend/src/components/talonChat/TalonChatContainer.vue
+++ b/frontend/src/components/talonChat/TalonChatContainer.vue
@@ -25,6 +25,8 @@
 		<TalonChatQuery
 			v-model:input="input"
 			:loading="streaming"
+			:resetting
+			:context-tokens
 			@message="sendMessage"
 			@stop="stopStream()"
 			@clear-chat="clearChat()"
@@ -38,7 +40,7 @@ import type { Message } from "./TalonChatQuery.vue"
 import { useStorage } from "@vueuse/core"
 import { NScrollbar, useMessage } from "naive-ui"
 import { nanoid } from "nanoid"
-import { nextTick, onBeforeUnmount, ref } from "vue"
+import { nextTick, onBeforeUnmount, onMounted, ref } from "vue"
 import Api from "@/api"
 import Icon from "@/components/common/Icon.vue"
 import Markdown from "@/components/common/Markdown.vue"
@@ -61,6 +63,11 @@ const input = ref("")
 const streaming = ref(false)
 const streamBuffer = ref("")
 const scrollbar = ref<ScrollbarInst | null>(null)
+const resetting = ref(false)
+// Size of the conversation Talon is carrying. Surfaced because a resumed
+// session grows without bound: past a few hundred thousand tokens replies
+// slow to minutes, and there is otherwise nothing to tell the analyst why.
+const contextTokens = ref<number | null>(null)
 
 let abortController: AbortController | null = null
 
@@ -69,9 +76,34 @@ function useExample(example: string) {
 	sendMessage({ input: example })
 }
 
-function clearChat() {
-	messages.value = []
+async function clearChat() {
+	if (resetting.value) return
+
+	resetting.value = true
+	try {
+		// Reset Talon first. Emptying the local list on a failed reset would
+		// report success while the agent still holds every prior turn.
+		await Api.talon.resetSession()
+		messages.value = []
+		contextTokens.value = null
+	} catch {
+		message.error("Couldn't start a new session. Talon still has the previous conversation.")
+	} finally {
+		resetting.value = false
+	}
 }
+
+async function loadContextSize() {
+	try {
+		const res = await Api.talon.getSessionContext()
+		contextTokens.value = res.data?.input_tokens ?? null
+	} catch {
+		// Advisory only — a status hiccup must not disturb the chat.
+		contextTokens.value = null
+	}
+}
+
+onMounted(loadContextSize)
 
 function scrollChat() {
 	nextTick(() => {
@@ -116,6 +148,7 @@ async function sendMessage(payload: Message) {
 				streaming.value = false
 				streamBuffer.value = ""
 				scrollChat()
+				loadContextSize()
 			},
 			(err: string) => {
 				if (err !== "AbortError") {
@@ -151,9 +184,9 @@ function stopStream() {
 }
 
 defineExpose({
-	clearHistory() {
-		messages.value = []
-	}
+	// Same contract as the in-chat control: a caller asking to clear the history
+	// means "start a new conversation", not "hide the transcript".
+	clearHistory: clearChat
 })
 
 // Cancel anything still in flight when this component goes away: without it the

--- a/frontend/src/components/talonChat/TalonChatQuery.vue
+++ b/frontend/src/components/talonChat/TalonChatQuery.vue
@@ -20,12 +20,28 @@
 		/>
 		<div class="absolute right-0 bottom-0 left-0 flex items-center justify-between p-2 pr-3">
 			<div class="flex items-center gap-2.5">
-				<n-button size="tiny" secondary @click="clearChat()">
+				<n-button size="tiny" secondary :loading="resetting" :disabled="resetting" @click="clearChat()">
 					<template #icon>
 						<Icon name="mdi:broom" />
 					</template>
-					Clear chat
+					New session
 				</n-button>
+				<n-tooltip v-if="contextLabel" trigger="hover">
+					<template #trigger>
+						<span
+							class="text-tertiary cursor-default font-mono text-xs"
+							:class="{ 'text-warning': contextHeavy }"
+						>
+							{{ contextLabel }}
+						</span>
+					</template>
+					Talon is carrying {{ contextTokens?.toLocaleString() }} tokens of conversation.
+					{{
+						contextHeavy
+							? "Replies get slower and more expensive as this grows — start a new session to reset it."
+							: "Starting a new session resets it."
+					}}
+				</n-tooltip>
 			</div>
 			<n-button
 				circle
@@ -43,7 +59,7 @@
 
 <script setup lang="ts">
 import _trim from "lodash/trim"
-import { NButton, NInput } from "naive-ui"
+import { NButton, NInput, NTooltip } from "naive-ui"
 import { computed, toRefs } from "vue"
 import Icon from "@/components/common/Icon.vue"
 
@@ -51,7 +67,13 @@ export interface Message {
 	input: string
 }
 
-const props = defineProps<{ loading?: boolean; editMessageBody?: string | null }>()
+const props = defineProps<{
+	loading?: boolean
+	editMessageBody?: string | null
+	resetting?: boolean
+	/** Size of the conversation Talon is carrying, in tokens. */
+	contextTokens?: number | null
+}>()
 
 const emit = defineEmits<{
 	(e: "message", value: Message): void
@@ -60,7 +82,17 @@ const emit = defineEmits<{
 	(e: "clear-chat"): void
 }>()
 
-const { loading, editMessageBody } = toRefs(props)
+const { loading, editMessageBody, resetting, contextTokens } = toRefs(props)
+
+// Past roughly this size, replies noticeably slow down. Advisory, not a limit.
+const HEAVY_CONTEXT_TOKENS = 300_000
+
+const contextHeavy = computed(() => (contextTokens.value ?? 0) >= HEAVY_CONTEXT_TOKENS)
+const contextLabel = computed(() => {
+	const tokens = contextTokens.value
+	if (!tokens) return null
+	return `context ${tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : tokens}`
+})
 const input = defineModel<string | null>("input", { default: null })
 const isFormValid = computed(() => !!_trim(input.value || ""))
 


### PR DESCRIPTION
Spec B from the gameplan on #1111 — the CoPilot half. Completes the work started in taylorwalton/talon#12 (session lanes) and #13 (per-user lanes).

## The problem

Talon holds the conversation, not CoPilot. The chat sends only the current message; the agent resumes its own stored session. So this:

```ts
function clearChat() {
    messages.value = []
}
```

cleared the *display* and nothing else. The transcript vanished, the analyst believed they had started fresh, and Talon still had every prior turn. That is both the reported surprise ("I cleared the chat and it still knows") and the reported cost — a resumed session grows without bound until replies take minutes and often never render.

Separately, the outbound payload identified every caller as `sender: "copilot"`, so Talon could not tell two analysts apart. Until this lands, per-user lanes exist in Talon but nothing exercises them: every analyst shares the anonymous lane, where concurrent callers are batched into one prompt and can receive each other's replies.

## Changes

**`POST /talon/session/reset`** — clears the caller's Talon conversation. Admin/analyst scoped, standard `routes / services / schema` split. No `copilot.py` edit needed; `talon_router` is already mounted.

**`POST /talon/message` stamps the authenticated user**, which selects that analyst's lane in Talon.

The user id comes from the JWT in both cases, never from the request body — a caller able to name its own `user_id` could read or reset a colleague's conversation. The lane fields are deliberately **absent from `TalonMessageRequest`**, so a client cannot supply them even by accident; the service builds the outbound payload explicitly.

**`GET /talon/session/context`** — the size of the caller's own conversation, for the header readout. Resolved server-side rather than filtering Talon's `/status` in the browser: `/status` lists *every* lane, and with per-user conversations those figures are other analysts' activity. Advisory by design — a Talon that is down or has no record of the lane yields `null`, not an error, because this only decorates the chat.

**The chat resets Talon first**, and empties the local list only once that succeeds. A failed reset says so instead of reporting success while the agent still remembers:

> Couldn't start a new session. Talon still has the previous conversation.

The control is renamed **New session**, which is what it now does — "Clear chat" describes wiping a display. `defineExpose({ clearHistory })` follows the same contract rather than staying a display-only wipe.

**The composer shows the conversation size** next to the button, refreshed after each completed turn and highlighted past 300k tokens, with a tooltip explaining why it matters. The failure mode this whole issue describes was invisible until it was severe; this gives an analyst a reason to reset before replies start crawling.

## Verification

- `pre-commit run --files …` — black, isort, flake8, trailing commas, all passed.
- `vue-tsc --noEmit` — clean, project-wide.
- `eslint` — clean on all three touched frontend files.

## Dependency

Needs taylorwalton/talon#12 and #13 deployed. Against an older Talon the reset returns a 500 and the UI reports the failure honestly rather than silently pretending — which is the correct degradation, but the two should ship together.

## Not in this PR

The Talon-side follow-up noted in #13: a swept idle lane leaves its `.claude/` directory on disk.

Refs #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fFbajcAEwjtuZWAVT3Xg9
