### PR TITLE
fix(eventSearch): discover fields across every index in the source pattern

### DIFF
--- a/backend/app/siem/services/events.py
+++ b/backend/app/siem/services/events.py
@@ -220,34 +220,33 @@ async def get_field_mappings(
     source_name: str,
     db: AsyncSession,
 ) -> FieldMappingsResponse:
-    """Retrieve index field name mappings for a customer's event source."""
+    """Retrieve the field names available across a customer's event source.
+
+    Uses `_field_caps` rather than `_mapping` because an event source pattern routinely
+    spans many indices whose mappings diverge: a quiet period or a dynamically-mapped
+    field means one index can be missing fields another has, so reading a single index's
+    mapping under-reports the source (#1114). `_field_caps` answers exactly this question
+    -- the union of fields over every matching index -- in one response instead of a full
+    mapping per index, and it echoes each field path as the mapping declares it, so no
+    path is re-derived here and already-configured columns keep resolving.
+    """
     event_source = await get_event_source_by_customer_and_name(customer_code, source_name, db)
     es_client = await create_wazuh_indexer_client_async("Wazuh-Indexer")
     try:
-        mapping_response = await es_client.indices.get_mapping(index=event_source.index_pattern)
-
-        # Flatten nested mappings into dot-notation field list
-        fields = []
-        for index_name in mapping_response:
-            properties = mapping_response[index_name].get("mappings", {}).get("properties", {})
-            _flatten_properties(properties, "", fields)
-            break  # All indices matching pattern share the same mapping
-
-        # Deduplicate and sort
-        seen = set()
-        unique_fields = []
-        for f in fields:
-            if f.field not in seen:
-                seen.add(f.field)
-                unique_fields.append(f)
-        unique_fields.sort(key=lambda x: x.field)
+        response = await es_client.field_caps(
+            index=event_source.index_pattern,
+            fields="*",
+            ignore_unavailable=True,
+            allow_no_indices=True,
+        )
+        fields = _fields_from_field_caps(response.get("fields", {}))
 
         return FieldMappingsResponse(
-            fields=unique_fields,
-            total=len(unique_fields),
+            fields=fields,
+            total=len(fields),
             index_pattern=event_source.index_pattern,
             success=True,
-            message=f"Retrieved {len(unique_fields)} field mappings",
+            message=f"Retrieved {len(fields)} field mappings",
         )
     except Exception as e:
         logger.error(f"Error retrieving field mappings: {e}")
