### PR TITLE
feat(agents): reset pagination on filter changes to improve user expe…

### DIFF
--- a/frontend/src/views/agents/Agents.vue
+++ b/frontend/src/views/agents/Agents.vue
@@ -110,6 +110,12 @@ watch(textFilter, val => {
 	update(val)
 })
 
+// Every filter change (text search and Customer select) restarts the list from the first page,
+// otherwise a narrower result set leaves the user on a page that no longer exists.
+watch([textFilterDebounced, customerCodesFilter], () => {
+	page.value = 1
+})
+
 const agentsFiltered = computed(() => {
 	return agents.value
 		.filter(({ hostname, ip_address, agent_id, label }) =>


### PR DESCRIPTION
Added a watcher to reset the pagination to the first page whenever the text filter or customer selection changes. This ensures users are not left on a page with no results after applying filters, enhancing navigation and usability in the agents view.