### PR TITLE
fix(nginx): stop serving .htaccess and deny dotfiles from the web root

### DIFF
--- a/customer-portal/nginx.conf
+++ b/customer-portal/nginx.conf
@@ -44,6 +44,16 @@ http {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
 
+        # Deny access to dotfiles (.htaccess, .env, .git, ...). nginx has no
+        # default rule for these, unlike Apache's stock ^\.ht deny. 404 rather
+        # than 403 so we do not confirm whether the file exists. /.well-known/
+        # (RFC 8615: certbot HTTP-01, security.txt) is deliberately exempt.
+        location ~ /\.(?!well-known).* {
+            access_log off;
+            log_not_found off;
+            return 404;
+        }
+
         # Cache static assets
         location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf|eot)$ {
             expires 1y;
@@ -56,7 +66,7 @@ http {
         }
 
         # API proxy (adjust backend URL as needed)
-        location /api {
+        location ^~ /api {
             proxy_pass http://copilot-backend:5000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/frontend/build/etc/nginx/sites-enabled/default.conf
+++ b/frontend/build/etc/nginx/sites-enabled/default.conf
@@ -53,8 +53,18 @@ server {
     # remove X-Powered-By, which is an information leak
     fastcgi_hide_header X-Powered-By;
 
+    # Deny access to dotfiles (.htaccess, .env, .git, ...). nginx has no
+    # default rule for these, unlike Apache's stock ^\.ht deny. 404 rather
+    # than 403 so we do not confirm whether the file exists. /.well-known/
+    # (RFC 8615: certbot HTTP-01, security.txt) is deliberately exempt.
+    location ~ /\.(?!well-known).* {
+        access_log off;
+        log_not_found off;
+        return 404;
+    }
+
     # Proxy /api requests to the FastAPI backend
-    location /api {
+    location ^~ /api {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -63,7 +73,7 @@ server {
     }
 
     # location for scoutsuite-report
-    location /scoutsuite-report {
+    location ^~ /scoutsuite-report {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,8 +15,18 @@ http {
     listen 2000;
     server_name _;
 
+    # Deny access to dotfiles (.htaccess, .env, .git, ...). nginx has no
+    # default rule for these, unlike Apache's stock ^\.ht deny. 404 rather
+    # than 403 so we do not confirm whether the file exists. /.well-known/
+    # (RFC 8615: certbot HTTP-01, security.txt) is deliberately exempt.
+    location ~ /\.(?!well-known).* {
+        access_log off;
+        log_not_found off;
+        return 404;
+    }
+
     # location for scoutsuite-report
-    location /scoutsuite-report {
+    location ^~ /scoutsuite-report {
         proxy_pass http://copilot-backend:5000;
     }
 

--- a/frontend/public/.htaccess
+++ b/frontend/public/.htaccess
@@ -1,8 +1,0 @@
-<IfModule mod_rewrite.c>
-RewriteEngine On
-# Send all requests to the index.html unless
-# it's a directory or a file that actually exists
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^ index.html [L]
-</IfModule>


### PR DESCRIPTION
Closes #1126.

A client scan flagged `.htaccess` as readable on a deployed frontend (`10.50.105.20`), rated High under CVE-2000-0234 and marked "NOT REMEDIATED from Q1 2026". The exposure is real; the classification is not. Full analysis in #1126.

## What was wrong

`frontend/public/.htaccess` shipped to production: Vite copies `public/` verbatim into `dist/`, and the Dockerfile copies `dist/` to `/var/www/copilot` — the nginx root. nginx has no default dotfile rule (that is an Apache default), so it served the file. Contents were eight lines of dead `mod_rewrite`; nothing referenced it, and the SPA fallback it described is already handled by `try_files`.

## What changed

1. **Deleted `frontend/public/.htaccess`.**
2. **Dotfile deny** in all three nginx configs — closes the whole scanner plugin family, not just this finding:
   ```nginx
   location ~ /\.(?!well-known).* {
       access_log off;
       log_not_found off;
       return 404;
   }
   ```
   `/.well-known/` is exempt (RFC 8615) — the bare `/\.` form of this fix silently breaks certbot HTTP-01 and `security.txt`. 404 rather than 403 so we do not confirm existence.
3. **`location /api` → `location ^~ /api`** (same for `/scoutsuite-report`). See below — this one is load-bearing.

The deny had to go in `frontend/build/etc/nginx/sites-enabled/default.conf`, the config the Dockerfile actually templates. `frontend/nginx.conf` is not used in the image; updated anyway for consistency.

## Why `^~` matters

nginx evaluates regex locations **before** unmodified prefix locations, so a bare `location ~ /\.` outranks `location /api` and captures proxied requests. The backend has routes carrying a user-supplied filename as a path segment:

```
/case/data-store/download/{case_id}/{file_name}
/case-report-template/download/{file_name}
/groups/{group_id}/files/{filename}
```

Dot-leading names are routine IR evidence for a SOC platform — `.bash_history`, `.ssh/config`, `.env` off a compromised host — so those downloads would have started 404ing. `^~` tells nginx to skip regex evaluation when that prefix is the longest match.

Uploads were never at risk: they carry the filename in the multipart **body**, which location matching never sees.

Incidental fix: in `customer-portal/nginx.conf` the asset-cache regex `~* \.(js|css|...)$` also outranked the plain `location /api`, so `/api/anything.js` was served from the static root instead of proxied. `^~` corrects that pre-existing latent bug.

## Verification

Run against `nginx:1.30.3-alpine`, the image production uses. `nginx -t` passes on all three configs. Runtime matrix, shipped config + stub backend:

| Request | Code | Result |
|---|---|---|
| `/.htaccess` · `/.env` · `/.git/config` | 404 | finding closed |
| `/api/case/data-store/download/42/.bash_history` | 200 | proxied |
| `/api/case-report-template/download/.env` | 200 | proxied |
| `/.well-known/acme-challenge/token` | 200 | certbot intact |
| `/assets/index-abc.js` | 200 | assets intact |
| `/some/spa/route` · `/` | 200 | SPA fallback intact |

Before/after:

- **Pre-fix config** — `/.htaccess` → **200** with `RewriteEngine On`, reproducing the client finding exactly.
- **Deny without `^~`** — `/.htaccess` → 404, but `/api/.../.bash_history` → **404 too**, which is the regression `^~` prevents.

## Post-deploy checks

This only reaches `10.50.105.20` after a frontend image rebuild and redeploy. Once deployed:

```bash
curl -sk -o /dev/null -w '%{http_code}\n' https://<host>/.htaccess          # expect 404
curl -sk -o /dev/null -w '%{http_code}\n' https://<host>/                    # expect 200
# with a valid token, a case attachment download:
curl -sk -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer <jwt>" \
  'https://<host>/api/incidents/db_operations/case/data-store/download/<case_id>/<file_name>'
```

Then ask the client to re-run the scan against the host.

## Regression plan

The blast radius is URL routing on the two static frontends. The backend, database and API are untouched, so nothing here can corrupt state — worst case is that some paths 404 that should not. Everything is recoverable by redeploy.

**Symptoms to watch, and what each means**

| Symptom | Likely cause |
|---|---|
| A file download 404s where it previously worked | a stored filename begins with `.` on a route not covered by `^~ /api` |
| Certificate renewal fails | `/.well-known/acme-challenge/` not reaching the webroot |
| A static asset 404s | an asset path contains a slash-then-dot segment |
| nginx container crashloops on start | config error — check `docker logs <container>` for the `nginx: [emerg]` line |

`access_log off` is set inside the deny block, so a blocked request will **not** appear in the access log. If you are diagnosing a suspected false 404, drop that line temporarily to make hits visible.

**Immediate rollback** — revert and redeploy:

```bash
git revert dc54d1d3 && git push
# rebuild + redeploy the frontend image, or:
docker compose pull && docker compose up -d copilot-frontend
```

Or pin back to the previous published image tag without touching the repo. Note that reverting restores the `.htaccess` exposure, so re-open #1126 if you do.

**Targeted mitigation (preferred over full rollback).** If exactly one path is affected, exempt it rather than reverting the whole change — the exposure stays closed:

```nginx
# add the prefix to the ^~ set so regex evaluation is skipped for it
location ^~ /the/affected/prefix { ... }
```

or widen the lookahead if a second well-known-style path is needed:

```nginx
location ~ /\.(?!well-known|other-needed-path).* { ... }
```

**Re-verification after any change** — always `nginx -t` before reload, and re-run the routing matrix above. The matrix is cheap to reproduce locally: mount the config into `nginx:1.30.3-alpine` with a stub backend on the `copilot-backend` alias and curl the table.

**Longer term:** the routing matrix in this PR is currently a manual check. Worth folding the `.htaccess` / `.env` / `.git` 404 assertions into `frontend/e2e/` so a future config change cannot silently reopen the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgqYyqWauH4yXr6E1us1o1