@@ -256,13 +255,38 @@ async def get_field_mappings(
         await es_client.close()
 
 
-def _flatten_properties(properties: dict, prefix: str, fields: list) -> None:
-    """Recursively flatten OpenSearch mapping properties into FieldMapping objects."""
-    for field_name, field_info in properties.items():
-        full_name = f"{prefix}{field_name}" if not prefix else f"{prefix}_{field_name}"
-        field_type = field_info.get("type")
-        if field_type:
-            fields.append(FieldMapping(field=full_name, type=field_type))
-        # Recurse into nested properties
-        if "properties" in field_info:
-            _flatten_properties(field_info["properties"], full_name, fields)
+def _fields_from_field_caps(field_caps: dict) -> list:
+    """Project a `_field_caps` `fields` object into a sorted FieldMapping list.
+
+    Three kinds of entry are dropped as noise in a column picker: metadata fields
+    (`_id`, `_index`, ...), container fields (`object`/`nested`, which hold no value of
+    their own -- the previous `_mapping` walk skipped them for the same reason), and
+    multi-field subfields whose parent leaf is also present (`full_log.keyword` when
+    `full_log` exists). A field mapped with conflicting types across indices reports
+    every type rather than silently picking a winner.
+    """
+    leaf_names = {name for name, caps in field_caps.items() if _leaf_types(caps)}
+
+    fields = []
+    for field_name, caps_by_type in field_caps.items():
+        types = _leaf_types(caps_by_type)
+        if not types:
+            continue
+        if any(caps.get("metadata_field") for caps in caps_by_type.values() if isinstance(caps, dict)):
+            continue
+        # A dotted name whose parent is itself a leaf field can only be a multi-field
+        # (an object's children have an object-typed parent, so they survive this test).
+        parent, _, _ = field_name.rpartition(".")
+        if parent and parent in leaf_names:
+            continue
+        fields.append(FieldMapping(field=field_name, type=", ".join(sorted(types))))
+
+    fields.sort(key=lambda f: f.field)
+    return fields
+
+
+def _leaf_types(caps_by_type) -> set:
+    """Type names under one `_field_caps` entry, excluding the container types."""
+    if not isinstance(caps_by_type, dict):
+        return set()
+    return {field_type for field_type in caps_by_type if field_type not in ("object", "nested")}

--- a/backend/tests/test_event_field_mappings.py
+++ b/backend/tests/test_event_field_mappings.py
@@ -1,0 +1,203 @@
+"""Event Search field discovery spans every index matching the source pattern.
+
+An event source's `index_pattern` routinely resolves to many indices whose mappings
+diverge -- a quiet period or a dynamically-mapped field means one index can be missing
+fields another has. The old implementation read `_mapping` and used only the first index
+in the response, so fields that existed in a sibling index were absent from the column
+selector even though events displayed them fine (#1114).
+
+Discovery now asks `_field_caps`, which returns the union over all matching indices in
+one response. These tests pin that (the call shape, and the projection of the response),
+plus the noise filtering a column picker needs.
+
+No DB, no network -- the indexer client and the event-source lookup are faked.
+
+Run with: cd backend && python -m pytest tests/test_event_field_mappings.py
+"""
+
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+
+from app.siem.services import events  # noqa: E402
+
+
+def _leaf(field_type: str, **extra) -> dict:
+    return {"type": field_type, "searchable": True, "aggregatable": True, **extra}
+
+
+class FakeIndexerClient:
+    """Records the `field_caps` call and replays a canned response."""
+
+    def __init__(self, response: dict):
+        self._response = response
+        self.field_caps_calls = []
+        self.closed = False
+
+    async def field_caps(self, **kwargs):
+        self.field_caps_calls.append(kwargs)
+        return self._response
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeEventSource:
+    def __init__(self, index_pattern: str):
+        self.index_pattern = index_pattern
+        self.time_field = "timestamp"
+
+
+def _run_get_field_mappings(monkeypatch, response: dict, index_pattern: str = "office365-abc-*"):
+    client = FakeIndexerClient(response)
+
+    async def fake_client(_connector_name):
+        return client
+
+    async def fake_lookup(customer_code, source_name, db):
+        return FakeEventSource(index_pattern)
+
+    monkeypatch.setattr(events, "create_wazuh_indexer_client_async", fake_client)
+    monkeypatch.setattr(events, "get_event_source_by_customer_and_name", fake_lookup)
+
+    result = asyncio.run(events.get_field_mappings("ABC", "Office365", db=None))
+    return result, client
+
+
+def test_fields_are_unioned_across_indices_in_the_pattern(monkeypatch):
+    """A field mapped in only one index of the pattern is still offered."""
+    # `_field_caps` reports, per field, which indices carry it when the coverage is
+    # partial -- the shape a quiet or newly-rolled index produces.
+    response = {
+        "indices": ["office365-abc-000001", "office365-abc-000002"],
+        "fields": {
+            "timestamp": {"date": _leaf("date")},
+            # present in both
+            "syslog_level": {"keyword": _leaf("keyword")},
+            # only in the older index
+            "data_office365_UserId": {"keyword": _leaf("keyword", indices=["office365-abc-000001"])},
+            # only in the newer index -- the field the old first-index-only read lost
+            "data_office365_ClientIP": {"keyword": _leaf("keyword", indices=["office365-abc-000002"])},
+        },
+    }
+
+    result, client = _run_get_field_mappings(monkeypatch, response)
+
+    assert [f.field for f in result.fields] == [
+        "data_office365_ClientIP",
+        "data_office365_UserId",
+        "syslog_level",
+        "timestamp",
+    ]
+    assert result.total == 4
+    assert result.index_pattern == "office365-abc-*"
+    assert result.success is True
+
+
+def test_field_caps_is_queried_for_the_whole_pattern(monkeypatch):
+    """The pattern is resolved server-side, tolerating unavailable and empty matches."""
+    _, client = _run_get_field_mappings(monkeypatch, {"fields": {"timestamp": {"date": _leaf("date")}}})
+
+    assert len(client.field_caps_calls) == 1
+    call = client.field_caps_calls[0]
+    assert call["index"] == "office365-abc-*"
+    assert call["fields"] == "*"
+    # One inaccessible or closed index must not fail discovery for the whole source.
+    assert call["ignore_unavailable"] is True
+    assert call["allow_no_indices"] is True
+    assert client.closed is True
+
+
+def test_multifield_subfields_are_suppressed_but_only_under_a_leaf_parent(monkeypatch):
+    """`full_log.keyword` is noise next to `full_log`; an object's children are not."""
+    response = {
+        "fields": {
+            "full_log": {"text": _leaf("text", aggregatable=False)},
+            "full_log.keyword": {"keyword": _leaf("keyword")},
+            # A container plus its child: the child must survive.
+            "agent": {"object": {"type": "object", "searchable": False, "aggregatable": False}},
+            "agent.name": {"keyword": _leaf("keyword")},
+            # A dotted name whose parent is not a field at all.
+            "orphan.subfield": {"keyword": _leaf("keyword")},
+        },
+    }
+
+    result, _ = _run_get_field_mappings(monkeypatch, response)
+
+    fields = [f.field for f in result.fields]
+    assert "full_log" in fields
+    assert "full_log.keyword" not in fields
+    # Containers hold no value of their own, so they are not selectable columns.
+    assert "agent" not in fields
+    assert "agent.name" in fields
+    assert "orphan.subfield" in fields
+
+
+def test_metadata_fields_are_excluded(monkeypatch):
+    response = {
+        "fields": {
+            "_id": {"_id": _leaf("_id", metadata_field=True, aggregatable=False)},
+            "_index": {"_index": _leaf("_index", metadata_field=True)},
+            "syslog_level": {"keyword": _leaf("keyword")},
+        },
+    }
+
+    result, _ = _run_get_field_mappings(monkeypatch, response)
+
+    assert [f.field for f in result.fields] == ["syslog_level"]
+
+
+def test_conflicting_types_across_indices_are_all_reported(monkeypatch):
+    """A field remapped between indices reports both types rather than picking one."""
+    response = {
+        "fields": {
+            "data_status": {
+                "keyword": _leaf("keyword", indices=["office365-abc-000002"]),
+                "long": _leaf("long", indices=["office365-abc-000001"]),
+            },
+        },
+    }
+
+    result, _ = _run_get_field_mappings(monkeypatch, response)
+
+    assert len(result.fields) == 1
+    assert result.fields[0].field == "data_status"
+    assert result.fields[0].type == "keyword, long"
+
+
+def test_empty_field_caps_response_is_not_an_error(monkeypatch):
+    """A pattern matching no index (or an index with no mapping yet) yields no fields."""
+    result, _ = _run_get_field_mappings(monkeypatch, {"indices": [], "fields": {}})
+
+    assert result.fields == []
+    assert result.total == 0
+    assert result.success is True
+
+
+def test_indexer_failure_surfaces_as_a_500(monkeypatch):
+    from fastapi import HTTPException
+
+    class FailingClient(FakeIndexerClient):
+        async def field_caps(self, **kwargs):
+            raise RuntimeError("indexer unreachable")
+
+    client = FailingClient({})
+
+    async def fake_client(_connector_name):
+        return client
+
+    async def fake_lookup(customer_code, source_name, db):
+        return FakeEventSource("office365-abc-*")
+
+    monkeypatch.setattr(events, "create_wazuh_indexer_client_async", fake_client)
+    monkeypatch.setattr(events, "get_event_source_by_customer_and_name", fake_lookup)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(events.get_field_mappings("ABC", "Office365", db=None))
+
+    assert exc.value.status_code == 500
+    # The client is still released on the failure path.
+    assert client.closed is True

--- a/frontend/src/components/events/ColumnConfig.vue
+++ b/frontend/src/components/events/ColumnConfig.vue
@@ -110,6 +110,38 @@
 				</div>
 			</n-card>
 		</section>
+
+		<!-- Add a column by field path -->
+		<section class="flex min-w-0 flex-col gap-3">
+			<div>
+				<p class="text-secondary text-3xs font-medium tracking-widest uppercase">Add field manually</p>
+				<p class="text-secondary mt-1 text-xs">
+					For fields not returned by discovery, such as a dynamically mapped field
+				</p>
+			</div>
+
+			<div class="flex flex-col gap-2 sm:flex-row">
+				<n-input
+					v-model:value="manualField"
+					class="font-mono"
+					size="small"
+					placeholder="Field path, e.g. syslog_level"
+					@keydown.enter="addManualColumn()"
+				/>
+				<n-input
+					v-model:value="manualLabel"
+					size="small"
+					placeholder="Column title (optional)"
+					@keydown.enter="addManualColumn()"
+				/>
+				<n-button size="small" secondary :disabled="!manualField.trim()" @click="addManualColumn()">
+					<template #icon>
+						<Icon :name="AddIcon" :size="14" />
+					</template>
+					Add
+				</n-button>
+			</div>
+		</section>
 	</div>
 </template>
 
@@ -139,11 +171,14 @@ const SearchIcon = "carbon:search"
 const CloseIcon = "carbon:close"
 const ArrowUpIcon = "carbon:arrow-up"
 const ArrowDownIcon = "carbon:arrow-down"
+const AddIcon = "carbon:add"
 
 const message = useMessage()
 
 const localColumns = ref<DisplayColumn[]>([])
 const fieldFilter = ref("")
+const manualField = ref("")
+const manualLabel = ref("")
 const saving = ref(false)
 
 watch(
@@ -156,6 +191,8 @@ watch(
 				width: c.width ?? null
 			}))
 			fieldFilter.value = ""
