### PR TITLE
fix(mitre): validate mitre_field and technique_id in queries

### DIFF
--- a/backend/app/connectors/wazuh_manager/routes/mitre.py
+++ b/backend/app/connectors/wazuh_manager/routes/mitre.py
@@ -397,7 +397,11 @@ async def list_mitre_techniques_in_alerts(
     page: int = Query(1, description="Page number for pagination", gt=0),
     rule_level: Optional[int] = Query(None, description="Filter by rule level"),
     rule_group: Optional[str] = Query(None, description="Filter by rule group"),
-    mitre_field: Optional[str] = Query(None, description="Override the field containing MITRE IDs"),
+    mitre_field: Optional[str] = Query(
+        None,
+        description="Override the field containing MITRE IDs",
+        pattern="^[A-Za-z0-9_.]+$",
+    ),
     index_pattern: str = Query("wazuh-*", description="Index pattern to search"),
 ) -> MitreTechniquesInAlertsResponse:
     """Search for MITRE ATT&CK techniques in Wazuh alerts."""
@@ -452,13 +456,21 @@ async def list_mitre_techniques_in_alerts(
     dependencies=[Security(auth_handler.require_any_scope("admin", "analyst"))],
 )
 async def get_mitre_technique_alerts(
-    technique_id: str = Path(..., description="MITRE ATT&CK technique ID (e.g., T1047, 1047)"),
+    technique_id: str = Path(
+        ...,
+        description="MITRE ATT&CK technique ID (e.g., T1047, 1047)",
+        pattern=r"^T?[0-9]{4}(\.[0-9]{3})?$",
+    ),
     time_range: str = Query("now-24h", description="Time range for the search (e.g., now-24h, now-7d)"),
     size: int = Query(25, description="Maximum number of alerts to return per page"),
     page: int = Query(1, description="Page number for pagination", gt=0),
     rule_level: Optional[int] = Query(None, description="Filter by rule level"),
     rule_group: Optional[str] = Query(None, description="Filter by rule group"),
-    mitre_field: Optional[str] = Query(None, description="Override the field containing MITRE IDs"),
+    mitre_field: Optional[str] = Query(
+        None,
+        description="Override the field containing MITRE IDs",
+        pattern="^[A-Za-z0-9_.]+$",
+    ),
     index_pattern: str = Query("wazuh-*", description="Index pattern to search"),
     alert_id: Optional[str] = Query(None, description="Filter by alert document id"),
 ) -> MitreTechniqueAlertsResponse:

--- a/backend/app/connectors/wazuh_manager/services/mitre.py
+++ b/backend/app/connectors/wazuh_manager/services/mitre.py
@@ -453,6 +453,36 @@ async def get_mitre_techniques(
         raise HTTPException(status_code=500, detail=f"Error processing MITRE data: {str(e)}")
 
 
+# mitre_field is user-controllable (a query parameter on both MITRE alert-search routes)
+# and is interpolated into a Painless script (_build_mitre_search_query) and into a Lucene
+# query_string (_build_mitre_alerts_query). Restrict it to plain field-name characters so
+# neither interpolation can be broken out of, regardless of which caller supplies the value.
+_MITRE_FIELD_PATTERN = re.compile(r"^[A-Za-z0-9_.]+$")
+
+
+def _validate_mitre_field(mitre_field: str) -> str:
+    """Validate a MITRE field name before it is interpolated into a script or query string."""
+    if not isinstance(mitre_field, str) or not _MITRE_FIELD_PATTERN.fullmatch(mitre_field):
+        raise HTTPException(status_code=400, detail="Invalid mitre_field")
+    return mitre_field
+
+
+# technique_id (the {technique_id} path parameter of GET .../techniques/{technique_id}/alerts)
+# is interpolated by the same f-string into the same Lucene query_string clause as mitre_field
+# (_build_mitre_alerts_query). A real MITRE ATT&CK technique id is "T" followed by 4 digits,
+# optionally with a ".NNN" sub-technique suffix (e.g. T1003.004); the route's own docstring
+# also accepts the bare-digit form without the "T" (e.g. "1047"). Restrict to that format so
+# the interpolation can never be broken out of, regardless of which caller supplies the value.
+_TECHNIQUE_ID_PATTERN = re.compile(r"^T?[0-9]{4}(\.[0-9]{3})?$")
+
+
+def _validate_technique_id(technique_id: str) -> str:
+    """Validate a MITRE technique id before it is interpolated into a query string."""
+    if not isinstance(technique_id, str) or not _TECHNIQUE_ID_PATTERN.fullmatch(technique_id):
+        raise HTTPException(status_code=400, detail="Invalid technique_id")
+    return technique_id
+
+
 async def search_mitre_techniques_in_alerts(
     time_range: str = "now-24h",
     size: int = 1000,
@@ -847,6 +877,8 @@ def _build_mitre_search_query(
     name_field: Optional[str] = None,
 ) -> Dict:
     """Build the Wazuh Indexer query for MITRE technique aggregation."""
+    mitre_field = _validate_mitre_field(mitre_field)
+
     # Build the base filters
     query_filters = [{"match_all": {}}, {"range": {"timestamp": {"from": time_range, "to": "now"}}}]
 
@@ -1031,6 +1063,9 @@ def _build_mitre_alerts_query(
     mitre_field: str,
 ) -> Dict:
     """Build the OpenSearch query to fetch alerts for a specific MITRE technique."""
+    mitre_field = _validate_mitre_field(mitre_field)
+    technique_id = _validate_technique_id(technique_id)
+
     # Build the base filters
     query_filters = [{"range": {"timestamp": {"from": time_range, "to": "now"}}}]
 

--- a/backend/tests/test_mitre_field_validation.py
+++ b/backend/tests/test_mitre_field_validation.py
@@ -1,0 +1,190 @@
+"""Tests for MITRE alert-search input validation (GHSA-68c5-wpf3-9r62).
+
+`mitre_field` lets a caller override which indexed field holds the MITRE technique id.
+CoPilot interpolates that value by f-string into a Painless script
+(`_build_mitre_search_query`, used by `GET /api/wazuh_manager/mitre/techniques/alerts`)
+and into a Lucene `query_string` clause (`_build_mitre_alerts_query`, used by
+`GET /api/wazuh_manager/mitre/techniques/{technique_id}/alerts`). A single quote in
+`mitre_field` closes the Painless string literal and lets the caller append arbitrary
+Painless; unescaped Lucene metacharacters do the equivalent in the query_string clause.
+
+`technique_id`, the path parameter of the same alerts route, is interpolated by the same
+f-string into the same `query_string` clause as `mitre_field` and is exposed to the exact
+same Lucene breakout.
+
+`_validate_mitre_field` constrains the field-name value to plain identifier characters
+(`[A-Za-z0-9_.]`), and `_validate_technique_id` constrains the technique id to its real
+format (`T` + 4 digits, optional `.NNN` sub-technique suffix, `T` optional), before either
+sink uses either value, mirroring the identifier allow-list already used for Velociraptor
+VQL interpolation (`app/connectors/velociraptor/utils/validation.py`, GHSA-5542-j2fc-gqjm).
+Both run inside the query builders themselves, so they also cover any future caller of
+`search_mitre_techniques_in_alerts` / `get_alerts_by_mitre_id` that does not go through
+FastAPI's own `Query(..., pattern=...)` / `Path(..., pattern=...)` constraints on the routes.
+
+Pure-function unit tests, no DB or Wazuh Indexer.
+
+Run with: cd backend && python -m pytest tests/test_mitre_field_validation.py
+"""
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("JWT_SECRET", "test-only-secret-not-the-compromised-default")
+# app.connectors.wazuh_manager.services.mitre pulls in app.db.db_session transitively
+# (via wazuh_indexer.utils.universal), which requires these at import time.
+os.environ.setdefault("MYSQL_USER", "copilot")
+os.environ.setdefault("MYSQL_PASSWORD", "test-only-password-not-the-default")
+os.environ.setdefault("MYSQL_ROOT_PASSWORD", "test-only-password-not-the-default")
+
+from app.connectors.wazuh_manager.services.mitre import (  # noqa: E402
+    _build_mitre_alerts_query,
+)
+from app.connectors.wazuh_manager.services.mitre import _build_mitre_search_query
+from app.connectors.wazuh_manager.services.mitre import _validate_mitre_field
+from app.connectors.wazuh_manager.services.mitre import _validate_technique_id
+
+
+@pytest.mark.parametrize(
+    "mitre_field",
+    [
+        "rule_mitre_id",  # the built-in default field
+        "rule.mitre.id",  # a dotted default field
+        "mitre.id",
+        "Custom_Field.123",
+    ],
+)
+def test_accepts_plain_field_names(mitre_field):
+    assert _validate_mitre_field(mitre_field) == mitre_field
+
+
+@pytest.mark.parametrize(
+    "mitre_field",
+    [
+        "rule_mitre_id'].value); throw new Exception('x",  # Painless string-literal breakout
+        "rule_mitre_id'] instanceof String ? '",
+        "x'] == 'y",
+        'x"] OR field:"y',  # Lucene query_string breakout
+        "x OR 1=1",
+        "x'",
+        'x"',
+        "x`",
+        "x\\",
+        "x\n",
+        "x y",  # whitespace
+        "",
+        None,
+    ],
+)
+def test_rejects_injection_and_malformed_field_names(mitre_field):
+    with pytest.raises(HTTPException) as exc:
+        _validate_mitre_field(mitre_field)
+    assert exc.value.status_code == 400
+
+
+def test_search_query_builder_rejects_unvalidated_field():
+    """_build_mitre_search_query must reject the injection before it reaches script_source."""
+    with pytest.raises(HTTPException) as exc:
+        _build_mitre_search_query(
+            time_range="now-24h",
+            size=25,
+            offset=0,
+            additional_filters=None,
+            index_pattern="wazuh-*",
+            mitre_field="rule_mitre_id'].value); throw new Exception('x",
+        )
+    assert exc.value.status_code == 400
+
+
+def test_search_query_builder_accepts_default_field():
+    query = _build_mitre_search_query(
+        time_range="now-24h",
+        size=25,
+        offset=0,
+        additional_filters=None,
+        index_pattern="wazuh-*",
+        mitre_field="rule_mitre_id",
+    )
+    script_source = query["body"]["aggs"]["techniques"]["terms"]["script"]["source"]
+    assert "doc['rule_mitre_id'].value" in script_source
+
+
+def test_alerts_query_builder_rejects_unvalidated_field():
+    """_build_mitre_alerts_query must reject the injection before it reaches query_string."""
+    with pytest.raises(HTTPException) as exc:
+        _build_mitre_alerts_query(
+            technique_id="T1047",
+            time_range="now-24h",
+            size=25,
+            offset=0,
+            additional_filters=None,
+            index_pattern="wazuh-*",
+            mitre_field='x"] OR field:"y',
+        )
+    assert exc.value.status_code == 400
+
+
+def test_alerts_query_builder_accepts_default_field():
+    query = _build_mitre_alerts_query(
+        technique_id="T1047",
+        time_range="now-24h",
+        size=25,
+        offset=0,
+        additional_filters=None,
+        index_pattern="wazuh-*",
+        mitre_field="rule_mitre_id",
+    )
+    should_clauses = query["body"]["query"]["bool"]["filter"][-1]["bool"]["should"]
+    assert {"term": {"rule_mitre_id": "T1047"}} in should_clauses
+
+
+@pytest.mark.parametrize(
+    "technique_id",
+    [
+        "T1047",  # technique id with the "T" prefix
+        "1047",  # bare-digit form, also documented on the route
+        "T1003.004",  # sub-technique
+        "1003.004",  # bare-digit sub-technique
+    ],
+)
+def test_accepts_real_technique_ids(technique_id):
+    assert _validate_technique_id(technique_id) == technique_id
+
+
+@pytest.mark.parametrize(
+    "technique_id",
+    [
+        'T1047" OR rule_mitre_id:*',  # Lucene query_string breakout (the reported gap)
+        "T1047 OR 1=1",
+        "T1047'",
+        "T1047`",
+        "T1047\\",
+        "T1047\n",
+        "T1047 ",  # trailing whitespace
+        "T104",  # too few digits
+        "T10470",  # too many digits
+        "T1003.4",  # sub-technique suffix must be 3 digits
+        "",
+        None,
+    ],
+)
+def test_rejects_injection_and_malformed_technique_ids(technique_id):
+    with pytest.raises(HTTPException) as exc:
+        _validate_technique_id(technique_id)
+    assert exc.value.status_code == 400
+
+
+def test_alerts_query_builder_rejects_unvalidated_technique_id():
+    """_build_mitre_alerts_query must reject the injection before it reaches query_string."""
+    with pytest.raises(HTTPException) as exc:
+        _build_mitre_alerts_query(
+            technique_id='T1047" OR rule_mitre_id:*',
+            time_range="now-24h",
+            size=25,
+            offset=0,
+            additional_filters=None,
+            index_pattern="wazuh-*",
+            mitre_field="rule_mitre_id",
+        )
+    assert exc.value.status_code == 400


### PR DESCRIPTION
### What

`_build_mitre_alerts_query` (`services/mitre.py:1084`, used by `GET /techniques/{technique_id}/alerts`) builds a Lucene `query_string` clause by f-string from two caller-controlled inputs:

- `mitre_field`, a query parameter on that route and on `GET /techniques/alerts`, also reaching a Painless aggregation script in `_build_mitre_search_query` (`services/mitre.py:862`).
- `technique_id`, the path parameter of `GET /techniques/{technique_id}/alerts`, passed unchanged via `routes/mitre.py:477` and `:499` into the same query builder.

Neither value was constrained to its expected shape before reaching the string literal.

### Why

A field name or technique id carrying a quote closes the surrounding literal early; what follows becomes Lucene syntax evaluated against the index. This repository already has the model for a gap of this shape: `app/connectors/velociraptor/utils/validation.py:34` allow-lists a Velociraptor client id (`^(server|C\.[0-9A-Fa-f]+...)$`) before it reaches VQL, since a free-form value in a query cannot stay inside its literal. The MITRE query builders had no counterpart for `mitre_field` or `technique_id`.

### How

`_validate_mitre_field` (`services/mitre.py:463`) restricts `mitre_field` to `^[A-Za-z0-9_.]+$`, covering the three built-in field names and any dotted custom field. `_validate_technique_id` (`services/mitre.py:479`) restricts `technique_id` to `^T?[0-9]{4}(\.[0-9]{3})?$`: with or without a sub-technique suffix, with or without the leading `T`, the bare-digit form the route's own parameter description already documents. Both query builders call their validator before the script or query string is built, so the check holds for any caller, not only the current routes. The two routes also constrain `mitre_field` and `technique_id` with FastAPI's `Query(..., pattern=...)` / `Path(..., pattern=...)`, already used in `routes/groups.py:143`.

Left unchanged: `rule_level`, `rule_group`, `alert_id`, `index_pattern` on the same routes, which reach the query through structured filter clauses (`term`, `match_phrase`), not string interpolation.

### Testing

- `cd backend && python -m pytest tests/test_mitre_field_validation.py` (extended file): 38 passed.
- The new `technique_id` tests fail on pre-patch code (`ImportError: cannot import name '_validate_technique_id'`), via `git stash` of the two changed source files.
- `black --check` and `isort -c` on all three changed files: clean.
- `cd backend && python -m pytest --continue-on-collection-errors` (full suite): 403 passed, 6 failed, 44 errored, all pre-existing (unset env vars at collection, `test_connector_cache.py`/`test_sandbox.py`/`test_resend_connector_verification.py` failures also on unpatched `main`).

### References

GHSA-68c5-wpf3-9r62 ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)