+			manualField.value = ""
+			manualLabel.value = ""
 		}
 	},
 	{ immediate: true }
@@ -189,6 +226,28 @@ function addColumn(fieldPath: string) {
 		label: defaultLabelFor(fieldPath),
 		width: null
 	})
+}
+
+/**
+ * Add a column for a field path typed by hand. Field discovery reports what the index
+ * mappings declare; a field can still be absent from that list (a dynamic mapping that
+ * has not been written yet, an alias), and the column renders fine regardless because
+ * values are read from the event `_source`.
+ */
+function addManualColumn() {
+	const key = manualField.value.trim()
+	if (!key) return
+	if (usedKeys.value.has(key)) {
+		message.warning(`Column "${key}" is already in the table`)
+		return
+	}
+	localColumns.value.push({
+		key,
+		label: manualLabel.value.trim() || defaultLabelFor(key),
+		width: null
+	})
+	manualField.value = ""
+	manualLabel.value = ""
 }
 
 function removeColumn(idx: number) {


### PR DESCRIPTION
Closes #1114

## The bug

`GET /siem/events/{customer_code}/{source_name}/fields` built the column selector from `_mapping` and used only the first index in the response:

```python
for index_name in mapping_response:
    properties = mapping_response[index_name].get("mappings", {}).get("properties", {})
    _flatten_properties(properties, "", fields)
    break  # All indices matching pattern share the same mapping
```

That assumption does not hold. An event source's `index_pattern` routinely resolves to many indices, and their mappings diverge — a quiet period or a dynamically-mapped field means one index can be missing fields a sibling index has. So fields went missing from the column selector even though the events contained them, and columns configured earlier kept displaying them correctly. Exactly the asymmetry the reporter described.

## The fix

Ask `_field_caps`, which answers precisely this question — the union of fields across every index matching the pattern — in one response instead of a full mapping per index:

```python
response = await es_client.field_caps(
    index=event_source.index_pattern,
    fields="*",
    ignore_unavailable=True,
    allow_no_indices=True,
)
```

Two properties worth calling out:

- **It echoes each field path exactly as the mapping declares it**, so nothing is re-derived in Python. Logs transit Graylog before the indexer, so field names are flat (`data_office365_ClientIP`) — those stay flat, and every already-configured `displayed_columns` key keeps resolving. No renaming risk from the wider list.
- **The tolerance flags matter**: one inaccessible or closed index in the pattern must not fail discovery for the whole source.

The old `_flatten_properties` walk goes away with the `_mapping` path. A latent bug goes with it — it joined nested mapping levels with `_`, so a genuinely nested mapping (an event source pointed at raw `wazuh-alerts-*`, which bypasses Graylog) would have produced `source_ip` for a field the renderer resolves by dot-split. `_field_caps` never derives a path, so the question no longer arises.

New `_fields_from_field_caps` projects the response, dropping what is noise in a column picker:

| Dropped | Why |
|---|---|
| `metadata_field` entries (`_id`, `_index`) | Not source fields |
| `object` / `nested` containers | Carry no value of their own — the previous mapping walk skipped them too |
| Multi-field subfields under a leaf parent (`full_log.keyword` beside `full_log`) | Duplicate of the parent |

The multi-field test is deliberately *parent-is-leaf*, not "has a dot" — an object's children (`agent.name`, whose parent is `object`-typed) survive it. A field remapped between indices reports every type (`"keyword, long"`) rather than silently picking a winner.

## Manual column entry

The issue's fallback request, implemented as well — it covers what discovery structurally cannot report (a dynamic mapping not yet written to any index, an alias) and lets an operator name the column:

```
Field path:    data_office365_ClientIP
Column title:  Client IP        (optional — falls back to the derived label)
```

It feeds the same `localColumns` array as the picker, so reordering, renaming and removal work identically. Duplicate keys warn instead of silently no-oping.

## Tests

`backend/tests/test_event_field_mappings.py` — 7 cases, fake indexer client, no DB or network:

- a field present in only **one** index of the pattern is still offered (the regression itself)
- the call shape: `fields="*"` plus both tolerance flags, and the client is released
- multi-field suppression vs. object children vs. a dotted name with no parent field
- metadata fields excluded
- conflicting types across indices all reported
- empty response is not an error
- indexer failure surfaces as a 500 and still closes the client

## Verification

- `python -m pytest tests/test_event_field_mappings.py` → 7 passed
- `vue-tsc --noEmit` → clean project-wide
- eslint clean, `pre-commit run --files …` all green

**Not verified here:** no live indexer was reachable from this workstation, so the `_field_caps` response shape is exercised against canned fixtures rather than real OpenSearch. Worth eyeballing a multi-index event source — the reporter's own case — to confirm the field count jumps before merge.

## Side effect

The same field list feeds the Lucene query-field autocomplete in `EventSearchFilters.vue`, so that surface widens too.

